### PR TITLE
feat: use self-hosted runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: [labeled]
   push:
-    branches: [ develop, main ]
+    branches: [develop, main]
 
 concurrency:
   group: ${{ github.ref }}
@@ -54,7 +54,6 @@ jobs:
   clippy_build_and_test:
     runs-on: self-hosted
     needs:
-      - toml
       - format
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Use our own self hosted runner by choosing  it when defining a ci job. 