### PR TITLE
fix(pallet-storage-provider): save sectors to a partition when proving

### DIFF
--- a/pallets/storage-provider/src/tests/prove_commit_sector.rs
+++ b/pallets/storage-provider/src/tests/prove_commit_sector.rs
@@ -80,6 +80,10 @@ fn successfully_prove_sector() {
         // check that the sector has been activated
         assert!(!sp_state.sectors.is_empty());
         assert!(sp_state.sectors.contains_key(&sector_number));
+        // always assigns first deadline and first partition, probably will fail when we change deadline calculation algo.
+        let deadline = &sp_state.deadlines.due[0];
+        let assigned_partition = &deadline.partitions[&0];
+        assert_eq!(assigned_partition.sectors.len(), 1);
     });
 }
 


### PR DESCRIPTION
### Description

It's a bug. Found it when implementing #155.

### Important points for reviewers

I'm relying on a precondition in tests that a deadline and a partition assigned is always the first one.
Not sure how to calculate that properly and which issue will change that. I say it's good for now.

### Checklist

- [X] Are there important points that reviewers should know?
  - [X] If yes, which ones?
- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
