### PR TITLE
feat: Add common types used by storage provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,13 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "common"
+version = "0.1.0"
 source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
 dependencies = [
  "ark-ec",
@@ -9766,7 +9773,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "blake2 0.10.6",
- "common",
+ "common 0.1.0 (git+https://github.com/w3f/ring-proof)",
  "fflonk",
  "merlin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license-file = "LICENSE"
 repository = "https://github.com/eigerco/polka-storage"
 
 [workspace]
-members = ["node", "runtime"]
+members = ["node", "pallets/common", "runtime"]
 resolver = "2"
 
 # FIXME(#@jmg-duarte,#7,14/5/24): remove the patch once something >1.11.0 is released

--- a/pallets/common/Cargo.toml
+++ b/pallets/common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+name = "common"
+repository.workspace = true
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+codec.workspace = true
+
+[lints]
+workspace = true

--- a/pallets/common/src/address.rs
+++ b/pallets/common/src/address.rs
@@ -1,0 +1,20 @@
+use codec::{Decode, Encode};
+pub use payload::Payload;
+
+mod payload;
+
+/// Hash length of payload for SECP and Actor addresses.
+pub const PAYLOAD_HASH_LEN: usize = 20;
+
+/// BLS public key length used for validation of BLS addresses.
+pub const BLS_PUB_LEN: usize = 48;
+
+/// Max length of f4 sub addresses.
+pub const MAX_SUBADDRESS_LEN: usize = 54;
+
+/// Address is the struct that defines the protocol and data payload conversion from either
+/// a public key or value
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+pub struct Address {
+    payload: Payload,
+}

--- a/pallets/common/src/address/payload.rs
+++ b/pallets/common/src/address/payload.rs
@@ -1,0 +1,26 @@
+use crate::address::{BLS_PUB_LEN, MAX_SUBADDRESS_LEN, PAYLOAD_HASH_LEN};
+use crate::ActorID;
+use codec::{Decode, Encode};
+
+/// A "delegated" (f4) address.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Decode, Encode)]
+pub struct DelegatedAddress {
+    namespace: ActorID,
+    length: u64,
+    buffer: [u8; MAX_SUBADDRESS_LEN],
+}
+
+/// Payload is the data of the Address. Variants are the supported Address protocols.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Decode, Encode)]
+pub enum Payload {
+    /// f0: ID protocol address.
+    ID(u64),
+    /// f1: SECP256K1 key address, 20 byte hash of PublicKey.
+    Secp256k1([u8; PAYLOAD_HASH_LEN]),
+    /// f2: Actor protocol address, 20 byte hash of actor data.
+    Actor([u8; PAYLOAD_HASH_LEN]),
+    /// f3: BLS key address, full 48 byte public key.
+    BLS([u8; BLS_PUB_LEN]),
+    /// f4: Delegated address, a namespace with an arbitrary subaddress.
+    Delegated(DelegatedAddress),
+}

--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -1,0 +1,69 @@
+use codec::{Decode, Encode, Error as CodecError};
+
+pub mod address;
+pub mod registered_proof;
+
+/// Identifier for Actors, includes builtin and initialized actors
+pub type ActorID = u64;
+
+/// Identifier for a CID
+pub type Cid = String;
+
+#[derive(Decode, Encode, Default)]
+pub struct MinerId(pub u32);
+
+// Code from https://github.com/paritytech/polkadot/blob/rococo-v1/parachain/src/primitives.rs
+/// This type can be converted into and possibly from an AccountId (which itself is generic).
+pub trait AccountIdConversion<AccountId>: Sized {
+    /// Convert into an account ID. This is infallible.
+    fn into_account(&self) -> AccountId;
+
+    /// Try to convert an account ID into this type. Might not succeed.
+    fn try_from_account(a: &AccountId) -> Option<Self>;
+}
+
+// Code from https://github.com/paritytech/polkadot/blob/rococo-v1/parachain/src/primitives.rs
+// This will be moved to own crate and can remove
+struct TrailingZeroInput<'a>(&'a [u8]);
+
+impl<'a> codec::Input for TrailingZeroInput<'a> {
+    fn remaining_len(&mut self) -> Result<Option<usize>, CodecError> {
+        Ok(None)
+    }
+
+    fn read(&mut self, into: &mut [u8]) -> Result<(), CodecError> {
+        let len = into.len().min(self.0.len());
+        into[..len].copy_from_slice(&self.0[..len]);
+        for i in &mut into[len..] {
+            *i = 0;
+        }
+        self.0 = &self.0[len..];
+        Ok(())
+    }
+}
+
+// Code modified from https://github.com/paritytech/polkadot/blob/rococo-v1/parachain/src/primitives.rs
+/// Format is b"miner" ++ encode(minerId) ++ 00.... where 00... is indefinite trailing
+/// zeroes to fill AccountId.
+impl<T: Encode + Decode> AccountIdConversion<T> for MinerId {
+    fn into_account(&self) -> T {
+        (b"miner", self)
+            .using_encoded(|b| T::decode(&mut TrailingZeroInput(b)))
+            .unwrap()
+    }
+
+    fn try_from_account(x: &T) -> Option<Self> {
+        x.using_encoded(|d| {
+            if &d[0..5] != b"miner" {
+                return None;
+            }
+            let mut cursor = &d[5..];
+            let result = Decode::decode(&mut cursor).ok()?;
+            if cursor.iter().all(|x| *x == 0) {
+                Some(result)
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/pallets/common/src/registered_proof.rs
+++ b/pallets/common/src/registered_proof.rs
@@ -1,0 +1,99 @@
+/// SectorSize indicates one of a set of possible sizes in the network.
+#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[repr(u64)]
+pub enum SectorSize {
+    _2KiB = 2 << 10,
+    _8MiB = 8 << 20,
+    _512MiB = 512 << 20,
+    _32GiB = 32 << 30,
+    _64GiB = 2 * (32 << 30),
+}
+
+/// Proof of spacetime type, indicating version and sector size of the proof.
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+pub enum RegisteredPoStProof {
+    StackedDRGWinning2KiBV1,
+    StackedDRGWinning8MiBV1,
+    StackedDRGWinning512MiBV1,
+    StackedDRGWinning32GiBV1,
+    StackedDRGWinning64GiBV1,
+    StackedDRGWindow2KiBV1,
+    StackedDRGWindow8MiBV1,
+    StackedDRGWindow512MiBV1,
+    StackedDRGWindow32GiBV1,
+    StackedDRGWindow64GiBV1,
+    StackedDRGWindow2KiBV1P1,
+    StackedDRGWindow8MiBV1P1,
+    StackedDRGWindow512MiBV1P1,
+    StackedDRGWindow32GiBV1P1,
+    StackedDRGWindow64GiBV1P1,
+    Invalid(i64),
+}
+
+impl RegisteredPoStProof {
+    /// Returns the sector size of the proof type, which is measured in bytes.
+    pub fn sector_size(self) -> Result<SectorSize, String> {
+        use RegisteredPoStProof::*;
+        match self {
+            StackedDRGWindow2KiBV1P1 | StackedDRGWindow2KiBV1 | StackedDRGWinning2KiBV1 => {
+                Ok(SectorSize::_2KiB)
+            }
+            StackedDRGWindow8MiBV1P1 | StackedDRGWindow8MiBV1 | StackedDRGWinning8MiBV1 => {
+                Ok(SectorSize::_8MiB)
+            }
+            StackedDRGWindow512MiBV1P1 | StackedDRGWindow512MiBV1 | StackedDRGWinning512MiBV1 => {
+                Ok(SectorSize::_512MiB)
+            }
+            StackedDRGWindow32GiBV1P1 | StackedDRGWindow32GiBV1 | StackedDRGWinning32GiBV1 => {
+                Ok(SectorSize::_32GiB)
+            }
+            StackedDRGWindow64GiBV1P1 | StackedDRGWindow64GiBV1 | StackedDRGWinning64GiBV1 => {
+                Ok(SectorSize::_64GiB)
+            }
+            Invalid(i) => Err(format!("unsupported proof type: {}", i)),
+        }
+    }
+
+    /// Proof size for each PoStProof type
+    pub fn proof_size(self) -> Result<usize, String> {
+        use RegisteredPoStProof::*;
+        match self {
+            StackedDRGWinning2KiBV1
+            | StackedDRGWinning8MiBV1
+            | StackedDRGWinning512MiBV1
+            | StackedDRGWinning32GiBV1
+            | StackedDRGWinning64GiBV1
+            | StackedDRGWindow2KiBV1
+            | StackedDRGWindow8MiBV1
+            | StackedDRGWindow512MiBV1
+            | StackedDRGWindow32GiBV1
+            | StackedDRGWindow64GiBV1
+            | StackedDRGWindow2KiBV1P1
+            | StackedDRGWindow8MiBV1P1
+            | StackedDRGWindow512MiBV1P1
+            | StackedDRGWindow32GiBV1P1
+            | StackedDRGWindow64GiBV1P1 => Ok(192),
+            Invalid(i) => Err(format!("unsupported proof type: {}", i)),
+        }
+    }
+    /// Returns the partition size, in sectors, associated with a proof type.
+    /// The partition size is the number of sectors proven in a single PoSt proof.
+    pub fn window_post_partitions_sector(self) -> Result<u64, String> {
+        // Resolve to post proof and then compute size from that.
+        use RegisteredPoStProof::*;
+        match self {
+            StackedDRGWinning64GiBV1 | StackedDRGWindow64GiBV1 | StackedDRGWindow64GiBV1P1 => {
+                Ok(2300)
+            }
+            StackedDRGWinning32GiBV1 | StackedDRGWindow32GiBV1 | StackedDRGWindow32GiBV1P1 => {
+                Ok(2349)
+            }
+            StackedDRGWinning2KiBV1 | StackedDRGWindow2KiBV1 | StackedDRGWindow2KiBV1P1 => Ok(2),
+            StackedDRGWinning8MiBV1 | StackedDRGWindow8MiBV1 | StackedDRGWindow8MiBV1P1 => Ok(2),
+            StackedDRGWinning512MiBV1 | StackedDRGWindow512MiBV1 | StackedDRGWindow512MiBV1P1 => {
+                Ok(2)
+            }
+            Invalid(i) => Err(format!("unsupported proof type: {}", i)),
+        }
+    }
+}


### PR DESCRIPTION
# Description

Add `common` lib for types used by different pallets. The `common` library will be extended when needed. This commit adds types that the storage provider pallet needs.

# Implementation

All types have been documented in the code.
Types added:
- `ActorID` -> Identifier for Actors.
- `Cid` -> Identifier for a CID.
- `MinerId` -> Tuple struct holding u32 identifying a miner.
- `Address` -> Defines the protocol and data payload conversion from either a public key or a value.
- `Payload` -> The data of the `Address`.
- `DelegatedAddress` -> A "delegated" (f4) address.

The `AccountIdConversion` trait has been added to implement conversion between `AccountId` and other types. This trait has been implemented for `MinerID`.

Fixes #42 