### PR TITLE
chore: Replace static str errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14915,6 +14915,7 @@ dependencies = [
  "sp-core 34.0.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-2)",
  "sp-runtime 39.0.1",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-2)",
+ "thiserror 2.0.3",
 ]
 
 [[package]]

--- a/cli/polka-storage-provider/server/src/db.rs
+++ b/cli/polka-storage-provider/server/src/db.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use primitives_proofs::SectorNumber;
+use primitives_proofs::{SectorNumber, SectorNumberError};
 use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, Options as DBOptions, DB as RocksDB};
 use serde::{de::DeserializeOwned, Serialize};
 use storagext::types::market::{ConversionError, DealProposal};
@@ -184,7 +184,7 @@ impl DealDB {
 
     /// Atomically increments sector_id counter, so it can be used as an identifier by a sector.
     /// Prior to all of the calls to this function, `initialize_biggest_sector_id` must be called at the node start-up.
-    pub fn next_sector_number(&self) -> Result<SectorNumber, &'static str> {
+    pub fn next_sector_number(&self) -> Result<SectorNumber, SectorNumberError> {
         // [`Ordering::Relaxed`] can be used here, as it's an update on a single variable.
         // It does not depend on other Atomic variables and it does not matter which thread makes it first.
         // We just need it to be different on every thread that calls it concurrently, so the ids are not duplicated.

--- a/primitives/proofs/Cargo.toml
+++ b/primitives/proofs/Cargo.toml
@@ -9,16 +9,17 @@ version = "0.1.0"
 
 [dependencies]
 cid = { workspace = true, default-features = false, features = ["alloc"] }
-clap = { workspace = true, features = ["derive"], optional = true }
 codec = { workspace = true, default-features = false, features = ["derive"] }
 scale-decode = { workspace = true, default-features = false, features = ["derive"] }
 scale-encode = { workspace = true, default-features = false, features = ["derive"] }
 scale-info = { workspace = true, default-features = false, features = ["derive"] }
-serde = { workspace = true, features = ["derive"], optional = true }
 sp-core = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
 thiserror = { workspace = true, default-features = false }
+
+clap = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true, default-features = true }

--- a/primitives/proofs/Cargo.toml
+++ b/primitives/proofs/Cargo.toml
@@ -9,17 +9,16 @@ version = "0.1.0"
 
 [dependencies]
 cid = { workspace = true, default-features = false, features = ["alloc"] }
+clap = { workspace = true, features = ["derive"], optional = true }
 codec = { workspace = true, default-features = false, features = ["derive"] }
 scale-decode = { workspace = true, default-features = false, features = ["derive"] }
 scale-encode = { workspace = true, default-features = false, features = ["derive"] }
 scale-info = { workspace = true, default-features = false, features = ["derive"] }
-
+serde = { workspace = true, features = ["derive"], optional = true }
 sp-core = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
-
-clap = { workspace = true, features = ["derive"], optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+thiserror = { workspace = true, default-features = false }
 
 [dev-dependencies]
 serde_json = { workspace = true, default-features = true }

--- a/primitives/proofs/src/types.rs
+++ b/primitives/proofs/src/types.rs
@@ -37,9 +37,9 @@ impl SectorNumber {
     ///
     /// Returns a `Result` containing the new `SectorNumber` if valid,
     /// or an error message if the sector number exceeds `MAX_SECTORS`.
-    pub fn new(sector_number: u32) -> Result<Self, &'static str> {
+    pub fn new(sector_number: u32) -> Result<Self, SectorNumberError> {
         if sector_number > MAX_SECTORS {
-            return Err("Sector number is too large");
+            return Err(SectorNumberError::NumberTooLarge);
         }
 
         Ok(Self(sector_number))
@@ -67,6 +67,25 @@ impl Decode for SectorNumber {
         let value = u32::decode(input)?;
         SectorNumber::new(value).map_err(|_| "Sector number is too large".into())
     }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Eq,
+    Encode,
+    EncodeAsType,
+    TypeInfo,
+    RuntimeDebug,
+    MaxEncodedLen,
+    thiserror::Error,
+)]
+pub enum SectorNumberError {
+    #[error("Sector number is too large")]
+    NumberTooLarge,
 }
 
 // Implement the `Visitor` trait to define how to go from SCALE
@@ -130,7 +149,7 @@ impl From<u16> for SectorNumber {
 }
 
 impl TryFrom<u32> for SectorNumber {
-    type Error = &'static str;
+    type Error = SectorNumberError;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Self::new(value)


### PR DESCRIPTION
### Description

When I was refactoring the errors for the market pallet, I noticed there we some `Result`'s that returned a static str as the error. This small change adds proper errors for those.  static str's cannot be returned as errors in pallet, this future-proofs the error were we to use them in pallets.
