### PR TITLE
feat: Add remove_sectors to ExpirationQueue

### DIFF
--- a/pallets/storage-provider/src/expiration_queue.rs
+++ b/pallets/storage-provider/src/expiration_queue.rs
@@ -507,6 +507,7 @@ mod tests {
     extern crate alloc;
 
     use alloc::collections::btree_set::BTreeSet;
+
     use primitives_proofs::SectorNumber;
     use sp_runtime::BoundedBTreeSet;
 


### PR DESCRIPTION
### Description

Add remove_sectors functionality and tests to the ExpirationQueue.
There is a slight difference in the interface with the Filecoin implementation. Our implementation does not take in any recoveries for the remove_sectors because that is only used to recover power in Filecoin, a mechanism we do not have.

### Important points for reviewers

[Filecoin reference](https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/actors/miner/src/expiration_queue.rs#L467)
