### PR TITLE
feat(polka-storage-provider): generate a verifying key and proving key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9360,14 +9360,21 @@ dependencies = [
 name = "polka-storage-proofs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bellpepper-core",
  "bellperson",
  "bls12_381",
  "blstrs",
+ "filecoin-proofs",
  "pairing",
  "parity-scale-codec",
+ "primitives-proofs",
  "rand",
  "rand_xorshift",
  "scale-info",
+ "storage-proofs-core",
+ "storage-proofs-porep",
+ "thiserror",
 ]
 
 [[package]]
@@ -9376,6 +9383,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "bls12_381",
  "chrono",
  "cid 0.11.1",
  "clap",
@@ -9385,6 +9393,9 @@ dependencies = [
  "ipld-core",
  "jsonrpsee 0.23.2",
  "mater",
+ "parity-scale-codec",
+ "polka-storage-proofs",
+ "primitives-proofs",
  "sc-cli",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ primitives-proofs = { path = "primitives/proofs", default-features = false }
 storagext = { path = "cli/polka-storage/storagext" }
 
 # FileCoin proofs
+bellpepper-core = "0.2"
 bellperson = "0.26"
 blstrs = "0.7"
 filecoin-hashers = "13.1.0"

--- a/cli/polka-storage-provider/Cargo.toml
+++ b/cli/polka-storage-provider/Cargo.toml
@@ -10,14 +10,18 @@ version = "0.1.0"
 [dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["macros", "multipart"] }
+bls12_381 = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 cid = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+codec = { workspace = true }
 filecoin-hashers.workspace = true
 fr32.workspace = true
 futures = { workspace = true }
 ipld-core.workspace = true
 jsonrpsee = { workspace = true, features = ["http-client", "macros", "server", "ws-client"] }
+polka-storage-proofs = { workspace = true, features = ["std", "substrate"] }
+primitives-proofs = { workspace = true, features = ["std"] }
 sc-cli = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/cli/polka-storage-provider/src/commands/utils/mod.rs
+++ b/cli/polka-storage-provider/src/commands/utils/mod.rs
@@ -1,8 +1,10 @@
 mod commp;
 
-use std::{fs::File, path::PathBuf};
+use std::{fs::File, io::Write, path::PathBuf};
 
 use mater::CarV2Reader;
+use polka_storage_proofs::porep;
+use primitives_proofs::RegisteredSealProof;
 
 use crate::{
     commands::utils::commp::{calculate_piece_commitment, piece_commitment_cid, CommPError},
@@ -17,6 +19,17 @@ pub enum UtilsCommand {
     CalculatePieceCommitment {
         /// Path to the data
         input_path: PathBuf,
+    },
+    /// Generates PoRep verifying key and proving parameters for zk-SNARK workflows (prove commit)
+    #[clap(name = "porep-params")]
+    GeneratePoRepParams {
+        /// PoRep has multiple variants dependant on the sector size.
+        /// Parameters are required for each sector size and its corresponding PoRep.
+        #[arg(short, long, default_value = "2KiB")]
+        seal_proof: PoRepSealProof,
+        /// Directory where the params files will be put. Defaults to current directory.
+        #[arg(short, long)]
+        output_path: Option<PathBuf>,
     },
 }
 
@@ -44,6 +57,45 @@ impl UtilsCommand {
 
                 println!("Piece commitment CID: {cid}");
             }
+            UtilsCommand::GeneratePoRepParams {
+                seal_proof,
+                output_path,
+            } => {
+                let output_path = if let Some(output_path) = output_path {
+                    output_path
+                } else {
+                    std::env::current_dir()?
+                };
+
+                let file_name: String = seal_proof.clone().into();
+
+                let mut parameters_file =
+                    file_with_extension(&output_path, file_name.as_str(), "params")?;
+                let mut vk_file = file_with_extension(&output_path, file_name.as_str(), "vk")?;
+                let mut vk_scale_file =
+                    file_with_extension(&output_path, file_name.as_str(), "vk.scale")?;
+
+                println!(
+                    "Generating params for {} sectors... It can take a couple of minutes ⌛",
+                    file_name
+                );
+                let parameters =
+                    porep::generate_random_groth16_parameters(seal_proof.0).expect("work pls");
+                parameters.write(&mut parameters_file)?;
+                parameters.vk.write(&mut vk_file)?;
+
+                let vk =
+                    polka_storage_proofs::VerifyingKey::<bls12_381::Bls12>::try_from(parameters.vk)
+                        .map_err(|e| UtilsCommandError::FromBytesError(e))?;
+                let bytes = codec::Encode::encode(&vk);
+                vk_scale_file.write_all(&bytes)?;
+
+                println!(
+                    "Wrote {1}.params, {1}.vk, {1}.vk.scale into {} directory",
+                    output_path.display(),
+                    file_name
+                );
+            }
         }
 
         Ok(())
@@ -52,6 +104,44 @@ impl UtilsCommand {
 
 #[derive(Debug, thiserror::Error)]
 pub enum UtilsCommandError {
-    #[error("the commp command failed with the following error: {0}")]
+    #[error("the commp command failed because: {0}")]
     CommPError(#[from] CommPError),
+    #[error("failed to create a file '{0}' because: {1}")]
+    FileCreateError(PathBuf, std::io::Error),
+    #[error("failed to convert from rust-fil-proofs to polka-storage-proofs: {0}")]
+    FromBytesError(#[from] polka_storage_proofs::FromBytesError),
+}
+
+#[derive(Clone, Debug)]
+pub struct PoRepSealProof(RegisteredSealProof);
+
+impl std::str::FromStr for PoRepSealProof {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "2KiB" => Ok(PoRepSealProof(RegisteredSealProof::StackedDRG2KiBV1P1)),
+            v => Err(format!("unknown value for RegisteredSealProof: {}", v)),
+        }
+    }
+}
+
+impl Into<String> for PoRepSealProof {
+    fn into(self) -> String {
+        match self.0 {
+            RegisteredSealProof::StackedDRG2KiBV1P1 => "2KiB".into(),
+        }
+    }
+}
+
+fn file_with_extension(
+    output_path: &PathBuf,
+    file_name: &str,
+    extension: &str,
+) -> Result<std::fs::File, UtilsCommandError> {
+    let mut new_path = output_path.clone();
+    new_path.push(file_name);
+    new_path.set_extension(extension);
+    std::fs::File::create_new(new_path.clone())
+        .map_err(|e| UtilsCommandError::FileCreateError(new_path, e))
 }

--- a/lib/polka-storage-proofs/Cargo.toml
+++ b/lib/polka-storage-proofs/Cargo.toml
@@ -11,12 +11,19 @@ version = "0.1.0"
 # Permanently used crates.
 bls12_381 = { workspace = true }
 pairing = { workspace = true }
-rand = { workspace = true }
+primitives-proofs = { workspace = true }
 rand_xorshift = { workspace = true }
 
 # Crates are only imported on feature 'std'.
+anyhow = { workspace = true, optional = true }
+bellpepper-core = { workspace = true, optional = true }
 bellperson = { workspace = true, optional = true }
 blstrs = { workspace = true, optional = true }
+filecoin-proofs = { workspace = true, optional = true }
+rand = { workspace = true, default-features = false, optional = true }
+storage-proofs-core = { workspace = true, optional = true }
+storage-proofs-porep = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 
 # Crates are only imported on feature 'substrate'.
 codec = { workspace = true, features = ["derive"], optional = true }
@@ -30,5 +37,16 @@ workspace = true
 
 [features]
 default = ["std"]
-std = ["dep:bellperson", "dep:blstrs"]
+std = [
+  "dep:anyhow",
+  "dep:bellpepper-core",
+  "dep:bellperson",
+  "dep:blstrs",
+  "dep:filecoin-proofs",
+  "dep:storage-proofs-core",
+  "dep:storage-proofs-porep",
+  "dep:thiserror",
+  "primitives-proofs/std",
+  "rand/std",
+]
 substrate = ["dep:codec", "dep:scale-info"]

--- a/lib/polka-storage-proofs/src/groth16/std.rs
+++ b/lib/polka-storage-proofs/src/groth16/std.rs
@@ -46,6 +46,14 @@ where
     }
 }
 
