### PR TITLE
fix: Remove Extension from MaxSectorExpirationExtension

### DIFF
--- a/docs/src/pallets/storage-provider.md
+++ b/docs/src/pallets/storage-provider.md
@@ -70,7 +70,7 @@ storagext-cli --sr25519-key "//Alice" storage-provider register alice
 ### `pre_commit_sectors`
 
 After publishing a deal, the storage provider needs to pre-commit the sector information to the chain.
-Sectors are not valid after pre-commit. The sectors need to be proven first. 
+Sectors are not valid after pre-commit. The sectors need to be proven first.
 The pre-commit extrinsic takes in an array of the following values:
 
 | Name            | Description                                                            | Type                                                           |
@@ -316,7 +316,7 @@ The Storage Provider Pallet actions can fail with the following errors:
 - `SectorNumberAlreadyUsed` - A storage provider tries to pre-commit a sector number that has already been used.
 - `ExpirationBeforeActivation` - A storage provider tries to pre-commit a sector where that sector expires before activation.
 - `ExpirationTooSoon` - A storage provider tries to pre-commit a sector with a total lifetime less than MinSectorExpiration.
-- `ExpirationTooLong` - A storage provider tries to pre-commit a sector with an expiration that exceeds `MaxSectorExpirationExtension`.
+- `ExpirationTooLong` - A storage provider tries to pre-commit a sector with an expiration that exceeds `MaxSectorExpiration`.
 - `MaxSectorLifetimeExceeded` - A storage provider tries to pre-commit a sector with a total lifetime that exceeds `SectorMaximumLifetime`.
 - `InvalidCid` - Emitted when a storage provider submits an invalid unsealed CID when trying to pre-commit a sector.
 - `ProveCommitAfterDeadline` - A storage provider has tried to prove a previously pre-committed sector after the proving deadline.
