### PR TITLE
docs: Update docs to include p2p Peer ID and keys

### DIFF
--- a/docs/src/storage-provider-cli/client/index.md
+++ b/docs/src/storage-provider-cli/client/index.md
@@ -114,3 +114,14 @@ $ SIGNED_DEAL='{
 $ polka-storage-provider-client publish-deal "$SIGNED_DEAL"
 0
 ```
+
+## `generate-peer-id`
+
+The `generate-peer-id` command generates a Peer ID from an ed25519 public key in PEM file format.
+
+To generate an ed25519 keypair check the [Polka Storage Provider server documentation](../server.md#p2p-key-generation).
+
+```bash
+$ polka-storage-provider-client generate-peer-id --pubkey <PUBLIC_KEY_PATH>
+12D3KooWCYTvmMFvMgo4CKNMaCTJQhUv7BN1TB3xrSPZJ6FVErmH
+```

--- a/docs/src/storage-provider-cli/server.md
+++ b/docs/src/storage-provider-cli/server.md
@@ -1,7 +1,23 @@
 # Polka Storage Provider — Server
 
-This chapter covers the available CLI options for the Polka Storage Provider server.
+This chapter covers the Polka Storage Provider server.
 
+## P2P Key generation
+
+The Polka Storage Provider server runs a p2p node that is used to map Peer ID's to Multi-addresses.
+The server can run either a bootstrap node, used to aid in discovery,
+or a registration node, which registers to a bootstrap node with their Peer ID to Multi-address mapping.
+For both of these node types, the server needs an ed25519 private key.
+The ed25519 public key is used to create a Peer ID using the [Polka Storage Provider client](./client/index.md#generate-peer-id).
+
+To generate the ed25519 keypair use the following command:
+
+```bash
+openssl genpkey -algorithm ED25519 -out <PRIVATE_KEY_PATH> -outpubkey <PUBLIC_KEY_PATH>
+```
+
+
+## CLI Options
 <!-- Sadly, tables will not cut it here, since the text is just too big for the table. -->
 
 ### `--sr25519-key`


### PR DESCRIPTION
### Description

Add docs to Polka Storage Provider server on how to generate an ed25519 keypair.
Add docs to Polka Storage Provider client on how to convert an ed25519 public key to Peer ID.
