### PR TITLE
fix: Remove unused SP pallet errors

### DIFF
--- a/pallets/storage-provider/src/deadline.rs
+++ b/pallets/storage-provider/src/deadline.rs
@@ -602,10 +602,6 @@ pub enum DeadlineError {
     DeadlineIndexOutOfRange,
     /// Emitted when a trying to get a deadline index but fails because that index does not exist.
     DeadlineNotFound,
-    /// Emitted when a given index in `Deadlines` already exists and try to insert a deadline on that index.
-    DeadlineIndexExists,
-    /// Emitted when trying to insert a new deadline fails.
-    CouldNotInsertDeadline,
     /// Emitted when constructing `DeadlineInfo` fails.
     CouldNotConstructDeadlineInfo,
     /// Emitted when a proof is submitted for a partition that is already proven.
@@ -624,10 +620,6 @@ pub enum DeadlineError {
     SectorsNotFaulty,
     /// Emitted when assigning sectors to deadlines fails.
     CouldNotAssignSectorsToDeadlines,
-    /// Emitted when updates to a partition fail.
-    FailedToUpdatePartition,
-    /// Emitted when trying to update a deadline fails.
-    FailedToUpdateDeadline,
     /// Emitted when trying to update fault expirations fails
     FailedToUpdateFaultExpiration,
     /// Wrapper around the partition error type

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -283,10 +283,6 @@ pub mod pallet {
         InvalidProofType,
         /// Emitted when there is not enough funds to run an extrinsic.
         NotEnoughFunds,
-        /// Emitted when a sector fails to activate.
-        SectorActivateFailed,
-        /// Emitted when removing a pre_committed sector after proving fails.
-        CouldNotRemoveSector,
         /// Emitted when trying to reuse a sector number
         SectorNumberAlreadyUsed,
         /// Emitted when expiration is after activation

--- a/pallets/storage-provider/src/partition.rs
+++ b/pallets/storage-provider/src/partition.rs
@@ -248,8 +248,6 @@ where
 
 #[derive(Decode, Encode, PalletError, TypeInfo, RuntimeDebug)]
 pub enum PartitionError {
-    /// Emitted when trying to get the live sectors for a partition fails.
-    FailedToGetLiveSectors,
     /// Emitted when adding sectors fails
     FailedToAddSector,
     /// Emitted when trying to add a sector number that has already been used in this partition.


### PR DESCRIPTION
### Description

While writing docs I encountered some error cases that were not used in the SP pallet. This PR removes the unused error members.