@@ -346,9 +346,9 @@ The Storage Provider Pallet has the following constants:
 | `WPoStChallengeLookBack`                                          | This period allows the storage providers to start working on the [PoSt](../glossary.md#post) before the deadline is officially opened to receiving a [PoSt](../glossary.md#post). | 1 Minute    |
 | <code id="const-period-deadlines">`WPoStPeriodDeadlines`</code>   | Represents how many challenge deadlines there are in one proving period. Closely tied to `WPoStChallengeWindow`.                                                                  | 48          |
 | `MinSectorExpiration`                                             | Minimum time past the current block a sector may be set to expire.                                                                                                                | 5 Minutes   |
-| `MaxSectorExpirationExtension`                                    | Maximum time past the current block a sector may be set to expire.                                                                                                                | 60 Minutes  |
+| `MaxSectorExpiration`                                             | Maximum time past the current block a sector may be set to expire.                                                                                                                | 60 Minutes  |
 | `SectorMaximumLifetime`                                           | Maximum time a sector can stay in pre-committed state.                                                                                                                            | 120 Minutes |
-| `MaxProveCommitDuration`                                          | Maximum time between [pre-commit](#pre_commit_sectors) and [proving](#prove_commit_sector) the committed sector.                                                                   | 5 Minutes   |
+| `MaxProveCommitDuration`                                          | Maximum time between [pre-commit](#pre_commit_sectors) and [proving](#prove_commit_sector) the committed sector.                                                                  | 5 Minutes   |
 | `MaxPartitionsPerDeadline`                                        | Maximum number of partitions that can be assigned to a single deadline.                                                                                                           | 3000        |
 | `FaultMaxAge`                                                     | Maximum time a [fault](../glossary.md#fault) can exist before being removed by the pallet.                                                                                        | 210 Minutes |
 | <code id="fault-declaration-cutoff">FaultDeclarationCutoff</code> | Time before a deadline opens that a storage provider can declare or recover a fault.                                                                                              | 2 Minutes   |

--- a/pallets/market/src/mock.rs
+++ b/pallets/market/src/mock.rs
@@ -60,7 +60,7 @@ parameter_types! {
     pub const WpostChallengeWindow: BlockNumber = 4 * MINUTES;
     pub const WpostChallengeLookBack: BlockNumber = MINUTES;
     pub const MinSectorExpiration: BlockNumber = 5 * MINUTES;
-    pub const MaxSectorExpirationExtension: BlockNumber = 360 * MINUTES;
+    pub const MaxSectorExpiration: BlockNumber = 360 * MINUTES;
     pub const SectorMaximumLifetime: BlockNumber = 120 * MINUTES;
     pub const MaxProveCommitDuration: BlockNumber = 5 * MINUTES;
     pub const MaxPartitionsPerDeadline: u64 = 3000;
@@ -90,7 +90,7 @@ impl pallet_storage_provider::Config for Test {
     type WPoStChallengeWindow = WpostChallengeWindow;
     type WPoStChallengeLookBack = WpostChallengeLookBack;
     type MinSectorExpiration = MinSectorExpiration;
-    type MaxSectorExpirationExtension = MaxSectorExpirationExtension;
+    type MaxSectorExpiration = MaxSectorExpiration;
     type SectorMaximumLifetime = SectorMaximumLifetime;
     type MaxProveCommitDuration = MaxProveCommitDuration;
     type WPoStPeriodDeadlines = WPoStPeriodDeadlines;

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -189,7 +189,7 @@ pub mod pallet {
 
         /// Maximum number of blocks past the current block a sector may be set to expire.
         #[pallet::constant]
-        type MaxSectorExpirationExtension: Get<BlockNumberFor<Self>>;
+        type MaxSectorExpiration: Get<BlockNumberFor<Self>>;
 
         /// Maximum number of blocks a sector can stay in pre-committed state
         #[pallet::constant]
@@ -296,7 +296,7 @@ pub mod pallet {
         ExpirationBeforeActivation,
         /// Emitted when expiration is less than minimum after activation
         ExpirationTooSoon,
-        /// Emitted when the expiration exceeds MaxSectorExpirationExtension
+        /// Emitted when the expiration exceeds MaxSectorExpiration
         ExpirationTooLong,
         /// Emitted when a sectors lifetime exceeds SectorMaximumLifetime
         MaxSectorLifetimeExceeded,
@@ -883,9 +883,9 @@ pub mod pallet {
                 expiration - activation > T::MinSectorExpiration::get(),
                 Error::<T>::ExpirationTooSoon
             );
-            // expiration cannot exceed MaxSectorExpirationExtension from now
+            // expiration cannot exceed MaxSectorExpiration from now
             ensure!(
-                expiration < curr_block + T::MaxSectorExpirationExtension::get(),
+                expiration < curr_block + T::MaxSectorExpiration::get(),
                 Error::<T>::ExpirationTooLong,
             );
             // total sector lifetime cannot exceed SectorMaximumLifetime for the sector's seal proof

--- a/pallets/storage-provider/src/tests/mod.rs
+++ b/pallets/storage-provider/src/tests/mod.rs
@@ -97,7 +97,7 @@ parameter_types! {
     pub const WpostChallengeWindow: BlockNumber = 4 * MINUTES;
     pub const WpostChallengeLookBack: BlockNumber = MINUTES;
     pub const MinSectorExpiration: BlockNumber = 5 * MINUTES;
-    pub const MaxSectorExpirationExtension: BlockNumber = 360 * MINUTES;
+    pub const MaxSectorExpiration: BlockNumber = 360 * MINUTES;
     pub const SectorMaximumLifetime: BlockNumber = 120 * MINUTES;
     pub const MaxProveCommitDuration: BlockNumber = 5 * MINUTES;
     pub const MaxPartitionsPerDeadline: u64 = 3000;
@@ -118,7 +118,7 @@ impl pallet_storage_provider::Config for Test {
     type WPoStChallengeWindow = WpostChallengeWindow;
     type WPoStChallengeLookBack = WpostChallengeLookBack;
     type MinSectorExpiration = MinSectorExpiration;
-    type MaxSectorExpirationExtension = MaxSectorExpirationExtension;
+    type MaxSectorExpiration = MaxSectorExpiration;
     type SectorMaximumLifetime = SectorMaximumLifetime;
     type MaxProveCommitDuration = MaxProveCommitDuration;
     type WPoStPeriodDeadlines = WPoStPeriodDeadlines;

--- a/pallets/storage-provider/src/tests/pre_commit_sectors.rs
+++ b/pallets/storage-provider/src/tests/pre_commit_sectors.rs
@@ -10,7 +10,7 @@ use crate::{
     sector::{SectorPreCommitInfo, MAX_SECTORS},
     tests::{
         account, cid_of, events, publish_deals, register_storage_provider, run_to_block, Balances,
-        MaxProveCommitDuration, MaxSectorExpirationExtension, RuntimeEvent, RuntimeOrigin,
+        MaxProveCommitDuration, MaxSectorExpiration, RuntimeEvent, RuntimeOrigin,
         SectorPreCommitInfoBuilder, StorageProvider, Test, ALICE, CHARLIE, INITIAL_FUNDS,
     },
 };
@@ -384,7 +384,7 @@ fn fails_expiration_too_long() {
         let sector = SectorPreCommitInfoBuilder::default()
             // Set expiration to be in the next block after the maximum
             // allowed
-            .expiration(current_height + MaxSectorExpirationExtension::get() + 1)
+            .expiration(current_height + MaxSectorExpiration::get() + 1)
             .build();
 
         // Run pre commit extrinsic

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -319,7 +319,7 @@ parameter_types! {
     pub const WpostChallengeWindow: BlockNumber = 30 * 60 / (SLOT_DURATION as BlockNumber / 1000);
     pub const WPoStChallengeLookBack: BlockNumber = 10 * MINUTES;
     pub const MinSectorExpiration: BlockNumber = 180 * DAYS;
-    pub const MaxSectorExpirationExtension: BlockNumber = 1278 * DAYS;
+    pub const MaxSectorExpiration: BlockNumber = 1278 * DAYS;
     pub const SectorMaximumLifetime: BlockNumber = (365 * DAYS) * 5; // 5 years
     pub const MaxProveCommitDuration: BlockNumber =  (30 * DAYS) + 150;
     pub const WPoStPeriodDeadlines: u64 = 48;
@@ -345,7 +345,7 @@ parameter_types! {
     pub const WpostChallengeWindow: BlockNumber = 2 * MINUTES;
     pub const WPoStChallengeLookBack: BlockNumber = MINUTES;
     pub const MinSectorExpiration: BlockNumber = 5 * MINUTES;
-    pub const MaxSectorExpirationExtension: BlockNumber = 60 * MINUTES;
+    pub const MaxSectorExpiration: BlockNumber = 60 * MINUTES;
     pub const SectorMaximumLifetime: BlockNumber = 120 * MINUTES;
     pub const MaxProveCommitDuration: BlockNumber = 5 * MINUTES;
     pub const MaxPartitionsPerDeadline: u64 = 3000;
@@ -366,7 +366,7 @@ impl pallet_storage_provider::Config for Runtime {
     type WPoStChallengeWindow = WpostChallengeWindow;
     type WPoStChallengeLookBack = WPoStChallengeLookBack;
     type MinSectorExpiration = MinSectorExpiration;
-    type MaxSectorExpirationExtension = MaxSectorExpirationExtension;
+    type MaxSectorExpiration = MaxSectorExpiration;
     type SectorMaximumLifetime = SectorMaximumLifetime;
     type MaxProveCommitDuration = MaxProveCommitDuration;
     type WPoStPeriodDeadlines = WPoStPeriodDeadlines;


### PR DESCRIPTION
### Description

The `MaxSectorExpirationExtension` constant does not need the Extension part since we do not currently support sector life extension.

The `MaxSectorExpirationExtension` value in Filecoin is used as a maximum sector expiration and re-used as the maximum extension in the `extend_sector_expiration` transaction. Since we currently do not support the extend_sector_expiration extrinsic we should rename the value `MaxSectorExpiration`.

The documentation has been updated to reflect the name change.

### Important points for reviewers

[Reference to Filecoin extend_sector_expiration](https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/actors/miner/src/lib.rs#L2256)
