### PR TITLE
fix: Add u64::MAX TTL to p2p registration

### DIFF
--- a/storage-provider/server/src/p2p/bootstrap.rs
+++ b/storage-provider/server/src/p2p/bootstrap.rs
@@ -39,7 +39,9 @@ impl BootstrapConfig {
             .with_behaviour(|key| BootstrapBehaviour {
                 // Rendezvous server behaviour for serving new peers to connecting nodes.
                 rendezvous: rendezvous::server::Behaviour::new(
-                    rendezvous::server::Config::default(),
+                    // TTL of 584_542_100_000 years.
+                    // If the client changes their multiaddress the old multiaddr gets overwritten, not appended.
+                    rendezvous::server::Config::default().with_max_ttl(u64::MAX),
                 ),
                 // The identify behaviour is used to share the external address and the public key with connecting clients.
                 identify: identify::Behaviour::new(identify::Config::new(

--- a/storage-provider/server/src/p2p/mod.rs
+++ b/storage-provider/server/src/p2p/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use register::RegisterConfig;
 const P2P_NAMESPACE: &str = "polka-storage";
 
 #[derive(Default, Debug, Clone, Copy, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum NodeType {
     #[default]
     Bootstrap,
@@ -148,7 +149,6 @@ pub async fn run_register_node(
             swarm,
             rendezvous_point,
             rendezvous_point_address,
-            None,
             Namespace::from_static(P2P_NAMESPACE),
         ) => {
             if let Err(e) = res {

--- a/storage-provider/server/src/p2p/register.rs
+++ b/storage-provider/server/src/p2p/register.rs
@@ -69,7 +69,6 @@ pub(crate) async fn register(
     mut swarm: Swarm<RegisterBehaviour>,
     rendezvous_point: PeerId,
     rendezvous_point_address: Multiaddr,
-    ttl: Option<u64>,
     namespace: Namespace,
 ) -> Result<(), P2PError> {
     tracing::info!("Attempting to register with rendezvous point {rendezvous_point} at {rendezvous_point_address}");
@@ -97,7 +96,9 @@ pub(crate) async fn register(
                 if let Err(error) = swarm.behaviour_mut().rendezvous.register(
                     namespace.clone(),
                     rendezvous_point,
-                    ttl,
+                    // TTL of 584_542_100_000 years
+                    // If re-registered with a new multiaddr the old value gets overwritten
+                    Some(u64::MAX),
                 ) {
                     tracing::error!("Failed to register: {error}");
                     return Err(P2PError::RegistrationFailed(rendezvous_point));


### PR DESCRIPTION
### Description

Add a TTL to the registration of `u64::MAX`. This requires setting the max TTL to the same in the bootstrap node. If a storage provide has to re-register (due to changed multiaddr for example) the old multiaddr gets overwritten.