### PR TITLE
fix(pallet-storage-provider): clear declared recoveries after Window PoSt

### DIFF
--- a/pallets/storage-provider/src/partition.rs
+++ b/pallets/storage-provider/src/partition.rs
@@ -228,6 +228,22 @@ where
             .try_into()
             .expect("BoundedBTreeSet should be able to be created from BTreeSet");
     }
+
+    /// Removes all previously faulty sectors, declared as recoveries, from faults and clears recoveries.
+    ///
+    /// References:
+    /// * <https://github.com/filecoin-project/builtin-actors/blob/82d02e58f9ef456aeaf2a6c737562ac97b22b244/actors/miner/src/partition_state.rs#L271>
+    pub fn recover_all_declared_recoveries(&mut self) {
+        self.faults = self
+            .faults
+            .difference(&self.recoveries)
+            .copied()
+            .collect::<BTreeSet<u64>>()
+            .try_into()
+            .expect("(faults - recoveries).len() <= faults.len()");
+
+        self.recoveries.clear();
+    }
 }
 
 #[derive(Decode, Encode, PalletError, TypeInfo, RuntimeDebug)]


### PR DESCRIPTION
### Description

Fixes #195. 
Fault recovery declaration **DID NOT** clear the `partition.faults`.
Sectors are removed from `partition.faults` if a `PoSt` for a `partition` was delivered an sectors were marked as `recovered` previously.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Did you document new (or modified) APIs?
