### PR TITLE
feat(pallet-proofs): set-up skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7636,6 +7636,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-proofs"
+version = "0.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.0",
+]
+
+[[package]]
 name = "pallet-proxy"
 version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2407-1#16b0fd09d9e9281c20ee0c1d8b87d011e3e3454e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "cli/polka-storage/storagext-cli",
   "node",
   "pallets/market",
+  "pallets/proofs",
   "pallets/storage-provider",
   "primitives/proofs",
   "runtime",

--- a/pallets/proofs/Cargo.toml
+++ b/pallets/proofs/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+authors.workspace = true
+description = "handles proof verification"
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+name = "pallet-proofs"
+publish = false
+repository.workspace = true
+version = "0.0.0"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+frame-benchmarking = { optional = true, workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+sp-runtime.workspace = true
+
+[dev-dependencies]
+sp-core = { default-features = true, workspace = true }
+sp-io = { default-features = true, workspace = true }
+
+[features]
+default = ["std"]
+runtime-benchmarks = [
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "sp-runtime/runtime-benchmarks",
+]
+std = ["codec/std", "frame-benchmarking?/std", "frame-support/std", "frame-system/std", "scale-info/std", "sp-runtime/std"]
+try-runtime = ["frame-support/try-runtime", "frame-system/try-runtime", "sp-runtime/try-runtime"]

--- a/pallets/proofs/src/lib.rs
+++ b/pallets/proofs/src/lib.rs
@@ -1,0 +1,51 @@
+//! # Proofs Pallet
+//!
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+    use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
+    use frame_system::pallet_prelude::*;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    }
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        SomethingStored {
+            block_number: BlockNumberFor<T>,
+            who: T::AccountId,
+        },
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        NoneValue,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        pub fn do_something(origin: OriginFor<T>, bn: u32) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
+            let block_number: BlockNumberFor<T> = bn.into();
+            Self::deposit_event(Event::SomethingStored { block_number, who });
+
+            Ok(().into())
+        }
+    }
+}

--- a/pallets/proofs/src/mock.rs
+++ b/pallets/proofs/src/mock.rs
@@ -1,0 +1,44 @@
+use frame_support::derive_impl;
+use frame_system::{mocking::MockBlock, GenesisConfig};
+use sp_runtime::BuildStorage;
+
+// Configure a mock runtime to test the pallet.
+#[frame_support::runtime]
+mod test_runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeFreezeReason,
+        RuntimeHoldReason,
+        RuntimeSlashReason,
+        RuntimeLockId,
+        RuntimeTask
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type ProofsModule = crate;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Nonce = u64;
+    type Block = MockBlock<Test>;
+}
+
+impl crate::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap()
+        .into()
+}

--- a/pallets/proofs/src/tests.rs
+++ b/pallets/proofs/src/tests.rs
@@ -1,0 +1,10 @@
+use frame_support::assert_ok;
+
+use crate::mock::*;
+
+#[test]
+fn it_works_for_default_value() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(ProofsModule::do_something(RuntimeOrigin::signed(1), 42));
+    });
+}


### PR DESCRIPTION
### Description

Fixes #358.
Sets-up pallet-proofs for future work, nothing much too say.
Left a default event and extrinsic for completeness.

### Important points for reviewers

This pallet is responsible for verifying PoRep and PoSt.
Will be called directly, by the Storage Provider Pallet during prove commit and submit windowed PoSt.

### Checklist

- [X] Are there important points that reviewers should know?
  - [X] If yes, which ones?
- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
