### PR TITLE
feat: submit windowed posts repeatedly

### DIFF
--- a/pallets/storage-provider/src/deadline.rs
+++ b/pallets/storage-provider/src/deadline.rs
@@ -720,8 +720,7 @@ where
         self.block_number >= self.fault_cutoff
     }
 
-    /// Calculates the deadline information in the next proving period in which the deadline will be open.
-    /// If the current deadline is still open, it'll return the deadline in the next proving period.
+    /// Calculates the deadline information in the next proving period.
     ///
     /// ### Example 1
     /// Current Block = 110
@@ -736,11 +735,7 @@ where
     /// next() -> [240, 260)
     ///
     pub fn next(self) -> Result<Self, GeneralPalletError> {
-        let gap = if self.is_open() {
-            BlockNumber::zero()
-        } else {
-            self.block_number - self.period_start
-        };
+        let gap = self.block_number - self.period_start;
         let delta_periods = BlockNumber::one() + gap / self.w_post_proving_period;
 
         Self::new(
@@ -763,7 +758,6 @@ where
             return Ok(self);
         }
 
-        // has elapsed, advance by some multiples of w_post_proving_period
         self.next()
     }
 

--- a/pallets/storage-provider/src/deadline.rs
+++ b/pallets/storage-provider/src/deadline.rs
@@ -664,7 +664,7 @@ where
         let (open_at, close_at, challenge, fault_cutoff) = if idx_converted < period_deadlines {
             let open_at = period_start + (idx_converted * w_post_challenge_window);
             let close_at = open_at + w_post_challenge_window;
-            let challenge = period_start - w_post_challenge_lookback;
+            let challenge = open_at - w_post_challenge_lookback;
             let fault_cutoff = open_at - fault_declaration_cutoff;
             (open_at, close_at, challenge, fault_cutoff)
         } else {

--- a/pallets/storage-provider/src/deadline.rs
+++ b/pallets/storage-provider/src/deadline.rs
@@ -723,12 +723,12 @@ where
     /// It calculates the next period start by getting the gap between the current block number and the closing block number
     /// and adding 1. Making sure it is a multiple of proving period by dividing by `w_post_proving_period`.
     fn next(self) -> Result<Self, GeneralPalletError> {
-        let gap = self.block_number - self.close_at;
-        let delta_periods = BlockNumber::one() + gap / self.w_post_proving_period;
+        // let gap = self.block_number - self.close_at;
+        // let delta_periods = BlockNumber::one() + gap / self.w_post_proving_period;
 
         Self::new(
             self.block_number,
-            self.period_start + self.w_post_proving_period * delta_periods,
+            self.period_start + self.w_post_proving_period,
             self.idx,
             self.w_post_period_deadlines,
             self.w_post_proving_period,
@@ -760,7 +760,6 @@ where
 
         self.next()
     }
-
 }
 
 /// Returns true if the deadline at the given index is currently mutable.

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -1098,7 +1098,7 @@ pub mod pallet {
             })
         }
 
-        /// Gets the current deadline of the storage provider.
+        /// Gets the next, not yet opened, deadline of the storage provider.
         ///
         /// If there is no Storage Provider of given AccountId returns [`Option::None`].
         /// May exceptionally return [`Option::None`] when
@@ -1120,6 +1120,7 @@ pub mod pallet {
                 T::WPoStChallengeLookBack::get(),
                 T::FaultDeclarationCutoff::get(),
             )
+            .and_then(DeadlineInfo::next_not_opened)
             .ok()?;
 
             Some(ExternalDeadlineInfo {

--- a/pallets/storage-provider/src/tests/deadline.rs
+++ b/pallets/storage-provider/src/tests/deadline.rs
@@ -1,0 +1,61 @@
+use crate::deadline::DeadlineInfo;
+
+
+fn default_deadline() -> DeadlineInfo<u64> {
+    let block_number = 112;
+    let period_start = 100;
+    let deadline_index = 0;
+    let period_deadlines = 3;
+    let proving_period = 60;
+    let challenge_window = 20;
+    let challenge_lookback = 20;
+    let cutoff = 5;
+
+    DeadlineInfo::<u64>::new(
+        block_number,
+        period_start,
+        deadline_index,
+        period_deadlines,
+        proving_period,
+        challenge_window,
+        challenge_lookback,
+        cutoff
+    ).unwrap()
+}
+
+#[test]
+fn calculates_next_deadline_when_its_open() {
+    let deadline_info = default_deadline();
+    assert_eq!(deadline_info.is_open(), true);
+
+    let next = deadline_info.next().unwrap();
+
+    assert_eq!(next.open_at, 160);
+    assert_eq!(next.close_at, 180);
+}
+
+#[test]
+fn calculates_next_deadline_when_its_elapsed() {
+    let mut deadline_info = default_deadline();
+    deadline_info.block_number = 121;
+    assert_eq!(deadline_info.is_open(), false);
+    assert_eq!(deadline_info.has_elapsed(), true);
+
+    let next = deadline_info.next().unwrap();
+
+    assert_eq!(next.open_at, 160);
+    assert_eq!(next.close_at, 180);
+}
+
+#[test]
+fn calculates_next_deadline_when_its_2_proving_periods_behind() {
+    let mut deadline_info = default_deadline();
+    deadline_info.block_number = 162;
+    assert_eq!(deadline_info.is_open(), false);
+    assert_eq!(deadline_info.has_elapsed(), true);
+
+    let next = deadline_info.next().unwrap();
+
+    assert_eq!(next.open_at, 220);
+    assert_eq!(next.close_at, 240);
+}

--- a/pallets/storage-provider/src/tests/deadline.rs
+++ b/pallets/storage-provider/src/tests/deadline.rs
@@ -1,6 +1,5 @@
 use crate::deadline::DeadlineInfo;
 
-
 fn default_deadline() -> DeadlineInfo<u64> {
     let block_number = 112;
     let period_start = 100;
@@ -19,8 +18,9 @@ fn default_deadline() -> DeadlineInfo<u64> {
         proving_period,
         challenge_window,
         challenge_lookback,
-        cutoff
-    ).unwrap()
+        cutoff,
+    )
+    .unwrap()
 }
 
 #[test]

--- a/pallets/storage-provider/src/tests/mod.rs
+++ b/pallets/storage-provider/src/tests/mod.rs
@@ -40,6 +40,7 @@ use crate::{
 
 mod declare_faults;
 mod declare_faults_recovered;
+mod deadline;
 mod expiration_queue;
 mod post_hook;
 mod pre_commit_sector_hook;

--- a/pallets/storage-provider/src/tests/mod.rs
+++ b/pallets/storage-provider/src/tests/mod.rs
@@ -38,9 +38,9 @@ use crate::{
     sector::SectorPreCommitInfo,
 };
 
+mod deadline;
 mod declare_faults;
 mod declare_faults_recovered;
-mod deadline;
 mod expiration_queue;
 mod post_hook;
 mod pre_commit_sector_hook;


### PR DESCRIPTION
### Description

It's a *simple*, at least for now, until it works. If it stops working, we can extend it.
Algorithm:
1. When the pipeline starts, schedule a Windowed PoSt for each deadline (send a message to the queue).
2. When the message is polled, it get the **next not elapsed deadline info for an index** from the chain.
3. Waits till a PoSt can be sutmittted for the deadline.
4. When the proof has been submitted, schedule another PoSt message to the pipeline. Start from 2. all over again.

`just testnet && examples/rpc_publish.sh examples/test-data-big.txt`

It keeps submitting a proof and works.

Closes #621. 

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
- [X] Did you document new (or modified) APIs?
- Follow-ups:
    - #625 
