### PR TITLE
feat: add openssl to nix config file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           cargo-expand
           cargo-tarpaulin
           clang
+          openssl
           just
           mdbook
           mdbook-linkcheck
@@ -49,6 +50,7 @@
         devShells.default = mkShell {
           inherit buildInputs;
 
+          OPENSSL_NO_VENDOR = 1;
           LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
           PROTOC = "${protobuf}/bin/protoc";
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library/";


### PR DESCRIPTION
### Description

Add packages `openssl` and `perl` to the nix configuration file to become even more independent from local setups.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?