### PR TITLE
fix(storage-provider): multiple sectors, multiple cache dirs

### DIFF
--- a/lib/polka-storage-proofs/src/post/mod.rs
+++ b/lib/polka-storage-proofs/src/post/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    path::PathBuf,
-};
+use std::{collections::BTreeMap, path::PathBuf};
 
 use bellperson::groth16;
 use blstrs::Bls12;

--- a/lib/polka-storage-proofs/src/post/mod.rs
+++ b/lib/polka-storage-proofs/src/post/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use bellperson::groth16;
@@ -54,6 +54,7 @@ pub struct ReplicaInfo {
     pub sector_id: SectorNumber,
     pub comm_r: Commitment,
     pub replica_path: PathBuf,
+    pub cache_path: PathBuf,
 }
 
 /// Generates Windowed PoSt for a replica.
@@ -61,13 +62,12 @@ pub struct ReplicaInfo {
 ///
 /// References:
 /// * <https://github.com/filecoin-project/rust-fil-proofs/blob/5a0523ae1ddb73b415ce2fa819367c7989aaf73f/filecoin-proofs/src/api/window_post.rs#L100>
-pub fn generate_window_post<CacheDirectory: AsRef<Path>>(
+pub fn generate_window_post(
     proof_type: RegisteredPoStProof,
     groth_params: &groth16::MappedParameters<Bls12>,
     randomness: Ticket,
     prover_id: ProverId,
     partition_replicas: Vec<ReplicaInfo>,
-    cache_dir: CacheDirectory,
 ) -> Result<Vec<groth16::Proof<Bls12>>, PoStError> {
     type Tree = SectorShapeBase;
 
@@ -79,7 +79,7 @@ pub fn generate_window_post<CacheDirectory: AsRef<Path>>(
             PrivateReplicaInfo::<Tree>::new(
                 replica.replica_path,
                 replica.comm_r,
-                cache_dir.as_ref().to_path_buf(),
+                replica.cache_path,
             )?,
         );
     }

--- a/storage-provider/client/src/commands/proofs.rs
+++ b/storage-provider/client/src/commands/proofs.rs
@@ -452,6 +452,7 @@ impl ProofsCommand {
                         .try_into()
                         .map_err(|_| UtilsCommandError::CommRError)?,
                     replica_path,
+                    cache_path: cache_directory,
                 }];
 
                 println!("Loading parameters...");
@@ -465,7 +466,6 @@ impl ProofsCommand {
                     randomness,
                     prover_id,
                     replicas,
-                    cache_directory,
                 )
                 .map_err(|e| UtilsCommandError::GeneratePoStError(e))?;
 

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -763,7 +763,7 @@ async fn submit_windowed_post(
 
 #[tracing::instrument(skip_all)]
 async fn schedule_posts(state: Arc<PipelineState>) -> Result<(), PipelineError> {
-    let proving_period = state.xt_client.proving_period_info().await?;
+    let proving_period = state.xt_client.proving_period_info()?;
 
     for deadline_index in 0..proving_period.deadlines {
         schedule_post(state.clone(), deadline_index)?;

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -710,13 +710,7 @@ async fn submit_windowed_post(
         let post_proof = state.server_info.post_proof;
 
         tokio::task::spawn_blocking(move || {
-            post::generate_window_post(
-                post_proof,
-                &post_params,
-                randomness,
-                prover_id,
-                replicas,
-            )
+            post::generate_window_post(post_proof, &post_params, randomness, prover_id, replicas)
         })
     };
     let proofs = handle.await??;

--- a/storage-provider/server/src/pipeline/types.rs
+++ b/storage-provider/server/src/pipeline/types.rs
@@ -99,6 +99,10 @@ pub struct PreCommittedSector {
     /// Tracks all of the deals that have been added to the sector.
     pub deals: Vec<(DealId, DealProposal)>,
 
+    /// Cache directory of the sector.
+    /// Each sector needs to have it's cache directory in a different place, because `p_aux` and `t_aux` are stored there.
+    pub cache_path: std::path::PathBuf,
+
     /// Path of an existing file where the sealed sector data is stored.
     ///
     /// File at this path is initially created by [`Sector::create`], however it's empty.
@@ -154,6 +158,7 @@ impl PreCommittedSector {
     /// Should only be called after sealing and pre-commit process has ended.
     pub async fn create(
         unsealed: UnsealedSector,
+        cache_path: std::path::PathBuf,
         sealed_path: std::path::PathBuf,
         comm_r: Commitment<CommR>,
         comm_d: Commitment<CommD>,
@@ -166,6 +171,7 @@ impl PreCommittedSector {
             sector_number: unsealed.sector_number,
             piece_infos: unsealed.piece_infos,
             deals: unsealed.deals,
+            cache_path,
             sealed_path,
             comm_r,
             comm_d,
@@ -190,6 +196,10 @@ pub struct ProvenSector {
     /// Tracks all of the deals that have been added to the sector.
     pub deals: Vec<(DealId, DealProposal)>,
 
+    /// Cache directory of the sector.
+    /// Each sector needs to have it's cache directory in a different place, because `p_aux` and `t_aux` are stored there.
+    pub cache_path: std::path::PathBuf,
+
     /// Path of an existing file where the sealed sector data is stored.
     pub sealed_path: std::path::PathBuf,
 
@@ -207,6 +217,7 @@ impl ProvenSector {
             sector_number: sector.sector_number,
             piece_infos: sector.piece_infos,
             deals: sector.deals,
+            cache_path: sector.cache_path,
             sealed_path: sector.sealed_path,
             comm_r: sector.comm_r,
             comm_d: sector.comm_d,


### PR DESCRIPTION
### Description

When I did some patch-working to make publish multiple deals and turn on the pipeline, prove commit started to fail.
Turns out we need a cache dir per sector.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Did you document new (or modified) APIs?
