### PR TITLE
fix(maat): SeedNotAvailable

### DIFF
--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -1059,7 +1059,7 @@ pub mod pallet {
             );
             // expiration cannot be less than minimum after activation
             ensure!(
-                expiration - activation > T::MinSectorExpiration::get(),
+                expiration - activation >= T::MinSectorExpiration::get(),
                 Error::<T>::ExpirationTooSoon
             );
             // expiration cannot exceed MaxSectorExpiration from now


### PR DESCRIPTION
### Description

Fixes the missing seed issue

### Important points for reviewers

Now fails with a wrong PoRep
```
---- real_world_use_case stdout ----
thread 'real_world_use_case' panicked at maat/tests/real_world.rs:239:10:
called `Result::unwrap()` on an `Err` value: Runtime(Module(ModuleError(<Proofs::InvalidPoRepProof>)))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Checklist

- [x] Make sure that you described what this change does.
- [x] Have you tested this solution?