### PR TITLE
fix(sp): persist provider state on post proof submittion

### DIFF
--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -488,8 +488,9 @@ pub mod pallet {
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             let current_block = <frame_system::Pallet<T>>::block_number();
-            let mut sp = StorageProviders::<T>::try_get(&owner)
+            let sp = StorageProviders::<T>::try_get(&owner)
                 .map_err(|_| Error::<T>::StorageProviderNotFound)?;
+
             if let Err(e) = Self::validate_windowed_post(
                 current_block,
                 &windowed_post,
@@ -498,6 +499,7 @@ pub mod pallet {
                 log::error!(target: LOG_TARGET, "submit_window_post: PoSt submission is invalid {e:?}");
                 return Err(e.into());
             }
+
             let current_deadline = sp
                 .deadline_info(
                     current_block,
@@ -506,15 +508,30 @@ pub mod pallet {
                     T::WPoStProvingPeriod::get(),
                 )
                 .map_err(|e| Error::<T>::DeadlineError(e))?;
+
             Self::validate_deadline(current_block, &current_deadline, &windowed_post)?;
-            let deadlines = sp.get_deadlines_mut();
-            log::debug!(target: LOG_TARGET, "submit_windowed_post: deadlines = {deadlines:#?}");
-            // record sector as proven
-            deadlines
-                .record_proven(windowed_post.deadline as usize, windowed_post.partition)
-                .map_err(|e| Error::<T>::DeadlineError(e))?;
+
+            // mutate provider state
+            StorageProviders::<T>::try_mutate(&owner, |maybe_sp| -> DispatchResult {
+                let sp = maybe_sp
+                    .as_mut()
+                    .ok_or(Error::<T>::StorageProviderNotFound)?;
+                let deadlines = sp.get_deadlines_mut();
+
+                log::debug!(target: LOG_TARGET, "submit_windowed_post: deadlines = {deadlines:#?}");
+
+                // record sector as proven
+                deadlines
+                    .record_proven(windowed_post.deadline as usize, windowed_post.partition)
+                    .map_err(|e| Error::<T>::DeadlineError(e))?;
+
+                Ok(())
+            })?;
+
             log::debug!(target: LOG_TARGET, "submit_windowed_post: proof recorded");
+
             Self::deposit_event(Event::ValidPoStSubmitted { owner });
+
             Ok(())
         }
     }

--- a/pallets/storage-provider/src/tests/mod.rs
+++ b/pallets/storage-provider/src/tests/mod.rs
@@ -399,14 +399,17 @@ struct SubmitWindowedPoStBuilder {
 }
 
 impl SubmitWindowedPoStBuilder {
-    pub(crate) fn chain_commit_block(self, chain_commit_block: BlockNumber) -> Self {
-        Self {
-            chain_commit_block,
-            ..self
-        }
+    pub fn chain_commit_block(mut self, chain_commit_block: BlockNumber) -> Self {
+        self.chain_commit_block = chain_commit_block;
+        self
     }
 
-    pub(crate) fn build(self) -> SubmitWindowedPoStParams<BlockNumber> {
+    pub fn partition(mut self, partition: PartitionNumber) -> Self {
+        self.partition = partition;
+        self
+    }
+
+    pub fn build(self) -> SubmitWindowedPoStParams<BlockNumber> {
         SubmitWindowedPoStParams {
             deadline: self.deadline,
             partition: self.partition,

--- a/pallets/storage-provider/src/tests/submit_windowed_post.rs
+++ b/pallets/storage-provider/src/tests/submit_windowed_post.rs
@@ -1,8 +1,9 @@
-use frame_support::assert_ok;
+use frame_support::{assert_noop, assert_ok};
 use sp_core::bounded_vec;
 
 use crate::{
-    pallet::{Event, StorageProviders},
+    deadline::DeadlineError,
+    pallet::{Error, Event, StorageProviders},
     sector::ProveCommitSector,
     tests::{
         account, events, new_test_ext, register_storage_provider, run_to_block,
@@ -11,76 +12,96 @@ use crate::{
     },
 };
 
+/// Setup the environment for the submit_windowed_post tests
+fn setup() {
+    // Setup accounts
+    let storage_provider = ALICE;
+    let storage_client = BOB;
+
+    // Register storage provider
+    register_storage_provider(account(storage_provider));
+
+    // Add balance to the market pallet
+    assert_ok!(Market::add_balance(
+        RuntimeOrigin::signed(account(storage_provider)),
+        60
+    ));
+    assert_ok!(Market::add_balance(
+        RuntimeOrigin::signed(account(storage_client)),
+        70
+    ));
+
+    // Generate a deal proposal
+    let deal_proposal = DealProposalBuilder::default()
+        .client(storage_client)
+        .provider(storage_provider)
+        .signed(storage_client);
+
+    // Publish the deal proposal
+    assert_ok!(Market::publish_storage_deals(
+        RuntimeOrigin::signed(account(storage_provider)),
+        bounded_vec![deal_proposal],
+    ));
+
+    // Sector to be pre-committed and proven
+    let sector_number = 1;
+
+    // Sector data
+    let sector = SectorPreCommitInfoBuilder::default()
+        .sector_number(sector_number)
+        .deals(vec![0])
+        .build();
+
+    // Run pre commit extrinsic
+    assert_ok!(StorageProvider::pre_commit_sector(
+        RuntimeOrigin::signed(account(storage_provider)),
+        sector.clone()
+    ));
+
+    // Prove commit sector
+    let sector = ProveCommitSector {
+        sector_number,
+        proof: bounded_vec![0xd, 0xe, 0xa, 0xd],
+    };
+
+    assert_ok!(StorageProvider::prove_commit_sector(
+        RuntimeOrigin::signed(account(storage_provider)),
+        sector
+    ));
+
+    // Remove any events that were triggered until now.
+    System::reset_events();
+
+    // Check if the sector was successfully committed
+    let state = StorageProviders::<Test>::get(account(ALICE)).unwrap();
+    let deadlines = state.deadlines;
+    let new_dl = deadlines.due.first().expect("programmer error");
+    assert_eq!(new_dl.live_sectors, 1);
+    assert_eq!(new_dl.total_sectors, 1);
+}
+
 #[test]
 fn submit_windowed_post() {
     new_test_ext().execute_with(|| {
-        // Setup accounts
-        let storage_provider = ALICE;
-        let storage_client = BOB;
+        setup();
 
-        // Register storage provider
-        register_storage_provider(account(storage_provider));
+        let partition = 0;
 
-        // Add balance to the market pallet
-        assert_ok!(Market::add_balance(
-            RuntimeOrigin::signed(account(storage_provider)),
-            60
-        ));
-        assert_ok!(Market::add_balance(
-            RuntimeOrigin::signed(account(storage_client)),
-            70
-        ));
-
-        // Generate a deal proposal
-        let deal_proposal = DealProposalBuilder::default()
-            .client(storage_client)
-            .provider(storage_provider)
-            .signed(storage_client);
-
-        // Publish the deal proposal
-        assert_ok!(Market::publish_storage_deals(
-            RuntimeOrigin::signed(account(storage_provider)),
-            bounded_vec![deal_proposal],
-        ));
-
-        // Sector to be pre-committed and proven
-        let sector_number = 1;
-
-        // Sector data
-        let sector = SectorPreCommitInfoBuilder::default()
-            .sector_number(sector_number)
-            .deals(vec![0])
-            .build();
-
-        // Run pre commit extrinsic
-        assert_ok!(StorageProvider::pre_commit_sector(
-            RuntimeOrigin::signed(account(storage_provider)),
-            sector.clone()
-        ));
-
-        // Prove commit sector
-        let sector = ProveCommitSector {
-            sector_number,
-            proof: bounded_vec![0xd, 0xe, 0xa, 0xd],
-        };
-
-        assert_ok!(StorageProvider::prove_commit_sector(
-            RuntimeOrigin::signed(account(storage_provider)),
-            sector
-        ));
-        // Remove any events that were triggered until now.
-        System::reset_events();
         // proving period is assigned based on hash(account_id, block_number) % wpost_proving_offset `assign_proving_period_offset`.
         run_to_block(19);
+
         // Done with setup build window post proof
         let windowed_post = SubmitWindowedPoStBuilder::default()
             .chain_commit_block(System::block_number() - 1)
+            .partition(partition)
             .build();
+
         // Run extrinsic and assert that the result is `Ok`
         assert_ok!(StorageProvider::submit_windowed_post(
             RuntimeOrigin::signed(account(ALICE)),
             windowed_post,
         ));
+
         // Check that expected events were emitted
         assert_eq!(
             events(),
@@ -90,10 +111,54 @@ fn submit_windowed_post() {
                 }
             )]
         );
+
         let state = StorageProviders::<Test>::get(account(ALICE)).unwrap();
         let deadlines = state.deadlines;
         let new_dl = deadlines.due.first().expect("Programmer error");
-        assert_eq!(new_dl.live_sectors, 1);
-        assert_eq!(new_dl.total_sectors, 1);
+        let posted_partition = new_dl.partitions_posted.get(&partition).copied();
+
+        assert_eq!(posted_partition, Some(partition));
+    });
+}
+
+#[test]
+fn submit_windowed_post_for_sector_twice() {
+    new_test_ext().execute_with(|| {
+        setup();
+
+        // proving period is assigned based on hash(account_id, block_number) % wpost_proving_offset `assign_proving_period_offset`.
+        run_to_block(19);
+
+        // Build window post proof
+        let windowed_post = SubmitWindowedPoStBuilder::default()
+            .partition(0)
+            .chain_commit_block(System::block_number() - 1)
+            .build();
+
+        // Run extrinsic and assert that the result is `Ok`
+        assert_ok!(StorageProvider::submit_windowed_post(
+            RuntimeOrigin::signed(account(ALICE)),
+            windowed_post.clone(),
+        ));
+        // Check that only one event was emitted
+        assert_eq!(
+            events(),
+            [RuntimeEvent::StorageProvider(
+                Event::<Test>::ValidPoStSubmitted {
+                    owner: account(ALICE)
+                }
+            )]
+        );
+
+        // Run extrinsic and assert that the result is `Err`
+        assert_noop!(
+            StorageProvider::submit_windowed_post(
+                RuntimeOrigin::signed(account(ALICE)),
+                windowed_post,
+            ),
+            Error::<Test>::DeadlineError(DeadlineError::PartitionAlreadyProven)
+        );
+        // Check that nothing was emitted
+        assert_eq!(events(), []);
     });
 }


### PR DESCRIPTION
### Description

This pr fixes the state persistence when the post-proof is submitted for a deadline.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
