### PR TITLE
feat(polka-storage-provider-client): generate post 

### DIFF
--- a/cli/polka-storage-provider/client/src/commands/utils.rs
+++ b/cli/polka-storage-provider/client/src/commands/utils.rs
@@ -8,7 +8,7 @@ use std::{
 use mater::CarV2Reader;
 use polka_storage_proofs::{
     porep::{self, sealer::Sealer},
-    post,
+    post::{self, ReplicaInfo},
     types::PieceInfo,
 };
 use polka_storage_provider_common::commp::{
@@ -72,15 +72,39 @@ pub enum UtilsCommand {
         #[arg(short, long)]
         output_path: Option<PathBuf>,
     },
+    /// Creates a PoSt for a single sector.
+    PoSt {
+        /// PoSt has multiple variants dependant on the sector size.
+        /// Parameters are required for each sector size and its corresponding PoSt.
+        #[arg(long, default_value = "2KiB")]
+        post_type: PoStProof,
+        /// Path to where parameters to corresponding `post_type` are stored.
+        #[arg(short, long)]
+        proof_parameters_path: PathBuf,
+        /// Directory where cache data from `po-rep` for the `replica_path` sector command has been stored.
+        /// It must be the same, or else it won't work.
+        #[arg(short, long)]
+        cache_directory: PathBuf,
+        /// Replica file generated with `po-rep` command e.g. `77.sector.sealed`.
+        replica_path: PathBuf,
+        /// Hex-encoded CommR of a replica (output of `po-rep` command)
+        comm_r: String,
+        #[arg(short, long)]
+        /// Directory where the PoSt proof will be stored. Defaults to the current directory.
+        output_path: Option<PathBuf>,
+    },
 }
 
-const POREP_PARAMS_EXT: &str = ".porep.params";
-const POREP_VK_EXT: &str = ".porep.vk";
-const POREP_VK_EXT_SCALE: &str = ".porep.vk.scale";
+const POREP_PARAMS_EXT: &str = "porep.params";
+const POREP_VK_EXT: &str = "porep.vk";
+const POREP_VK_EXT_SCALE: &str = "porep.vk.scale";
 
-const POST_PARAMS_EXT: &str = ".post.params";
-const POST_VK_EXT: &str = ".post.vk";
-const POST_VK_EXT_SCALE: &str = ".post.vk.scale";
+const POST_PARAMS_EXT: &str = "post.params";
+const POST_VK_EXT: &str = "post.vk";
+const POST_VK_EXT_SCALE: &str = "post.vk.scale";
+
+const POREP_PROOF_EXT: &str = "proof.porep.scale";
+const POST_PROOF_EXT: &str = "proof.post.scale";
 
 impl UtilsCommand {
     /// Run the command.
@@ -175,7 +199,7 @@ impl UtilsCommand {
                         .expect("input file to have a name")
                         .to_str()
                         .expect("to be convertable to str"),
-                    "proof.scale",
+                    POREP_PROOF_EXT,
                 )?;
 
                 let mut source_file = tokio::fs::File::open(&input_path).await?;
@@ -311,6 +335,67 @@ impl UtilsCommand {
                 println!("{}", vk_file_name.display());
                 println!("{}", vk_scale_file_name.display());
             }
+            UtilsCommand::PoSt {
+                post_type,
+                proof_parameters_path,
+                cache_directory,
+                replica_path,
+                comm_r,
+                output_path,
+            } => {
+                let output_path = if let Some(output_path) = output_path {
+                    output_path
+                } else {
+                    std::env::current_dir()?
+                };
+
+                let (proof_scale_filename, mut proof_scale_file) = file_with_extension(
+                    &output_path,
+                    replica_path
+                        .file_name()
+                        .expect("input file to have a name")
+                        .to_str()
+                        .expect("to be convertable to str"),
+                    POST_PROOF_EXT,
+                )?;
+
+                // Those are hardcoded for the showcase only.
+                // They should come from Storage Provider Node, precommits and other information.
+                let sector_id = 77;
+                let randomness = [1u8; 32];
+                let prover_id = [0u8; 32];
+                let replicas = vec![ReplicaInfo {
+                    sector_id,
+                    comm_r: hex::decode(comm_r)
+                        .map_err(|_| UtilsCommandError::CommRError)?
+                        .try_into()
+                        .map_err(|_| UtilsCommandError::CommRError)?,
+                    replica_path,
+                }];
+
+                println!("Loading parameters...");
+                let proof_parameters = post::load_groth16_parameters(proof_parameters_path)
+                    .map_err(|e| UtilsCommandError::GeneratePoStError(e))?;
+
+                let proofs = post::generate_window_post(
+                    post_type.0,
+                    &proof_parameters,
+                    randomness,
+                    prover_id,
+                    replicas,
+                    cache_directory,
+                )
+                .map_err(|e| UtilsCommandError::GeneratePoStError(e))?;
+
+                println!("Proving...");
+                // We only prove a single sector here, so it'll only be 1 proof.
+                let proof_scale: polka_storage_proofs::Proof<bls12_381::Bls12> = proofs[0]
+                    .clone()
+                    .try_into()
+                    .expect("converstion between rust-fil-proofs and polka-storage-proofs to work");
+                proof_scale_file.write_all(&codec::Encode::encode(&proof_scale))?;
+                println!("Wrote proof to {}", proof_scale_filename.display());
+            }
         }
 
         Ok(())
@@ -329,6 +414,8 @@ pub enum UtilsCommandError {
     GeneratePoRepError(#[from] porep::PoRepError),
     #[error("failed to generate a post: {0}")]
     GeneratePoStError(#[from] post::PoStError),
+    #[error("CommR must be 32 bytes and generated by `po-rep` command")]
+    CommRError,
     #[error("failed to load piece file at path: {0}")]
     InvalidPieceFile(PathBuf, std::io::Error),
     #[error("provided invalid CommP {0}, error: {1}")]

--- a/lib/polka-storage-proofs/src/porep/mod.rs
+++ b/lib/polka-storage-proofs/src/porep/mod.rs
@@ -6,7 +6,7 @@ pub mod sealer;
 
 use bellperson::groth16;
 use blstrs::Bls12;
-use filecoin_proofs::{DefaultBinaryTree, DefaultPieceHasher};
+use filecoin_proofs::{DefaultPieceHasher, SectorShapeBase};
 use primitives_proofs::RegisteredSealProof;
 use rand::rngs::OsRng;
 use storage_proofs_core::{compound_proof::CompoundProof, proof::ProofScheme};
@@ -22,10 +22,10 @@ pub fn generate_random_groth16_parameters(
 ) -> Result<groth16::Parameters<Bls12>, PoRepError> {
     let porep_config = seal_to_config(seal_proof);
     let setup_params = filecoin_proofs::parameters::setup_params(&porep_config)?;
-    let public_params = StackedDrg::<DefaultBinaryTree, DefaultPieceHasher>::setup(&setup_params)?;
+    let public_params = StackedDrg::<SectorShapeBase, DefaultPieceHasher>::setup(&setup_params)?;
 
     let circuit = storage_proofs_porep::stacked::StackedCompound::<
-        DefaultBinaryTree,
+        SectorShapeBase,
         DefaultPieceHasher,
     >::blank_circuit(&public_params);
 

--- a/lib/polka-storage-proofs/src/post/mod.rs
+++ b/lib/polka-storage-proofs/src/post/mod.rs
@@ -1,14 +1,24 @@
 #![cfg(feature = "std")]
 
-use crate::types::{Commitment, ProverId, Ticket};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 use bellperson::groth16;
 use blstrs::Bls12;
-use filecoin_proofs::{DefaultOctTree, PoStType, PrivateReplicaInfo};
-use primitives_proofs::{SectorNumber, RegisteredPoStProof};
+use filecoin_proofs::{
+    as_safe_commitment, parameters::window_post_setup_params, PoStType, PrivateReplicaInfo,
+    SectorShapeBase,
+};
+use primitives_proofs::{RegisteredPoStProof, SectorNumber};
 use rand::rngs::OsRng;
-use std::{path::{PathBuf, Path}, collections::BTreeMap};
-use storage_proofs_core::compound_proof::CompoundProof;
+use storage_proofs_core::compound_proof::{self, CompoundProof};
+use storage_proofs_post::fallback::{
+    self, FallbackPoSt, FallbackPoStCompound, PrivateSector, PublicSector,
+};
+
+use crate::types::{Commitment, ProverId, Ticket};
 
 /// Generates parameters for proving and verifying PoSt.
 /// It should be called once and then reused across provers and the verifier.
@@ -19,14 +29,23 @@ pub fn generate_random_groth16_parameters(
     let post_config = seal_to_config(seal_proof);
 
     let public_params =
-        filecoin_proofs::parameters::window_post_public_params::<DefaultOctTree>(&post_config)?;
+        filecoin_proofs::parameters::window_post_public_params::<SectorShapeBase>(&post_config)?;
 
     let circuit =
-        storage_proofs_post::fallback::FallbackPoStCompound::<DefaultOctTree>::blank_circuit(
+        storage_proofs_post::fallback::FallbackPoStCompound::<SectorShapeBase>::blank_circuit(
             &public_params,
         );
 
     Ok(groth16::generate_random_parameters(circuit, &mut OsRng)?)
+}
+
+/// Loads Groth16 parameters from the specified path.
+/// Parameters needed to be serialized with [`groth16::Paramters::<Bls12>::write_bytes`].
+pub fn load_groth16_parameters(
+    path: std::path::PathBuf,
+) -> Result<groth16::MappedParameters<Bls12>, PoStError> {
+    groth16::Parameters::<Bls12>::build_mapped_parameters(path.clone(), false)
+        .map_err(|e| PoStError::FailedToLoadGrothParameters(path, e))
 }
 
 #[derive(Debug)]
@@ -36,24 +55,87 @@ pub struct ReplicaInfo {
     pub replica_path: PathBuf,
 }
 
+/// Generates Windowed PoSt for a replica.
+/// Only supports 2KiB sectors.
+///
+/// References:
+/// * <https://github.com/filecoin-project/rust-fil-proofs/blob/5a0523ae1ddb73b415ce2fa819367c7989aaf73f/filecoin-proofs/src/api/window_post.rs#L100>
 pub fn generate_window_post<CacheDirectory: AsRef<Path>>(
     proof_type: RegisteredPoStProof,
+    groth_params: &groth16::MappedParameters<Bls12>,
     randomness: Ticket,
     prover_id: ProverId,
     partition_replicas: Vec<ReplicaInfo>,
     cache_dir: CacheDirectory,
-) -> Result<Vec<u8>, PoStError> {
-    let config = seal_to_config(proof_type);
+) -> Result<Vec<groth16::Proof<Bls12>>, PoStError> {
+    type Tree = SectorShapeBase;
+
+    let post_config = seal_to_config(proof_type);
     let mut replicas = BTreeMap::new();
     for replica in partition_replicas {
-        replicas.insert(replica.sector_id.into(), PrivateReplicaInfo::<DefaultOctTree>::new(
-            replica.replica_path,
-            replica.comm_r,
-            cache_dir.as_ref().to_path_buf()
-        )?);
+        replicas.insert(
+            replica.sector_id.into(),
+            PrivateReplicaInfo::<Tree>::new(
+                replica.replica_path,
+                replica.comm_r,
+                cache_dir.as_ref().to_path_buf(),
+            )?,
+        );
+    }
+    let randomness_safe = as_safe_commitment(&randomness, "randomness")?;
+    let prover_id_safe = as_safe_commitment(&prover_id, "prover_id")?;
+
+    let vanilla_params = window_post_setup_params(&post_config);
+    let partitions = get_partitions_for_window_post(replicas.len(), &post_config);
+
+    let sector_count = vanilla_params.sector_count;
+    let setup_params = compound_proof::SetupParams {
+        vanilla_params,
+        partitions,
+        priority: post_config.priority,
+    };
+
+    let pub_params: compound_proof::PublicParams<'_, FallbackPoSt<'_, Tree>> =
+        FallbackPoStCompound::setup(&setup_params)?;
+
+    let trees: Vec<_> = replicas
+        .values()
+        .map(|replica| replica.merkle_tree(post_config.sector_size))
+        .collect::<Result<_, _>>()?;
+
+    let mut pub_sectors = Vec::with_capacity(sector_count);
+    let mut priv_sectors = Vec::with_capacity(sector_count);
+
+    for ((sector_id, replica), tree) in replicas.iter().zip(trees.iter()) {
+        let comm_r = replica.safe_comm_r()?;
+        let comm_c = replica.safe_comm_c();
+        let comm_r_last = replica.safe_comm_r_last();
+
+        pub_sectors.push(PublicSector {
+            id: *sector_id,
+            comm_r,
+        });
+        priv_sectors.push(PrivateSector {
+            tree,
+            comm_c,
+            comm_r_last,
+        });
     }
 
-    Ok(filecoin_proofs::generate_window_post(&config, &randomness, &replicas, prover_id)?)
+    let pub_inputs = fallback::PublicInputs {
+        randomness: randomness_safe,
+        prover_id: prover_id_safe,
+        sectors: pub_sectors,
+        k: None,
+    };
+
+    let priv_inputs = fallback::PrivateInputs::<Tree> {
+        sectors: &priv_sectors,
+    };
+
+    let proofs = FallbackPoStCompound::prove(&pub_params, &pub_inputs, &priv_inputs, groth_params)?;
+
+    Ok(proofs)
 }
 
 /// References:
@@ -80,4 +162,17 @@ pub enum PoStError {
     KeyGeneratorError(#[from] bellpepper_core::SynthesisError),
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
+    #[error("failed to load groth16 parameters from path: {0}, because {1}")]
+    FailedToLoadGrothParameters(std::path::PathBuf, std::io::Error),
+}
+
+/// Reference:
+/// * <https://github.com/filecoin-project/rust-fil-proofs/blob/266acc39a3ebd6f3d28c6ee335d78e2b7cea06bc/filecoin-proofs/src/api/post_util.rs#L217>
+fn get_partitions_for_window_post(
+    total_sector_count: usize,
+    post_config: &filecoin_proofs::PoStConfig,
+) -> Option<usize> {
+    let partitions = (total_sector_count as f32 / post_config.sector_count as f32).ceil() as usize;
+
+    (partitions > 1).then_some(partitions)
 }


### PR DESCRIPTION
### Description

FIxes #437. 
Introduces `polka-storage-provider-client utils po-rep` command which can be used to generate a PoSt based on PoRep (#417).
This command only proves PoSt for a single replica in a partition, works as a PoC so we can continue to make the verification on-chain.
Some sector choices were wrong previously, i.e. we used `DefaultBinaryTree` instead of `SectorShapeBase`. 
Keep in mind this only works for 2KiB sectors for now and in the future will require follow-ups. 


```
➜  polka-storage git:(feat/437/generate-post-sector) ✗ RUST_LOG=error ./target/debug/polka-storage-provider-client utils po-rep --proof-parameters-path 2KiB.porep.params --cache-directory /tmp/psp-cache test-data-big.car baga6ea4seaqbfhdvmk5qygevit25ztjwl7voyikb5k2fqcl2lsuefhaqtukuiii
Creating sector...
Precommitting...
Proving...
CommR: "4afb35f82a95a10187a913bc14520d9a1d173328265b301b5dcf440ef2583950"
CommD: "129c7562bb0c189544f5dccd365feaec2141eab458097a5ca8429c109d154421"
Proof: [Proof { a: G1Affine { x: Fp(0x0f2f76ef17319372044510373b57895d5366cf98cef115b87149aaeaf8d4e7fa84cfee2342808f7f4aa76e1e28fdbf92), y: Fp(0x1206c10250f5fc0c196949f0e3d1a83e7cdb011a112fc474e5c120af9be32e1d1fef7f5af08d04bd64d5b4824d7bbd9e), infinity: false }, b: G2Affine { x: Fp2 { c0: Fp(0x041137aca3908dfe68d770d407c7c88069e235cd6d031a3fc01478d3e3864e0e3c899f747fb5073639ea8d15e69aca21), c1: Fp(0x1368f04708eda943c4b8f638623d133c790c92c963d201dba8f6ed69741dbc5977cd5659ba6ebd6c8cb8a3e07246eccd) }, y: Fp2 { c0: Fp(0x179d1e1cee36b3b45d46d61bf0906e81fe5abeb955f631bff975f3cbce7778481251b007ba9b4b755d14da5460b94ef1), c1: Fp(0x0b4e3b7cf41527698583f6b50422526b9d232ebc1ea0f98eb300296cb4579fe3495a78c92294039b652a3ba6e738759c) }, infinity: false }, c: G1Affine { x: Fp(0x07ba8312436f625b69a4560055ed0b04e43b53a5b519e0440a1ad9f5d7fff6794497559a76ee2b4dd2b729c5ec71ed4c), y: Fp(0x0c98096679c3046fe2a18b8bd060e62d26e47d4c9e19b0373eedca297c8674b518e3a32f301acfc36ace4616891f7128), infinity: false } }]
Wrote proof to /home/th7nder/workspace/eiger/polka-storage/test-data-big.proof.porep.scale
➜  polka-storage git:(feat/437/generate-post-sector) ✗ RUST_LOG=ERROR ./target/debug/polka-storage-provider-client utils po-st --proof-parameters-path 2KiB.post.params --cache-directory /tmp/psp-cache 77.sector.sealed 4afb35f82a95a10187a913bc14520d9a1d173328265b301b5dcf440ef2583950 
Loading parameters...
Proving...
Wrote proof to /home/th7nder/workspace/eiger/polka-storage/77.sector.proof.post.scale
```

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
- [X] Did you document new (or modified) APIs?
