### PR TITLE
fix: use live sectors for proving partitions

### DIFF
--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -1156,7 +1156,7 @@ pub mod pallet {
                     .try_insert(
                         *partition_number,
                         primitives::pallets::PartitionState {
-                            sectors: partition.sectors.clone(),
+                            sectors: partition.active_sectors(),
                         },
                     )
                     .ok()?;

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -1156,7 +1156,7 @@ pub mod pallet {
                     .try_insert(
                         *partition_number,
                         primitives::pallets::PartitionState {
-                            sectors: partition.active_sectors(),
+                            sectors: partition.live_sectors(),
                         },
                     )
                     .ok()?;

--- a/pallets/storage-provider/src/partition.rs
+++ b/pallets/storage-provider/src/partition.rs
@@ -88,6 +88,21 @@ where
             .expect("Sectors is bounded to MAX_SECTORS so the length can never exceed MAX_SECTORS")
     }
 
+    /// Active sectors are those that are neither terminated nor faulty nor unproven.
+    /// Those are the sectors that need to be proven in a given deadline challenge window.
+    pub fn active_sectors(&self) -> BoundedBTreeSet<SectorNumber, ConstU32<MAX_SECTORS>> {
+        let without_faults = self.live_sectors()
+            .difference(&self.faults)
+            .copied()
+            .collect::<BTreeSet<_>>();
+
+        without_faults.difference(&self.unproven)
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .try_into()
+            .expect("Sectors is bounded to MAX_SECTORS so the length can never exceed MAX_SECTORS")
+    }
+
     /// Adds sectors to this partition.
     /// The sectors are "live", neither faulty, recovering, nor terminated.
     ///

--- a/pallets/storage-provider/src/partition.rs
+++ b/pallets/storage-provider/src/partition.rs
@@ -88,23 +88,6 @@ where
             .expect("Sectors is bounded to MAX_SECTORS so the length can never exceed MAX_SECTORS")
     }
 
-    /// Active sectors are those that are neither terminated nor faulty nor unproven.
-    /// Those are the sectors that need to be proven in a given deadline challenge window.
-    pub fn active_sectors(&self) -> BoundedBTreeSet<SectorNumber, ConstU32<MAX_SECTORS>> {
-        let without_faults = self
-            .live_sectors()
-            .difference(&self.faults)
-            .copied()
-            .collect::<BTreeSet<_>>();
-
-        without_faults
-            .difference(&self.unproven)
-            .copied()
-            .collect::<BTreeSet<_>>()
-            .try_into()
-            .expect("Sectors is bounded to MAX_SECTORS so the length can never exceed MAX_SECTORS")
-    }
-
     /// Adds sectors to this partition.
     /// The sectors are "live", neither faulty, recovering, nor terminated.
     ///

--- a/pallets/storage-provider/src/partition.rs
+++ b/pallets/storage-provider/src/partition.rs
@@ -91,12 +91,14 @@ where
     /// Active sectors are those that are neither terminated nor faulty nor unproven.
     /// Those are the sectors that need to be proven in a given deadline challenge window.
     pub fn active_sectors(&self) -> BoundedBTreeSet<SectorNumber, ConstU32<MAX_SECTORS>> {
-        let without_faults = self.live_sectors()
+        let without_faults = self
+            .live_sectors()
             .difference(&self.faults)
             .copied()
             .collect::<BTreeSet<_>>();
 
-        without_faults.difference(&self.unproven)
+        without_faults
+            .difference(&self.unproven)
             .copied()
             .collect::<BTreeSet<_>>()
             .try_into()

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -590,7 +590,7 @@ async fn submit_windowed_post(
         .xt_client
         .wait_for_height(deadline.start, true)
         .await?;
-    tracing::info!("Waiting finished, let's go");
+    tracing::info!("Waiting finished (block: {}), let's go", deadline.start);
 
     let Some(digest) = state
         .xt_client

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -260,7 +260,7 @@ async fn find_sector_for_piece(
 /// This function is *cancellation safe* as if future is dropped,
 /// it can be dropped only when waiting for `spawn_blocking`.
 /// When dropped when waiting, the sector state won't be preserved and adding piece can be retried.
-#[tracing::instrument(skip_all, fields(piece_cid, deal_id))]
+#[tracing::instrument(skip(state, deal, commitment))]
 async fn add_piece(
     state: Arc<PipelineState>,
     piece_path: PathBuf,
@@ -311,7 +311,7 @@ async fn add_piece(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, fields(sector_number))]
+#[tracing::instrument(skip(state))]
 /// Creates a replica and calls pre-commit on-chain.
 ///
 /// This method is *NOT CANCELLATION SAFE*.
@@ -446,7 +446,7 @@ async fn precommit(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, fields(sector_number))]
+#[tracing::instrument(skip(state))]
 async fn prove_commit(
     state: Arc<PipelineState>,
     sector_number: SectorNumber,
@@ -565,7 +565,7 @@ async fn prove_commit(
     Ok(())
 }
 
-#[tracing::instrument(skip(state), fields(deadline_index))]
+#[tracing::instrument(skip(state))]
 async fn submit_windowed_post(
     state: Arc<PipelineState>,
     deadline_index: u64,
@@ -729,7 +729,7 @@ async fn schedule_posts(state: Arc<PipelineState>) -> Result<(), PipelineError> 
     Ok(())
 }
 
-#[tracing::instrument(skip_all, fields(deadline_index))]
+#[tracing::instrument(skip(state))]
 fn schedule_post(state: Arc<PipelineState>, deadline_index: u64) -> Result<(), PipelineError> {
     state
         .pipeline_sender

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -565,7 +565,7 @@ async fn prove_commit(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, fields(deadline_index))]
+#[tracing::instrument(skip(state), fields(deadline_index))]
 async fn submit_windowed_post(
     state: Arc<PipelineState>,
     deadline_index: u64,


### PR DESCRIPTION
### Description

In the first iteration of the pipeline we were using always all of the sectors for proving. Now we're just using live sectors, so basically `all of the sectors - terminated ones`. Termination logic works, I tested it.
After sector expires, it's terminated and then PoSt no longer generated for it.
Faults are not yet here.

Closes #625.


### Checklist

- [X] Are there important points that reviewers should know?
  - [X] If yes, which ones?
- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
