### PR TITLE
feat(polka-storage-proofs): generate PoSt params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9391,6 +9391,7 @@ dependencies = [
  "scale-info",
  "storage-proofs-core",
  "storage-proofs-porep",
+ "storage-proofs-post",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ fr32 = "11.1.0"
 generic-array = "1.1.0"
 storage-proofs-core = "18.1.0"
 storage-proofs-porep = "18.1.0"
+storage-proofs-post = "18.1.0"
 
 # Substrate
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2407-1" }

--- a/lib/polka-storage-proofs/Cargo.toml
+++ b/lib/polka-storage-proofs/Cargo.toml
@@ -24,6 +24,7 @@ filecoin-proofs = { workspace = true, optional = true }
 rand = { workspace = true, default-features = false, optional = true }
 storage-proofs-core = { workspace = true, optional = true }
 storage-proofs-porep = { workspace = true, optional = true }
+storage-proofs-post = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 
 # Crates are only imported on feature 'substrate'.
@@ -49,6 +50,7 @@ std = [
   "dep:filecoin-proofs",
   "dep:storage-proofs-core",
   "dep:storage-proofs-porep",
+  "dep:storage-proofs-post",
   "dep:thiserror",
   "primitives-proofs/std",
   "rand/std",

--- a/lib/polka-storage-proofs/src/lib.rs
+++ b/lib/polka-storage-proofs/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod groth16;
 pub mod porep;
+pub mod post;
 pub mod types;
 
 pub use groth16::*;

--- a/lib/polka-storage-proofs/src/post/mod.rs
+++ b/lib/polka-storage-proofs/src/post/mod.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "std")]
+
+use bellperson::groth16;
+use blstrs::Bls12;
+use filecoin_proofs::{DefaultOctTree, PoStType};
+use primitives_proofs::RegisteredPoStProof;
+use rand::rngs::OsRng;
+use storage_proofs_core::compound_proof::CompoundProof;
+
+/// Generates parameters for proving and verifying PoSt.
+/// It should be called once and then reused across provers and the verifier.
+/// Verifying Key is only needed for verification (no_std), rest of the params are required for proving (std).
+pub fn generate_random_groth16_parameters(
+    seal_proof: RegisteredPoStProof,
+) -> Result<groth16::Parameters<Bls12>, PoStError> {
+    let post_config = seal_to_config(seal_proof);
+
+    let public_params =
+        filecoin_proofs::parameters::window_post_public_params::<DefaultOctTree>(&post_config)?;
+
+    let circuit =
+        storage_proofs_post::fallback::FallbackPoStCompound::<DefaultOctTree>::blank_circuit(
+            &public_params,
+        );
+
+    Ok(groth16::generate_random_parameters(circuit, &mut OsRng)?)
+}
+
+/// References:
+/// * <https://github.com/filecoin-project/rust-filecoin-proofs-api/blob/b44e7cecf2a120aa266b6886628e869ba67252af/src/registry.rs#L644>
+fn seal_to_config(seal_proof: RegisteredPoStProof) -> filecoin_proofs::PoStConfig {
+    match seal_proof {
+        RegisteredPoStProof::StackedDRGWindow2KiBV1P1 => {
+            filecoin_proofs::PoStConfig {
+                sector_size: filecoin_proofs::SectorSize(seal_proof.sector_size().bytes()),
+                challenge_count: filecoin_proofs::WINDOW_POST_CHALLENGE_COUNT,
+                // https://github.com/filecoin-project/rust-fil-proofs/blob/266acc39a3ebd6f3d28c6ee335d78e2b7cea06bc/filecoin-proofs/src/constants.rs#L104
+                sector_count: 2,
+                typ: PoStType::Window,
+                priority: true,
+                api_version: storage_proofs_core::api_version::ApiVersion::V1_2_0,
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PoStError {
+    #[error("key generation failure: {0}")]
+    KeyGeneratorError(#[from] bellpepper_core::SynthesisError),
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+}


### PR DESCRIPTION
### Description

```bash
galeheim ➜  polka-storage git:(feat/437/generate-post) ✗ ./target/debug/polka-storage-provider-client utils post-params
Generating PoSt params for 2KiB sectors... It can take a couple of minutes ⌛
Generated parameters: 
/Users/konrad.stepniak/workspace/polka-storage/2KiB.post.params
/Users/konrad.stepniak/workspace/polka-storage/2KiB.post.vk
/Users/konrad.stepniak/workspace/polka-storage/2KiB.post.vk.scale
```

Generates verifying key and params for PoSt.

This command should be executed once and then reused across Proofs/Verifications.
In the long run, we'll have some setup ceremony and set those params in a genesis block.

Partially #437.

### Checklist

- [X] Are there important points that reviewers should know?
  - [X] If yes, which ones?
- [X] Make sure that you described what this change does.
- [X] If there are follow-ups, have you created issues for them?
  - [X] If yes, which ones? / List them here
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
- [X] Did you document new (or modified) APIs?
