### PR TITLE
feat: Implement `submit_windowed_post` extrinsic

### DIFF
--- a/pallets/storage-provider/src/proofs.rs
+++ b/pallets/storage-provider/src/proofs.rs
@@ -40,10 +40,13 @@ impl RegisteredPoStProof {
 /// Proof of Spacetime data stored on chain.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct PoStProof {
+    /// The proof type, currently only one type is supported.
     pub post_proof: RegisteredPoStProof,
+    /// The proof submission, to be checked in the storage provider pallet.
     pub proof_bytes: BoundedVec<u8, ConstU32<256>>, // Arbitrary length
 }
 
+/// Parameter type for `submit_windowed_post` extrinsic.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SubmitWindowedPoStParams<BlockNumber> {
     /// The deadline index which the submission targets.


### PR DESCRIPTION
### Description

Implement the `submit_windowed_post` extrinsic, allowing an SP to submit their Proof-of-Spacetime. The validation of the proof is stubbed out. I am not sure if always returning true is the way to go for now or having some type of failure condition is preferred, I am open to suggestions.

### Important points for reviewers

[Filecoin implementation reference](https://github.com/filecoin-project/builtin-actors/blob/17ede2b256bc819dc309edf38e031e246a516486/actors/miner/src/lib.rs#L501)

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] If yes, which ones?
Proofs are not validated at the moment so the `validate_windowed_post` always returns true on the submitted proof.
- [x] If there are follow-ups, have you created issues for them?
  - [x] If yes, which ones? / List them here
#103 will check that the Proof-of-Spacetime is submitted on time.
- [ ] Have you tested this solution?
I did not write a test for this as it always returns true for every proof
- [x] Did you document new (or modified) APIs?
