### PR TITLE
bug: Fix mater tests

### DIFF
--- a/storage/mater/Cargo.toml
+++ b/storage/mater/Cargo.toml
@@ -29,7 +29,7 @@ tokio-util = { workspace = true, features = ["io"] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
-rand = { workspace = true, features = ["std", "std_rng"] }
+rand = { workspace = true, default_features = true }
 tempfile.workspace = true
 
 [lints]


### PR DESCRIPTION
### Description

Mater was missing the "std_rng" feature in the dev dependency rand which makes the tests fail to compile.