### PR TITLE
feat(polka-storage-proofs): implement proof (#395)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "jobserver",
  "libc",
@@ -3659,9 +3659,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -6130,7 +6130,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.5",
+ "redox_syscall 0.5.6",
 ]
 
 [[package]]
@@ -6369,18 +6369,18 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a231296ca742e418c43660cb68e082486ff2538e8db432bc818580f3965025ed"
+checksum = "4d1febb2b4a79ddd1980eede06a8f7902197960aa0383ffcfdd62fe723036725"
 dependencies = [
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.11.0"
+version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb44a01837a858d47e5a630d2ccf304c8efcc4b83b8f9f75b7a9ee4fcc6e57d"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -8819,7 +8819,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.5",
+ "redox_syscall 0.5.6",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -9145,6 +9145,7 @@ dependencies = [
  "pairing",
  "parity-scale-codec",
  "rand",
+ "rand_xorshift",
  "scale-info",
 ]
 
@@ -11161,9 +11162,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62871f2d65009c0256aed1b9cfeeb8ac272833c404e13d53d400cd0dad7a2ac0"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -13162,9 +13163,9 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4d772cfb7569e03868400344a1695d16560bf62b86b918604773607d39ec84"
+checksum = "8cd6ab090d823e75cfdb258aad5fe92e13f2af7d04b43a55d607d25fcc38c811"
 dependencies = [
  "base58",
  "blake2 0.10.6",
@@ -13466,9 +13467,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -16142,7 +16143,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.19",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -17617,9 +17618,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52ac009d615e79296318c1bcce2d422aaca15ad08515e344feeda07df67a587"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ quick-protobuf = "0.8.1"
 quote = { version = "1.0.33" }
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
+rand_xorshift = "0.3"
 rocksdb = { version = "0.21" }
 scale-info = { version = "2.11.1", default-features = false }
 sealed = "0.5"

--- a/lib/polka-storage-proofs/Cargo.toml
+++ b/lib/polka-storage-proofs/Cargo.toml
@@ -11,6 +11,8 @@ version = "0.1.0"
 # Permanently used crates.
 bls12_381 = { workspace = true }
 pairing = { workspace = true }
+rand = { workspace = true }
+rand_xorshift = { workspace = true }
 
 # Crates are only imported on feature 'std'.
 bellperson = { workspace = true, optional = true }

--- a/lib/polka-storage-proofs/src/groth16/substrate.rs
+++ b/lib/polka-storage-proofs/src/groth16/substrate.rs
@@ -3,15 +3,29 @@
 
 use super::*;
 
+impl<E> Default for VerifyingKey<E>
+where
+    E: Engine<G1Affine = G1Affine, G2Affine = G2Affine>,
+{
+    fn default() -> Self {
+        VerifyingKey::<E> {
+            alpha_g1: G1Affine::default(),
+            beta_g1: G1Affine::default(),
+            beta_g2: G2Affine::default(),
+            gamma_g2: G2Affine::default(),
+            delta_g1: G1Affine::default(),
+            delta_g2: G2Affine::default(),
+            ic: alloc::vec![],
+        }
+    }
+}
+
 impl<E> ::codec::Decode for VerifyingKey<E>
 where
     E: Engine<G1Affine = G1Affine, G2Affine = G2Affine>,
 {
     fn decode<I: ::codec::Input>(input: &mut I) -> Result<Self, ::codec::Error> {
-        // TODO(@neutrinoks,#395,20/09/2024): check again needed buffer size.
-        // We don't know how many `ic` values will be passed.
-        // 2784 == 20 * 96 + 864 | see notes above.
-        let mut buffer = [0u8; 2784];
+        let mut buffer = [0u8; VERIFYINGKEY_MAX_BYTES];
         let Some(n_bytes) = input.remaining_len()? else {
             return Err(::codec::Error::from("unable to get remaining_len"));
         };
@@ -49,6 +63,51 @@ where
     }
 }
 
+impl<E: Engine> Default for Proof<E>
+where
+    E: Engine<G1Affine = G1Affine, G2Affine = G2Affine>,
+{
+    fn default() -> Self {
+        Proof::<E> {
+            a: G1Affine::default(),
+            b: G2Affine::default(),
+            c: G1Affine::default(),
+        }
+    }
+}
+
+impl<E> ::codec::Decode for Proof<E>
+where
+    E: Engine<G1Affine = G1Affine, G2Affine = G2Affine>,
+{
+    fn decode<I: ::codec::Input>(input: &mut I) -> Result<Self, ::codec::Error> {
+        let mut buffer = [0u8; PROOF_BYTES];
+        input.read(&mut buffer[..])?;
+        Proof::<E>::from_bytes(&buffer[..]).map_err(|e| codec::Error::from(e.as_static_str()))
+    }
+}
+
+impl<E> ::codec::Encode for Proof<E>
+where
+    E: Engine<G1Affine = G1Affine, G2Affine = G2Affine>,
+{
+    fn size_hint(&self) -> usize {
+        PROOF_BYTES
+    }
+
+    fn encode_to<T: ::codec::Output + ?Sized>(&self, dest: &mut T) {
+        dest.write(&self.a.to_compressed()[..]);
+        dest.write(&self.b.to_compressed()[..]);
+        dest.write(&self.c.to_compressed()[..]);
+    }
+
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        let mut buffer = ByteBuffer::new();
+        self.encode_to(&mut buffer);
+        f(buffer.as_slice())
+    }
+}
+
 impl ::codec::Output for ByteBuffer {
     fn write(&mut self, bytes: &[u8]) {
         for b in bytes.iter() {
@@ -65,7 +124,7 @@ impl ::codec::Input for ByteBuffer {
     fn read(&mut self, into: &mut [u8]) -> Result<(), ::codec::Error> {
         let max = self.bytes_to_read();
         let n = core::cmp::min(into.len(), max);
-        self.1 = copy_to_buffer(&mut into[..n], self.1, &self.0[..]);
+        self.1 = to_fixed_buffer(&mut into[..n], self.1, &self.0[..]);
         Ok(())
     }
 }
@@ -75,6 +134,7 @@ mod tests {
     use codec::{Decode, Encode};
 
     use super::*;
+    use crate::groth16::tests::TEST_SEED;
 
     impl From<Vec<u8>> for ByteBuffer {
         fn from(vec: Vec<u8>) -> ByteBuffer {
@@ -84,13 +144,27 @@ mod tests {
 
     /// This is a smoke test of the `codec::Encode` and `codec::Decode` implementation.
     #[test]
-    fn verifying_key_encode_decode() {
-        let vkey = VerifyingKey::<Bls12>::random();
+    fn verifyingkey_encode_decode() {
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
+        let vkey = VerifyingKey::<Bls12>::random(&mut rng);
         let vkey_bytes = vkey.encode();
         let mut output = ByteBuffer::from(vkey_bytes);
         assert_eq!(
             vkey,
             VerifyingKey::decode(&mut output).expect("VerifyingKey::decode failed")
+        );
+    }
+
+    /// This is a smoke test of the `codec::Encode` and `codec::Decode` implementation.
+    #[test]
+    fn proof_encode_decode() {
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
+        let proof = Proof::<Bls12>::random(&mut rng);
+        let proof_bytes = proof.encode();
+        let mut output = ByteBuffer::from(proof_bytes);
+        assert_eq!(
+            proof,
+            Proof::decode(&mut output).expect("Proof::decode failed")
         );
     }
 }


### PR DESCRIPTION
### Description

This PR adds the `Proof` type definition to crate `polka-storage-proofs`. Additionally:
- random number generation for testing serialisation/deserialisation was fixed
- some utility methods were renamed for a better understanding

The definition of `MultiProof` was skipped because in polka-storage, they will be submitted separately only.

### Important points for reviewers

For some unknown reason, `Proof` gets serialised using `G1Affine::to_compressed`/`G2Affine::to_compressed` instead of the uncompressed variant like in `VerifyingKey`. We sticked here to implementations in `bellperson` / `rust-fil-proofs`.

### Checklist

- [X] Are there important points that reviewers should know?
  - [X] `VerifyingKey` uses uncompressed byte variant, `Proof` uses compressed byte variant.
- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
