### PR TITLE
feat: Add terminate_sectors

### DIFF
--- a/pallets/storage-provider/src/error.rs
+++ b/pallets/storage-provider/src/error.rs
@@ -13,6 +13,8 @@ pub enum GeneralPalletError {
     PartitionErrorFailedToAddFaults,
     /// Emitted when removing recovering sectors fails
     PartitionErrorFailedToRemoveRecoveries,
+    /// Emitted when trying to remove sectors that are not live
+    PartitionErrorSectorsNotLive,
 
     /// Deadline error module types
     /// Emitted when the passed in deadline index supplied for `submit_windowed_post` is out of range.

--- a/pallets/storage-provider/src/expiration_queue.rs
+++ b/pallets/storage-provider/src/expiration_queue.rs
@@ -158,7 +158,6 @@ where
 
             self.must_update_or_delete(expiration_height, set.expiration_set)?;
         }
-
         // Reschedule faulty sectors
         self.add_to_expiration_set(new_expiration, &[], &early_sectors)?;
 
@@ -361,7 +360,10 @@ where
             let mut expiration_set = self
                 .map
                 .get(&expiration_height)
-                .ok_or(GeneralPalletError::ExpirationQueueErrorExpirationSetNotFound)?
+                .ok_or({
+                    log::error!(target: LOG_TARGET, "remove_active_sectors: Could not find expiration set at {expiration_height:?}");
+                    GeneralPalletError::ExpirationQueueErrorExpirationSetNotFound
+                })?
                 .clone();
 
             // Remove sectors from the set
@@ -428,7 +430,10 @@ where
             let expiration_set = self
                 .map
                 .get(&expiration)
