### PR TITLE
fix(market): remove `TimeUnitInBlocks`

### DIFF
--- a/pallets/market/src/lib.rs
+++ b/pallets/market/src/lib.rs
@@ -80,27 +80,15 @@ pub mod pallet {
         #[pallet::constant]
         type MaxDeals: Get<u32>;
 
-        /// How many blocks are created in a time unit.
-        /// [`MinDealDuration`] and [`MaxDealDuration`] are expressed in terms of [`TimeUnitInBlocks`].
-        ///
-        /// E.g. `TimeUnitInBlocks = DAYS` is the number of of blocks finalized in a day
-        ///
-        #[pallet::constant]
-        type TimeUnitInBlocks: Get<BlockNumberFor<Self>>;
-
         /// How many days should a deal last (activated). Minimum.
         /// Filecoin uses 180 as default.
         /// https://github.com/filecoin-project/builtin-actors/blob/c32c97229931636e3097d92cf4c43ac36a7b4b47/actors/market/src/policy.rs#L29
-        ///
-        /// MinDealDuration = [`MinDealDuration`] * [`TimeUnitInBlocks`] in Blocks.
         #[pallet::constant]
         type MinDealDuration: Get<BlockNumberFor<Self>>;
 
         /// How many days should a deal last (activated). Maximum.
         /// Filecoin uses 1278 as default.
         /// https://github.com/filecoin-project/builtin-actors/blob/c32c97229931636e3097d92cf4c43ac36a7b4b47/actors/market/src/policy.rs#L29
-        ///
-        /// MaxDealDuration = [`MaxDealDuration`] * [`TimeUnitInBlocks`] in Blocks.
         #[pallet::constant]
         type MaxDealDuration: Get<BlockNumberFor<Self>>;
 
@@ -1074,8 +1062,8 @@ pub mod pallet {
                 ProposalError::DealNotPublished
             );
 
-            let min_dur = T::TimeUnitInBlocks::get() * T::MinDealDuration::get();
-            let max_dur = T::TimeUnitInBlocks::get() * T::MaxDealDuration::get();
+            let min_dur = T::MinDealDuration::get();
+            let max_dur = T::MaxDealDuration::get();
             ensure!(
                 deal.proposal.duration() >= min_dur && deal.proposal.duration() <= max_dur,
                 ProposalError::DealDurationOutOfBounds

--- a/pallets/market/src/mock.rs
+++ b/pallets/market/src/mock.rs
@@ -55,7 +55,6 @@ impl crate::Config for Test {
     type OffchainSignature = Signature;
     type OffchainPublic = AccountPublic;
     type MaxDeals = ConstU32<32>;
-    type TimeUnitInBlocks = ConstU64<1>;
     type MinDealDuration = ConstU64<2>;
     type MaxDealDuration = ConstU64<30>;
     type MaxDealsPerBlock = ConstU32<32>;

--- a/pallets/storage-provider/src/tests/mod.rs
+++ b/pallets/storage-provider/src/tests/mod.rs
@@ -85,7 +85,6 @@ impl pallet_market::Config for Test {
     type OffchainPublic = AccountPublic;
     type MaxDeals = ConstU32<500>;
 
-    type TimeUnitInBlocks = TimeUnitInBlocks;
     type MinDealDuration = MinDealDuration;
     type MaxDealDuration = MaxDealDuration;
     type MaxDealsPerBlock = ConstU32<500>;
@@ -106,7 +105,6 @@ parameter_types! {
     pub const FaultDeclarationCutoff: BlockNumber = 2 * MINUTES;
 
     // Market Pallet
-    pub const TimeUnitInBlocks: u64 = MINUTES;
     pub const MinDealDuration: u64 = 2 * MINUTES;
     pub const MaxDealDuration: u64 = 30 * MINUTES;
 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -333,9 +333,8 @@ parameter_types! {
     // Market Pallet
     /// Deal duration values copied from FileCoin.
     /// <https://github.com/filecoin-project/builtin-actors/blob/c32c97229931636e3097d92cf4c43ac36a7b4b47/actors/market/src/policy.rs#L28>
-    pub const TimeUnitInBlocks: u64 = DAYS;
-    pub const MinDealDuration: u64 = 20;
-    pub const MaxDealDuration: u64 = 1278;
+    pub const MinDealDuration: u64 = 20 * DAYS;
+    pub const MaxDealDuration: u64 = 1278 * DAYS;
 }
 
 #[cfg(feature = "testnet")]
@@ -354,9 +353,8 @@ parameter_types! {
     pub const FaultDeclarationCutoff: BlockNumber = 2 * MINUTES;
 
     // Market Pallet
-    pub const TimeUnitInBlocks: u64 = MINUTES;
-    pub const MinDealDuration: u64 = 5;
-    pub const MaxDealDuration: u64 = 180;
+    pub const MinDealDuration: u64 = 5 * MINUTES;
+    pub const MaxDealDuration: u64 = 180 * MINUTES;
 }
 
 impl pallet_storage_provider::Config for Runtime {
@@ -392,7 +390,6 @@ impl pallet_market::Config for Runtime {
     type OffchainPublic = AccountPublic;
     type MaxDeals = ConstU32<128>;
     type MaxDealsPerBlock = ConstU32<128>;
-    type TimeUnitInBlocks = TimeUnitInBlocks;
     type MinDealDuration = MinDealDuration;
     type MaxDealDuration = MaxDealDuration;
 }


### PR DESCRIPTION
### Description

Replace `TimeUnitInBlocks` with just declaring the proper value at once


