### PR TITLE
feat(pallet-proofs): depth-robust graph by random sample

### DIFF
--- a/pallets/proofs/Cargo.toml
+++ b/pallets/proofs/Cargo.toml
@@ -17,16 +17,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }
+digest = { workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
-scale-info = { features = ["derive"], workspace = true }
-sp-runtime.workspace = true
+primitives-proofs = { workspace = true }
 rand = { workspace = true, features = ["alloc"] }
 rand_chacha = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
 sha2 = { workspace = true }
-digest = { workspace = true }
-primitives-proofs = { workspace = true}
+sp-runtime.workspace = true
 
 [dev-dependencies]
 sp-core = { default-features = true, workspace = true }

--- a/pallets/proofs/src/crypto/feistel.rs
+++ b/pallets/proofs/src/crypto/feistel.rs
@@ -1,1 +1,0 @@
-// https://github.com/filecoin-project/rust-fil-proofs/blob/5a0523ae1ddb73b415ce2fa819367c7989aaf73f/storage-proofs-core/src/crypto/feistel.rs#L17

--- a/pallets/proofs/src/crypto/mod.rs
+++ b/pallets/proofs/src/crypto/mod.rs
@@ -1,1 +1,0 @@
-pub mod feistel;

--- a/pallets/proofs/src/graphs/mod.rs
+++ b/pallets/proofs/src/graphs/mod.rs
@@ -1,2 +1,1 @@
 pub mod bucket;
-pub mod stacked;

--- a/pallets/proofs/src/graphs/stacked.rs
+++ b/pallets/proofs/src/graphs/stacked.rs
@@ -1,3 +1,0 @@
-/// References:
-/// * https://github.com/filecoin-project/rust-fil-proofs/blob/master/storage-proofs-porep/src/stacked/vanilla/graph.rs#L61
-pub struct StackedBucketGraph {}

--- a/pallets/proofs/src/lib.rs
+++ b/pallets/proofs/src/lib.rs
@@ -5,7 +5,6 @@
 
 pub use pallet::*;
 
-mod crypto;
 mod graphs;
 mod porep;
 

--- a/pallets/proofs/src/porep/config.rs
+++ b/pallets/proofs/src/porep/config.rs
@@ -1,4 +1,4 @@
-use primitives_proofs::{RegisteredSealProof, SectorSize};
+use primitives_proofs::RegisteredSealProof;
 
 /// Identificator of a proof version.
 /// There are multiple of those of FileCoin and we need to be compatible with them.
@@ -6,9 +6,6 @@ use primitives_proofs::{RegisteredSealProof, SectorSize};
 pub type PoRepID = [u8; 32];
 
 pub struct Config {
-    seal_proof: RegisteredSealProof,
-    sector_size: SectorSize,
-    partitions: u8,
     porep_id: PoRepID,
     nodes: usize,
 }
@@ -16,9 +13,6 @@ pub struct Config {
 impl Config {
     pub fn new(seal_proof: RegisteredSealProof) -> Self {
         Self {
-            seal_proof,
-            sector_size: seal_proof.sector_size(),
-            partitions: partitions(seal_proof),
             porep_id: porep_id(seal_proof),
             // PRE-COND: sector size must be divisible by 32
             nodes: (seal_proof.sector_size().bytes() / 32) as usize,
@@ -27,10 +21,6 @@ impl Config {
 
     pub fn porep_id(&self) -> PoRepID {
         self.porep_id
-    }
-
-    pub fn sector_size(&self) -> SectorSize {
-        self.sector_size
     }
 
     /// Expected number of nodes in the base Depth Robust Graph
@@ -68,13 +58,5 @@ pub fn porep_id(seal_proof: RegisteredSealProof) -> PoRepID {
 fn proof_id(seal_proof: RegisteredSealProof) -> u64 {
     match seal_proof {
         RegisteredSealProof::StackedDRG2KiBV1P1 => 0,
-    }
-}
-
-/// Reference:
-/// * <https://github.com/filecoin-project/rust-fil-proofs/blob/5a0523ae1ddb73b415ce2fa819367c7989aaf73f/filecoin-proofs/src/constants.rs#L65>
-fn partitions(seal_proof: RegisteredSealProof) -> u8 {
-    match seal_proof {
-        RegisteredSealProof::StackedDRG2KiBV1P1 => 1,
     }
 }

--- a/pallets/storage-provider/src/sector.rs
+++ b/pallets/storage-provider/src/sector.rs
@@ -63,7 +63,7 @@ where
         Self {
             sector_number: precommit.info.sector_number,
             sector_expiry: precommit.info.expiration,
-            sector_type: precommit.info.seal_proof.clone(),
+            sector_type: precommit.info.seal_proof,
             deal_ids: precommit.info.deal_ids.clone(),
         }
     }

--- a/storage/mater/Cargo.toml
+++ b/storage/mater/Cargo.toml
@@ -29,7 +29,7 @@ tokio-util = { workspace = true, features = ["io"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
-rand = { workspace = true, features = ["std"]}
+rand = { workspace = true, features = ["std"] }
 tempfile.workspace = true
 
 [lints]


### PR DESCRIPTION
### Description

Fixes #376. This PR is a part of many.
Introduces the API and basic Depth Robust Graph by DRSample Algorithm. 
I did port the API almost 1:1 to FileCoin implementation, as we need to be compatible with it.
Proof Generation is going to be done by `rust-fil-proofs` api, and verification here.
I think I improved the wrapper API.
The test is a copy paste, as I don't understand this graph fully yet.


### Important points for reviewers

To be able to verify Proof of Replication on-chain, we need to be able to generate Public Inputs for zk-SNARK verification on-chain. This process consists of creating Stacked Depth Robust Graph and then doing some inclusion proof processing on top of that.
[Stacked Depth Robust Graph](https://spec.filecoin.io/algorithms/porep-old/stacked_drg/#section-algorithms.porep-old.stacked_drg.bucketsample-depth-robust-graphs-algorithm) is multipart thing, it consists of:
- BucketGraph (by [DRSample Algorithm](https://acmccs.github.io/papers/p1001-alwenA.pdf)) (this PR)
- Feistel Ciphers needed for Graph expansion
- [Chung Bipartite Expander](http://web.archive.org/web/20220623220540/https://web.stanford.edu/~bfisch/porep_short.pdf) (see Expander Construction).

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] If yes, which ones?
- [x] Make sure that you described what this change does.
- [x] If there are follow-ups, have you created issues for them?
  - [x] #376
  - [x] #369 
- [x] Have you tested this solution?
- [x] Were there any alternative implementations considered?
- [x] Did you document new (or modified) APIs?