-                .ok_or(GeneralPalletError::ExpirationQueueErrorExpirationSetNotFound)?;
+                .ok_or({
+                    log::error!(target: LOG_TARGET, "find_sectors_by_expiration: Could not find expiration set at {expiration:?}");
+                    GeneralPalletError::ExpirationQueueErrorExpirationSetNotFound
+                })?;
 
             if let Some(group) = group_expiration_set(&mut all_remaining, expiration_set.clone()) {
                 groups.insert(*expiration, group);

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
     use sp_arithmetic::traits::Zero;
 
     use crate::{
-        deadline::DeadlineInfo,
+        deadline::{deadline_is_mutable, DeadlineInfo},
         fault::{
             DeclareFaultsParams, DeclareFaultsRecoveredParams, FaultDeclaration,
             RecoveryDeclaration,
@@ -75,7 +75,7 @@ pub mod pallet {
         proofs::{assign_proving_period_offset, SubmitWindowedPoStParams},
         sector::{
             ProveCommitResult, ProveCommitSector, SectorOnChainInfo, SectorPreCommitInfo,
-            SectorPreCommitOnChainInfo, MAX_SECTORS,
+            SectorPreCommitOnChainInfo, TerminateSectorsParams, MAX_SECTORS,
         },
         sector_map::DeadlineSectorMap,
         storage_provider::{
@@ -321,6 +321,8 @@ pub mod pallet {
         FaultRecoveryTooLate,
         /// Tried to slash reserved currency and burn it.
         SlashingFailed,
+        /// Tried to terminate sectors that are not mutable.
+        CannotTerminateImmutableDeadline,
         /// Inner pallet errors
         GeneralPalletError(crate::error::GeneralPalletError),
     }
@@ -873,6 +875,70 @@ pub mod pallet {
                 recoveries: params.recoveries,
             });
 
+            Ok(())
+        }
+
+        /// Marks some sectors as terminated at the present block, earlier than their
+        /// scheduled termination, and adds these sectors to the early termination queue.
+        ///
+        /// References:
+        /// * https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/actors/miner/src/lib.rs#L2488-L2505
+        pub fn terminate_sectors(
+            origin: OriginFor<T>,
+            params: TerminateSectorsParams,
+        ) -> DispatchResult {
+            let owner = ensure_signed(origin)?;
+            let current_block = <frame_system::Pallet<T>>::block_number();
+            let mut sp = StorageProviders::<T>::try_get(&owner)
+                .map_err(|_| Error::<T>::StorageProviderNotFound)?;
+
+            let mut to_process = DeadlineSectorMap::new();
+
+            for term in params.terminations {
+                let deadline = term.deadline;
+                let partition = term.partition;
+
+                to_process
+                    .try_insert(deadline, partition, term.sectors)
+                    .map_err(|e| Error::<T>::GeneralPalletError(e))?;
+            }
+
+            let sectors = sp
+                .sectors
+                .iter()
+                .map(|(_sector_number, info)| info)
+                .cloned()
+                .collect::<Vec<_>>();
+            for (&deadline_idx, partition_sectors) in to_process.into_iter() {
+                ensure!(
+                    !deadline_is_mutable(
+                        sp.proving_period_start,
+                        deadline_idx,
+                        current_block,
+                        T::WPoStPeriodDeadlines::get(),
+                        T::WPoStProvingPeriod::get(),
+                        T::WPoStChallengeWindow::get(),
+                        T::WPoStChallengeLookBack::get(),
+                        T::FaultDeclarationCutoff::get(),
+                    )
+                    .map_err(|e| Error::<T>::GeneralPalletError(e))?,
+                    {
+                        log::error!(target: LOG_TARGET, "cannot terminate sectors in immutable deadline {}", deadline_idx);
+                        Error::<T>::CannotTerminateImmutableDeadline
+                    }
+                );
+
+                let deadlines = sp.get_deadlines_mut();
+                let deadline = deadlines
+                    .load_deadline_mut(deadline_idx as usize)
+                    .map_err(|e| Error::<T>::GeneralPalletError(e))?;
+
+                deadline
+                    .terminate_sectors(current_block, &sectors, partition_sectors)
+                    .map_err(|e| Error::<T>::GeneralPalletError(e))?;
+            }
+
+            // TODO(@aidan46, #167, 2024/10/01): Process early terminations
             Ok(())
         }
     }

--- a/pallets/storage-provider/src/sector.rs
+++ b/pallets/storage-provider/src/sector.rs
@@ -2,10 +2,11 @@ use codec::{Decode, Encode};
 use frame_support::{pallet_prelude::*, BoundedVec};
 use primitives_proofs::{
     DealId, RegisteredSealProof, SectorDeal, SectorId, SectorNumber, MAX_DEALS_PER_SECTOR,
+    MAX_TERMINATIONS_PER_CALL,
 };
 use scale_info::TypeInfo;
 
-use crate::partition::PartitionNumber;
+use crate::{pallet::DECLARATIONS_MAX, partition::PartitionNumber};
 
 // https://github.com/filecoin-project/builtin-actors/blob/17ede2b256bc819dc309edf38e031e246a516486/runtime/src/runtime/policy.rs#L262
 pub const MAX_SECTORS: u32 = 32 << 20;
@@ -139,4 +140,17 @@ impl ProveCommitResult {
             deadline_idx,
         }
     }
+}
+
+/// Argument used for the `terminate_sectors` extrinsic
+#[derive(Clone, RuntimeDebug, Decode, Encode, PartialEq, TypeInfo)]
+pub struct TerminateSectorsParams {
+    pub terminations: BoundedVec<TerminationDeclaration, ConstU32<DECLARATIONS_MAX>>,
+}
+
+#[derive(Clone, RuntimeDebug, Decode, Encode, PartialEq, TypeInfo)]
+pub struct TerminationDeclaration {
+    pub deadline: SectorNumber,
+    pub partition: PartitionNumber,
+    pub sectors: BoundedBTreeSet<SectorNumber, ConstU32<MAX_TERMINATIONS_PER_CALL>>,
 }


### PR DESCRIPTION
### Description

Add `terminate_sectors` extrinsic to the Storage Provider pallet. This implementation depends on #167, `process_early_terminations` because the sectors need to be processed after termination.

[terminate_sectors filecoin reference](https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/actors/miner/src/lib.rs#L2505)

### Checklist

- [ ] Are there important points that reviewers should know?
  - [ ] If yes, which ones?
- [ ] Make sure that you described what this change does.
- [ ] If there are follow-ups, have you created issues for them?
  - [ ] If yes, which ones? / List them here
- [ ] Have you tested this solution?
- [ ] Were there any alternative implementations considered?
- [ ] Did you document new (or modified) APIs?
