### PR TITLE
fix(storagext): losing transactions on reorg

### DIFF
--- a/storagext/lib/src/runtime/client.rs
+++ b/storagext/lib/src/runtime/client.rs
@@ -217,7 +217,7 @@ impl Client {
             .nonce(current_nonce)
             .build();
 
-        let ext: SubmittableExtrinsic<PolkaStorageConfig, OnlineClient<PolkaStorageConfig>> = self
+        let ext = self
             .client
             .tx()
             .create_signed_offline(call, account_keypair, ext_params)?;

--- a/storagext/lib/src/runtime/client.rs
+++ b/storagext/lib/src/runtime/client.rs
@@ -198,17 +198,26 @@ impl Client {
         Call: subxt::tx::Payload,
         Keypair: subxt::tx::Signer<PolkaStorageConfig>,
     {
+        let finalized_block_hash = self.legacy_rpc.chain_get_finalized_head().await?;
+        let finalized_block = self
+            .legacy_rpc
+            .chain_get_block(Some(finalized_block_hash))
+            .await?
+            .expect("chain to have info about the finalized head");
+
         let current_nonce = self
             .legacy_rpc
             .system_account_next_index(&account_keypair.account_id())
             .await?;
-        let current_header = self.legacy_rpc.chain_get_header(None).await?.unwrap();
+        // Default used by subxt
+        // https://github.com/paritytech/subxt/blob/f363f77a60271b840e8dfb4f6e2f0f728f5ced06/core/src/config/signed_extensions.rs#L231
+        const TX_VALID_FOR: u64 = 32;
         let ext_params = DefaultExtrinsicParamsBuilder::new()
-            .mortal(&current_header, 8)
+            .mortal(&finalized_block.block.header, TX_VALID_FOR)
             .nonce(current_nonce)
             .build();
 
-        let ext = self
+        let ext: SubmittableExtrinsic<PolkaStorageConfig, OnlineClient<PolkaStorageConfig>> = self
             .client
             .tx()
             .create_signed_offline(call, account_keypair, ext_params)?;


### PR DESCRIPTION
### Description

There was still a time when a transaction was discarded during a Reorg.
This was because Mortality was set based on the Best block. 
Best block was lost and transaction became invalid.

Fixes #647.


### Checklist

- [X] Are there important points that reviewers should know?
  - [X] If yes, which ones?
- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
