### PR TITLE
revert(09e27f6): change nix source & bump polkadot to 2412 and sub…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735617354,
-        "narHash": "sha256-5zJyv66q68QZJZsXtmjDBazGnF0id593VSy+8eSckoo=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "69b9a8c860bdbb977adfa9c5e817ccb717884182",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735784864,
-        "narHash": "sha256-tIl5p3ueaPw7T5T1UXkLc8ISMk6Y8CI/D/rd0msf73I=",
+        "lastModified": 1732069891,
+        "narHash": "sha256-moKx8AVJrViCSdA0e0nSsG8b1dAsObI4sRAtbqbvBY8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "04d5f1836721461b256ec452883362c5edc5288e",
+        "rev": "8509a51241c407d583b1963d5079585a992506e8",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "process-compose": "process-compose"
       },
       "locked": {
-        "lastModified": 1733999816,
-        "narHash": "sha256-T4jFoTeM/otm4UAF4KI1/iu7Uyr7D4S8JlAWGynrGlc=",
+        "lastModified": 1730354470,
+        "narHash": "sha256-LfFP7LgcvVwsxUGUQmMVfZkxiw1GeEac0oo/Quxc0zA=",
         "owner": "paritytech",
         "repo": "zombienet",
-        "rev": "ae6f7414bf4c9f4d2dd40b0a30938259233b0985",
+        "rev": "64f303d99865f3e813390e769385a0e9e03dd3dc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs = {


### PR DESCRIPTION
This reverts commit 09e27f64b9709b21e766d780eaaccf0625793067.

Reopens #650 , build is broken because: https://github.com/NixOS/nixpkgs/issues/370494.

