### PR TITLE
feat(mater): add overwrite and quiet flags for scripting

### DIFF
--- a/storage/mater-cli/src/convert.rs
+++ b/storage/mater-cli/src/convert.rs
@@ -9,9 +9,14 @@ use crate::error::Error;
 pub(crate) async fn convert_file_to_car(
     input_path: &PathBuf,
     output_path: &PathBuf,
+    overwrite: bool,
 ) -> Result<Cid, Error> {
     let source_file = File::open(input_path).await?;
-    let output_file = File::create_new(output_path).await?;
+    let output_file = if overwrite {
+        File::create(output_path).await
+    } else {
+        File::create_new(output_path).await
+    }?;
     let cid = create_filestore(source_file, output_file, Config::default()).await?;
 
     Ok(cid)
@@ -45,7 +50,7 @@ mod tests {
         let output_path = temp_dir.path().join("test_output.car");
 
         // Call the function under test
-        let result = convert_file_to_car(&input_path, &output_path).await;
+        let result = convert_file_to_car(&input_path, &output_path, false).await;
 
         // Assert the result is Ok
         assert!(result.is_ok());
@@ -69,7 +74,7 @@ mod tests {
         let output_path = temp_dir.path().join("test_output.car");
 
         // Call the function under test
-        let result = convert_file_to_car(&input_path, &output_path).await;
+        let result = convert_file_to_car(&input_path, &output_path, false).await;
 
         // Assert the result is an error
         assert!(result.is_err());
@@ -95,7 +100,7 @@ mod tests {
         println!("gets here");
 
         // Call the function under test
-        let result = convert_file_to_car(&input_path, &output_path).await;
+        let result = convert_file_to_car(&input_path, &output_path, false).await;
 
         // Assert the result is an error
         assert!(result.is_err());

--- a/storage/mater-cli/src/main.rs
+++ b/storage/mater-cli/src/main.rs
@@ -17,9 +17,18 @@ enum MaterCli {
     Convert {
         /// Path to input file
         input_path: PathBuf,
+
         /// Optional path to output CARv2 file.
         /// If no output path is given it will store the `.car` file in the same location.
         output_path: Option<PathBuf>,
+
+        /// If enabled, only the resulting CID will be printed.
+        #[arg(short, long, action)]
+        quiet: bool,
+
+        /// If enabled, the output will overwrite any existing files.
+        #[arg(long, action)]
+        overwrite: bool,
     },
     /// Convert a CARv2 file to its original format
     Extract {
@@ -36,19 +45,25 @@ async fn main() -> Result<(), Error> {
         MaterCli::Convert {
             input_path,
             output_path,
+            quiet,
+            overwrite,
         } => {
             let output_path = output_path.unwrap_or_else(|| {
                 let mut new_path = input_path.clone();
                 new_path.set_extension("car");
                 new_path
             });
-            let cid = convert_file_to_car(&input_path, &output_path).await?;
+            let cid = convert_file_to_car(&input_path, &output_path, overwrite).await?;
 
-            println!(
-                "Converted {} and saved the CARv2 file at {} with a CID of {cid}",
-                input_path.display(),
-                output_path.display()
-            );
+            if quiet {
+                println!("{}", cid);
+            } else {
+                println!(
+                    "Converted {} and saved the CARv2 file at {} with a CID of {cid}",
+                    input_path.display(),
+                    output_path.display()
+                );
+            }
         }
         MaterCli::Extract {
             input_path,


### PR DESCRIPTION
### Description

As described by the title. This is useful for scripting use cases — the `--overwrite` flag in general even


- [x] Have you tested this solution?
- [x] Did you document new (or modified) APIs?