+impl std::fmt::Display for FromBytesError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.as_static_str())
+    }
+}
+
+impl std::error::Error for FromBytesError {}
+
 impl std::io::Read for ByteBuffer {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let n = std::cmp::min(self.0.len(), buf.len());

--- a/lib/polka-storage-proofs/src/groth16/substrate.rs
+++ b/lib/polka-storage-proofs/src/groth16/substrate.rs
@@ -43,6 +43,7 @@ where
         self.serialised_bytes()
     }
 
+    // TODO(@th7nder,#408, 28/09/2024): Encode/Decode, make it use `to_compressed` to reduce the bytes stored on-chain.
     fn encode_to<T: ::codec::Output + ?Sized>(&self, dest: &mut T) {
         dest.write(&self.alpha_g1.to_uncompressed()[..]);
         dest.write(&self.beta_g1.to_uncompressed()[..]);
@@ -108,6 +109,9 @@ where
     }
 }
 
+// `parity_scale_codec` has a blanket implementation for `::codec::Output` if something implements `std::io::Write`
+// Hence, if we use both feature flags `std` and `substrate` there are conflicting implementations.
+#[cfg(not(feature = "std"))]
 impl ::codec::Output for ByteBuffer {
     fn write(&mut self, bytes: &[u8]) {
         for b in bytes.iter() {

--- a/lib/polka-storage-proofs/src/lib.rs
+++ b/lib/polka-storage-proofs/src/lib.rs
@@ -3,5 +3,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod groth16;
+pub mod porep;
 
 pub use groth16::*;

--- a/lib/polka-storage-proofs/src/porep/mod.rs
+++ b/lib/polka-storage-proofs/src/porep/mod.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "std")]
+
+use bellperson::groth16;
+use blstrs::Bls12;
+use filecoin_proofs::{DefaultBinaryTree, DefaultPieceHasher};
+use primitives_proofs::RegisteredSealProof;
+use rand::rngs::OsRng;
+use storage_proofs_core::{compound_proof::CompoundProof, proof::ProofScheme};
+use storage_proofs_porep::stacked::StackedDrg;
+
+/// Generates parameters for proving and verifying PoRep.
+/// It should be called once and then reused across provers and the verifier.
+/// Verifying Key is only needed for verification (no_std), rest of the params are required for proving (std).
+pub fn generate_random_groth16_parameters(
+    seal_proof: RegisteredSealProof,
+) -> Result<groth16::Parameters<Bls12>, PoRepError> {
+    let porep_config = seal_to_config(seal_proof);
+    let setup_params = filecoin_proofs::parameters::setup_params(&porep_config)?;
+    let public_params = StackedDrg::<DefaultBinaryTree, DefaultPieceHasher>::setup(&setup_params)?;
+
+    let circuit = storage_proofs_porep::stacked::StackedCompound::<
+        DefaultBinaryTree,
+        DefaultPieceHasher,
+    >::blank_circuit(&public_params);
+
+    Ok(groth16::generate_random_parameters::<Bls12, _, _>(
+        circuit, &mut OsRng,
+    )?)
+}
+
+fn seal_to_config(seal_proof: RegisteredSealProof) -> filecoin_proofs::PoRepConfig {
+    match seal_proof {
+        RegisteredSealProof::StackedDRG2KiBV1P1 => {
+            // https://github.com/filecoin-project/rust-filecoin-proofs-api/blob/b44e7cecf2a120aa266b6886628e869ba67252af/src/registry.rs#L308
+            let sector_size = 1 << 11;
+            let porep_id = [0u8; 32];
+            let api_version = storage_proofs_core::api_version::ApiVersion::V1_2_0;
+
+            filecoin_proofs::PoRepConfig::new_groth16(sector_size, porep_id, api_version)
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PoRepError {
+    #[error("proof-level failure: {0}")]
+    StorageProofsCoreError(#[from] storage_proofs_core::error::Error),
+    #[error("key generation failure: {0}")]
+    KeyGeneratorError(#[from] bellpepper_core::SynthesisError),
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}


### PR DESCRIPTION
### Description

```
➜  polka-storage git:(feat/400/generate-verifying-key) ✗ ./target/release/polka-storage-provider utils porep-params 
Generating params for 2KiB sectors... It can take a couple of minutes ⌛
Wrote 2KiB.params, 2KiB.vk, 2KiB.vk.scale into /home/th7nder/workspace/eiger/polka-storage directory
```

This PR introduces a command that's able to generate a Verifying Key and Parameters needed for proving and verifying.
`2KiB.vk` (~4kB)-> is a native-byte serialized Verifying Key
`2KiB.vk.scale` (~4kB) -> is SCALE-encoded Verifying Key needed in pallet-proofs
`2KiB.params` (~GB)-> are native-bytes serialized Params needed in Po-Rep generation.

This command should be executed once and then reused across Proofs/Verifications.
In the long run, we'll have some setup ceremony and set those params in a genesic block.

Fixes #400.

### Checklist

- [X] Are there important points that reviewers should know?
  - [X] If yes, which ones?
- [X] Make sure that you described what this change does.
- [X] If there are follow-ups, have you created issues for them?
  - [X] If yes, which ones? / List them here
  - [X] #408 
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
- [X] Did you document new (or modified) APIs?
