### PR TITLE
docs: add symlinks in mdbook and overall structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,12 @@
 mdbook serve
 ```
 
+Symlinks binding doesn't work with hot-reload, so you need to restart the server on your own to pick-up changes from:
+- pallet-market.md
+- pallet-storage-provider.md
+- storage-provider-node.md
+- storagext-cli.md
+
 ## Build
 
 ```bash

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,4 +1,8 @@
 # Summary
 
 - [Introduction](./intro.md)
+- [Storagext CLI](./storagext-cli.md)
+- [Storage Provider Node](./storage-provider-node.md)
+- [Market Pallet](./pallet-market.md)
+- [Storage Provider Pallet](./pallet-storage-provider.md)
 - [Glossary](./glossary.md)

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -1,1 +1,9 @@
 # Introduction
+
+TODO:
+- describe overall project and deliverables of P1, what functionalities we support
+- describe how to run the parachain (where to download docker etc), what are the dependencies
+- describe how to run the storage provider docs
+- redirect to storagext-cli docs
+- redirect to storage provider node docs (basically the CAR server)
+- redirect to pallet docs for market/storage-provider

--- a/docs/src/pallet-market.md
+++ b/docs/src/pallet-market.md
@@ -1,0 +1,1 @@
+../../pallets/market/README.md

--- a/docs/src/pallet-storage-provider.md
+++ b/docs/src/pallet-storage-provider.md
@@ -1,0 +1,1 @@
+../../pallets/storage-provider/README.md

--- a/docs/src/storage-provider-node.md
+++ b/docs/src/storage-provider-node.md
@@ -1,0 +1,1 @@
+../../cli/polka-storage-provider/README.md

--- a/docs/src/storagext-cli.md
+++ b/docs/src/storagext-cli.md
@@ -1,0 +1,1 @@
+../../cli/polka-storage/storagext-cli/README.md

--- a/pallets/market/README.md
+++ b/pallets/market/README.md
@@ -1,0 +1,2 @@
+# Market Pallet
+


### PR DESCRIPTION
### Description

Adds symlinks in mdBook to the specific READMEs in directories and proposes a structure of what we should include in there.