### PR TITLE
ci: don't skip with .rs files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   check-files:
     runs-on: ubuntu-latest
     outputs:
-      skip: ${{ steps.check-files.skip }}
+      skip: ${{ steps.check-files.outputs.skip }}
     steps:
       - uses: actions/checkout@v4
       - uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c #v44.5.7


### PR DESCRIPTION
CI here should have run: https://github.com/eigerco/polka-storage/actions/runs/10473911982/job/29006882355?pr=220