### PR TITLE
feat: replace Currency logic with Market in the SP pallet

### DIFF
--- a/pallets/market/src/lib.rs
+++ b/pallets/market/src/lib.rs
@@ -23,7 +23,7 @@ pub mod pallet {
     use cid::Cid;
     use codec::{Decode, Encode};
     use frame_support::{
-        dispatch::{DispatchClass, DispatchResult},
+        dispatch::DispatchResult,
         ensure,
         pallet_prelude::*,
         sp_runtime::{

--- a/pallets/market/src/lib.rs
+++ b/pallets/market/src/lib.rs
@@ -305,7 +305,6 @@ pub mod pallet {
     /// Invariant must be held at all times:
     /// `account(MarketPallet).balance == all_accounts.map(|balance| balance[account]].locked + balance[account].free).sum()`
     #[pallet::storage]
-    #[pallet::getter(fn balance_table)] // NOTE(@jmg-duarte,21/1/25): maybe this could be gated?
     pub type BalanceTable<T: Config> =
         StorageMap<_, _, T::AccountId, BalanceEntry<BalanceOf<T>>, ValueQuery>;
 

--- a/pallets/market/src/lib.rs
+++ b/pallets/market/src/lib.rs
@@ -789,6 +789,24 @@ pub mod pallet {
 
     /// Functions exposed by the pallet
     impl<T: Config> Pallet<T> {
+        /// Retrieve the locked balance for the given account.
+        pub fn locked(who: &T::AccountId) -> Option<BalanceOf<T>> {
+            // try_get is required because the StorageMap has ValueQuery instead of OptionQuery
+            match BalanceTable::<T>::try_get(who) {
+                Ok(entry) => Some(entry.locked),
+                Err(_) => None,
+            }
+        }
+
+        /// Retrieve the locked balance for the given account.
+        pub fn free(who: &T::AccountId) -> Option<BalanceOf<T>> {
+            // try_get is required because the StorageMap has ValueQuery instead of OptionQuery
+            match BalanceTable::<T>::try_get(who) {
+                Ok(entry) => Some(entry.free),
+                Err(_) => None,
+            }
+        }
+
         /// Account Id of the Market
         ///
         /// This actually does computation.
@@ -1159,15 +1177,13 @@ pub mod pallet {
 
     impl<T: Config> Market<T::AccountId, BlockNumberFor<T>, BalanceOf<T>> for Pallet<T> {
         fn lock_pre_commit_funds(who: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
-            lock_funds::<T>(who, amount)?;
             // NOTE(@jmg-duarte,21/1/25): unsure if this should emit an event
-            Ok(())
+            lock_funds::<T>(who, amount)
         }
 
         fn slash_pre_commit_funds(who: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
-            slash_and_burn::<T>(who, amount)?;
             // NOTE(@jmg-duarte,21/1/25): unsure if this should emit an event
-            Ok(())
+            slash_and_burn::<T>(who, amount)
         }
 
         /// Verifies a given set of storage deals is valid for sectors being PreCommitted.

--- a/pallets/market/src/lib.rs
+++ b/pallets/market/src/lib.rs
@@ -23,7 +23,7 @@ pub mod pallet {
     use cid::Cid;
     use codec::{Decode, Encode};
     use frame_support::{
-        dispatch::DispatchResult,
+        dispatch::{DispatchClass, DispatchResult},
         ensure,
         pallet_prelude::*,
         sp_runtime::{
@@ -121,10 +121,10 @@ pub mod pallet {
     pub struct BalanceEntry<Balance> {
         /// Amount of Balance that has been deposited for future deals/earned from deals.
         /// It can be withdrawn at any time.
-        pub(crate) free: Balance,
+        pub free: Balance,
         /// Amount of Balance that has been staked as Deal Collateral
         /// It's locked to a deal and cannot be withdrawn until the deal ends.
-        pub(crate) locked: Balance,
+        pub locked: Balance,
     }
 
     #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -305,6 +305,7 @@ pub mod pallet {
     /// Invariant must be held at all times:
     /// `account(MarketPallet).balance == all_accounts.map(|balance| balance[account]].locked + balance[account].free).sum()`
     #[pallet::storage]
+    #[pallet::getter(fn balance_table)] // NOTE(@jmg-duarte,21/1/25): maybe this could be gated?
     pub type BalanceTable<T: Config> =
         StorageMap<_, _, T::AccountId, BalanceEntry<BalanceOf<T>>, ValueQuery>;
 
@@ -1156,7 +1157,19 @@ pub mod pallet {
         }
     }
 
-    impl<T: Config> Market<T::AccountId, BlockNumberFor<T>> for Pallet<T> {
+    impl<T: Config> Market<T::AccountId, BlockNumberFor<T>, BalanceOf<T>> for Pallet<T> {
+        fn lock_pre_commit_funds(who: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
+            lock_funds::<T>(who, amount)?;
+            // NOTE(@jmg-duarte,21/1/25): unsure if this should emit an event
+            Ok(())
+        }
+
+        fn slash_pre_commit_funds(who: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
+            slash_and_burn::<T>(who, amount)?;
+            // NOTE(@jmg-duarte,21/1/25): unsure if this should emit an event
+            Ok(())
+        }
+
         /// Verifies a given set of storage deals is valid for sectors being PreCommitted.
         /// Computes UnsealedCID (CommD) for each sector or None for Committed Capacity sectors.
         /// Currently UnsealedCID is hardcoded as we `compute_commd` remains unimplemented because of #92.

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -110,13 +110,13 @@ pub mod pallet {
         /// More information about libp2p peer ids: https://docs.libp2p.io/concepts/fundamentals/peers/
         type PeerId: Clone + Debug + Decode + Encode + Eq + TypeInfo;
 
-        /// Currency mechanism, used for collateral
+        /// Currency mechanism, used for the Market balances.
         type Currency: ReservableCurrency<Self::AccountId>;
 
-        /// Market trait implementation for activating deals
-        type Market: Market<Self::AccountId, BlockNumberFor<Self>>;
+        /// Market trait implementation for activating deals.
+        type Market: Market<Self::AccountId, BlockNumberFor<Self>, BalanceOf<Self>>;
 
-        /// Proof verification trait implementation for verifying proofs
+        /// Proof verification trait implementation for verifying proofs.
         type ProofVerification: ProofVerification;
 
         /// Trait for AuthorVRF querying.
@@ -533,15 +533,17 @@ pub mod pallet {
                 deal_amounts,
             )?;
 
-            // Check balance for deposit
-            let balance = T::Currency::total_balance(&owner);
-            ensure!(balance >= total_deposit, Error::<T>::NotEnoughFunds);
-            T::Currency::reserve(&owner, total_deposit)?;
+            // Lock the pre-commit funds in the market account
+            T::Market::lock_pre_commit_funds(&owner, total_deposit)?;
+
             StorageProviders::<T>::try_mutate(&owner, |maybe_sp| -> DispatchResult {
                 let sp = maybe_sp
                     .as_mut()
                     .ok_or(Error::<T>::StorageProviderNotFound)?;
+
+                // NOTE(@jmg-duarte,21/1/25): Not sure if this is still needed
                 sp.add_pre_commit_deposit(total_deposit)?;
+
                 for sector_on_chain in on_chain_sectors {
                     sp.put_pre_committed_sector(sector_on_chain)
                         .map_err(|e| Error::<T>::GeneralPalletError(e))?;
@@ -1285,7 +1287,8 @@ pub mod pallet {
                 state.pre_commit_deposits = slashed_deposits;
 
                 // PRE-COND: currency was previously reserved in pre_commit
-                let Ok(()) = slash_and_burn::<T>(&storage_provider, slash_amount) else {
+                let Ok(()) = T::Market::slash_pre_commit_funds(&storage_provider, slash_amount)
+                else {
                     log::error!(target: LOG_TARGET, "failed to slash.. amount: {:?}, storage_provider: {:?}", slash_amount, storage_provider);
                     continue;
                 };
@@ -1598,35 +1601,6 @@ pub mod pallet {
     /// Calculate the required pre commit deposit amount
     fn calculate_pre_commit_deposit<T: Config>() -> BalanceOf<T> {
         BalanceOf::<T>::one() // TODO(@aidan46, #106, 2024-06-24): Set a logical value or calculation
-    }
-
-    /// Slashes **reserved* currency, burns it completely and settles the token amount in the chain.
-    ///
-    /// Preconditions:
-    /// - `slash_amount` needs to be previously reserved via `T::Currency::reserve()` on `account`,
-    fn slash_and_burn<T: Config>(
-        account: &T::AccountId,
-        slash_amount: BalanceOf<T>,
-    ) -> Result<(), DispatchError> {
-        let (imbalance, balance) = T::Currency::slash_reserved(account, slash_amount);
-
-        log::debug!(target: LOG_TARGET, "imbalance: {:?}, balance: {:?}", imbalance.peek(), balance);
-        ensure!(balance == BalanceOf::<T>::zero(), {
-            log::error!(target: LOG_TARGET, "could not slash_reserved entirely, precondition violated");
-            Error::<T>::SlashingFailed
-        });
-
-        // slash_reserved returns NegativeImbalance, we need to get a concrete value and burn it to level out the circulating currency
-        let imbalance = T::Currency::burn(imbalance.peek());
-
-        // TODO(@jmg-duarte,20/11/2024): we'll probably need to review this,
-        // we're slashing an account (makes sense)
-        // burning the imbalance (maybe we could stash it in an account for rewards)
-        // and settling it??? — this part makes less sense since it's similar to a withdraw
-        T::Currency::settle(account, imbalance, WithdrawReasons::RESERVE, KeepAlive)
-            .map_err(|_| Error::<T>::SlashingFailed)?;
-
-        Ok(())
     }
 
     fn validate_seal_proof<T: Config>(

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -45,10 +45,7 @@ pub mod pallet {
         ensure, fail,
         pallet_prelude::*,
         sp_runtime::traits::{CheckedAdd, CheckedSub, One},
-        traits::{
-            Currency, ExistenceRequirement::KeepAlive, Imbalance, Randomness, ReservableCurrency,
-            WithdrawReasons,
-        },
+        traits::{Currency, Randomness, ReservableCurrency},
     };
     use frame_system::{
         ensure_signed,

--- a/pallets/storage-provider/src/tests/pre_commit_sector_hook.rs
+++ b/pallets/storage-provider/src/tests/pre_commit_sector_hook.rs
@@ -7,7 +7,7 @@ use crate::{
     pallet::{Event, StorageProviders},
     sector::ProveCommitSector,
     tests::{
-        account, events, publish_deals, register_storage_provider, run_to_block, Balances, Market,
+        account, events, publish_deals, register_storage_provider, run_to_block, Market,
         RuntimeEvent, RuntimeOrigin, SectorPreCommitInfoBuilder, StorageProvider, System, Test,
         CHARLIE,
     },

--- a/pallets/storage-provider/src/tests/pre_commit_sector_hook.rs
+++ b/pallets/storage-provider/src/tests/pre_commit_sector_hook.rs
@@ -7,7 +7,7 @@ use crate::{
     pallet::{Event, StorageProviders},
     sector::ProveCommitSector,
     tests::{
-        account, events, publish_deals, register_storage_provider, run_to_block, Balances,
+        account, events, publish_deals, register_storage_provider, run_to_block, Balances, Market,
         RuntimeEvent, RuntimeOrigin, SectorPreCommitInfoBuilder, StorageProvider, System, Test,
         CHARLIE,
     },
@@ -21,13 +21,15 @@ use crate::{
 #[test]
 fn pre_commit_hook_slashed_deal() {
     new_test_ext().execute_with(|| {
+        // TODO(@aidan46, #106, 2024-06-24): Set a logical value or calculation
+        const DEAL_PRECOMMIT_DEPOSIT: u64 = 1;
+        const DEAL_COLLATERAL: u64 = 25;
+
         let storage_provider = CHARLIE;
         register_storage_provider(account(storage_provider));
         publish_deals(storage_provider);
         let first_deal = 0;
         let second_deal = 1;
-        // TODO(@aidan46, #106, 2024-06-24): Set a logical value or calculation
-        let deal_precommit_deposit = 1;
 
         let first_sector = SectorPreCommitInfoBuilder::default()
             .sector_number(1.into())
@@ -49,6 +51,12 @@ fn pre_commit_hook_slashed_deal() {
             bounded_vec![second_sector.clone()],
         )
         .unwrap();
+        // 2 deals = (collateral + precommit) * 2
+        assert_eq!(
+            Market::locked(&account(storage_provider)),
+            // The cast is kind of an hack but we know it is safe
+            Some((2 * (DEAL_COLLATERAL + DEAL_PRECOMMIT_DEPOSIT) as u32).into())
+        );
 
         StorageProvider::prove_commit_sectors(
             RuntimeOrigin::signed(account(storage_provider)),
@@ -71,10 +79,12 @@ fn pre_commit_hook_slashed_deal() {
         // First sector removed from here because it was slashed, second one because it was proven.
         assert!(sp.pre_committed_sectors.is_empty());
         // Pre-commit from the second deal is still there, as pre-commit deposits are until sector expired.
-        assert_eq!(sp.pre_commit_deposits, deal_precommit_deposit);
+        assert_eq!(sp.pre_commit_deposits, DEAL_PRECOMMIT_DEPOSIT);
+        // 1 deal got slashed so the respective locked funds *vanished*
         assert_eq!(
-            Balances::reserved_balance(account(storage_provider)),
-            deal_precommit_deposit
+            Market::locked(&account(storage_provider)),
+            // The cast is kind of an hack but we know it is safe
+            Some(((2 * DEAL_COLLATERAL + DEAL_PRECOMMIT_DEPOSIT) as u32).into())
         );
         let mut expected_faulty_sectors = BoundedBTreeSet::new();
         expected_faulty_sectors
@@ -91,22 +101,14 @@ fn pre_commit_hook_slashed_deal() {
                     owner: account(storage_provider),
                     faulty_partitions: expected_faulty_partitions,
                 }),
-                // the slash -> withdraw is related to the usage of slash_and_burn
-                // when slashing the SP for a failed pre_commit
-                // this usage may need review for a proper economic balance
-                RuntimeEvent::Balances(pallet_balances::Event::<Test>::Slashed {
-                    who: account(storage_provider),
-                    amount: deal_precommit_deposit,
-                }),
                 RuntimeEvent::Balances(pallet_balances::Event::<Test>::Rescinded {
-                    amount: deal_precommit_deposit
+                    amount: DEAL_PRECOMMIT_DEPOSIT
                 }),
                 RuntimeEvent::Balances(pallet_balances::Event::<Test>::Withdraw {
-                    who: account(storage_provider),
-                    amount: deal_precommit_deposit,
-                }),
-                RuntimeEvent::Balances(pallet_balances::Event::<Test>::Rescinded {
-                    amount: deal_precommit_deposit
+                    // The money was removed from the balance table, as such,
+                    // the money is actually removed from the "pallet account"
+                    who: Market::account_id(),
+                    amount: DEAL_PRECOMMIT_DEPOSIT,
                 }),
                 RuntimeEvent::StorageProvider(Event::<Test>::SectorsSlashed {
                     owner: account(storage_provider),

--- a/pallets/storage-provider/src/tests/pre_commit_sectors.rs
+++ b/pallets/storage-provider/src/tests/pre_commit_sectors.rs
@@ -72,9 +72,20 @@ fn successfully_precommited() {
 #[test]
 fn successfully_precommited_no_deals() {
     new_test_ext().execute_with(|| {
+        const MARKET_BALANCE: u32 = 1000;
+
         // Register CHARLIE as a storage provider.
         let storage_provider = CHARLIE;
         register_storage_provider(account(storage_provider));
+
+        use crate::tests::{Market, System};
+        Market::add_balance(
+            RuntimeOrigin::signed(account(storage_provider)),
+            MARKET_BALANCE.into(),
+        )
+        .unwrap();
+
+        System::reset_events();
 
         // Sector to be pre-committed.
         let sector = SectorPreCommitInfoBuilder::default()
@@ -91,17 +102,13 @@ fn successfully_precommited_no_deals() {
         // Check that the events were triggered
         assert_eq!(
             events(),
-            [
-                RuntimeEvent::Balances(pallet_balances::Event::<Test>::Reserved {
-                    who: account(storage_provider),
-                    amount: 1
-                },),
-                RuntimeEvent::StorageProvider(Event::<Test>::SectorsPreCommitted {
+            [RuntimeEvent::StorageProvider(
+                Event::<Test>::SectorsPreCommitted {
                     block: 1,
                     owner: account(storage_provider),
                     sectors: bounded_vec![sector],
-                })
-            ]
+                }
+            )]
         );
 
         let sp = StorageProviders::<Test>::get(account(storage_provider))
@@ -113,8 +120,12 @@ fn successfully_precommited_no_deals() {
 
         assert_eq!(
             Balances::free_balance(account(storage_provider)),
-            INITIAL_FUNDS - 1
+            INITIAL_FUNDS - (MARKET_BALANCE as u64)
         );
+
+        let balance_entry = Market::balance_table(account(storage_provider));
+        assert_eq!(balance_entry.locked, 1); // Single pre-commit = price is 1
+        assert_eq!(balance_entry.free, 999);
     });
 }
 

--- a/pallets/storage-provider/src/tests/pre_commit_sectors.rs
+++ b/pallets/storage-provider/src/tests/pre_commit_sectors.rs
@@ -8,9 +8,9 @@ use super::new_test_ext;
 use crate::{
     pallet::{Error, Event, StorageProviders},
     tests::{
-        account, events, publish_deals, register_storage_provider, run_to_block, Balances,
+        account, events, publish_deals, register_storage_provider, run_to_block, Market,
         MaxProveCommitDuration, MaxSectorExpiration, RuntimeEvent, RuntimeOrigin,
-        SectorPreCommitInfoBuilder, StorageProvider, Test, ALICE, CHARLIE, INITIAL_FUNDS,
+        SectorPreCommitInfoBuilder, StorageProvider, System, Test, ALICE, CHARLIE,
     },
 };
 
@@ -29,10 +29,8 @@ fn successfully_precommited() {
             .build();
 
         // Check starting balance
-        assert_eq!(
-            Balances::free_balance(account(storage_provider)),
-            INITIAL_FUNDS - 70
-        );
+        // 70 (initial SP funds) - 25 * 2 (deals) = 20
+        assert_eq!(Market::free(&account(storage_provider)), Some(20));
 
         // Run pre commit extrinsic
         assert_ok!(StorageProvider::pre_commit_sectors(
@@ -43,17 +41,13 @@ fn successfully_precommited() {
         // Check that the events were triggered
         assert_eq!(
             events(),
-            [
-                RuntimeEvent::Balances(pallet_balances::Event::<Test>::Reserved {
-                    who: account(storage_provider),
-                    amount: 1
-                },),
-                RuntimeEvent::StorageProvider(Event::<Test>::SectorsPreCommitted {
+            [RuntimeEvent::StorageProvider(
+                Event::<Test>::SectorsPreCommitted {
                     block: 1,
                     owner: account(storage_provider),
                     sectors: bounded_vec![sector],
-                })
-            ]
+                }
+            )]
         );
 
         let sp = StorageProviders::<Test>::get(account(storage_provider))
@@ -63,8 +57,8 @@ fn successfully_precommited() {
         assert_eq!(sp.pre_committed_sectors.len(), 1);
         assert_eq!(sp.pre_commit_deposits, 1);
         assert_eq!(
-            Balances::free_balance(account(storage_provider)),
-            INITIAL_FUNDS - 70 - 1 // 1 for pre-commit deposit
+            Market::free(&account(storage_provider)),
+            Some(20 - 1) // 1 for pre-commit deposit
         );
     });
 }
@@ -78,7 +72,6 @@ fn successfully_precommited_no_deals() {
         let storage_provider = CHARLIE;
         register_storage_provider(account(storage_provider));
 
-        use crate::tests::{Market, System};
         Market::add_balance(
             RuntimeOrigin::signed(account(storage_provider)),
             MARKET_BALANCE.into(),
@@ -118,14 +111,8 @@ fn successfully_precommited_no_deals() {
         assert_eq!(sp.pre_committed_sectors.len(), 1);
         assert_eq!(sp.pre_commit_deposits, 1);
 
-        assert_eq!(
-            Balances::free_balance(account(storage_provider)),
-            INITIAL_FUNDS - (MARKET_BALANCE as u64)
-        );
-
-        let balance_entry = Market::balance_table(account(storage_provider));
-        assert_eq!(balance_entry.locked, 1); // Single pre-commit = price is 1
-        assert_eq!(balance_entry.free, 999);
+        assert_eq!(Market::locked(&account(storage_provider)), Some(1)); // Single pre-commit = price is 1
+        assert_eq!(Market::free(&account(storage_provider)), Some(999));
     });
 }
 
@@ -167,17 +154,13 @@ fn successfully_precommited_batch() {
         // Check that the events were triggered
         assert_eq!(
             events(),
-            [
-                RuntimeEvent::Balances(pallet_balances::Event::<Test>::Reserved {
-                    who: account(storage_provider),
-                    amount: SECTORS_TO_PRECOMMIT
-                },),
-                RuntimeEvent::StorageProvider(Event::<Test>::SectorsPreCommitted {
+            [RuntimeEvent::StorageProvider(
+                Event::<Test>::SectorsPreCommitted {
                     block: 1,
                     owner: account(storage_provider),
                     sectors,
-                })
-            ]
+                }
+            )]
         );
 
         let sp = StorageProviders::<Test>::get(account(storage_provider))
@@ -190,8 +173,8 @@ fn successfully_precommited_batch() {
         );
         assert_eq!(sp.pre_commit_deposits, SECTORS_TO_PRECOMMIT);
         assert_eq!(
-            Balances::free_balance(account(storage_provider)),
-            INITIAL_FUNDS - 70 - SECTORS_TO_PRECOMMIT
+            Market::free(&account(storage_provider)),
+            Some(20 - SECTORS_TO_PRECOMMIT)
         );
     });
 }

--- a/pallets/storage-provider/src/tests/prove_commit_sectors.rs
+++ b/pallets/storage-provider/src/tests/prove_commit_sectors.rs
@@ -10,7 +10,7 @@ use crate::{
     pallet::{Error, Event, StorageProviders},
     sector::{ProveCommitResult, ProveCommitSector},
     tests::{
-        account, events, publish_deals, register_storage_provider, run_to_block, Balances,
+        account, events, publish_deals, register_storage_provider, run_to_block, Balances, Market,
         RuntimeEvent, RuntimeOrigin, SectorPreCommitInfoBuilder, StorageProvider, System, Test,
         ALICE, BOB, CHARLIE, INITIAL_FUNDS,
     },
@@ -192,9 +192,9 @@ fn successfully_prove_multiple_sectors() {
 
         // check that the funds are still locked
         assert_eq!(
-            Balances::free_balance(account(storage_provider)),
-            // Provider reserved 70 tokens in the market pallet and 1 token is used per the pre-commit
-            INITIAL_FUNDS - 70 - SECTORS_TO_COMMIT as u64
+            Market::free(&account(storage_provider)),
+            // 70 - 25 * 2 = 20
+            Some(20 - SECTORS_TO_COMMIT as u64)
         );
         let sp_state = StorageProviders::<Test>::get(account(storage_provider))
             .expect("Should be able to get providers info");

--- a/pallets/storage-provider/src/tests/prove_commit_sectors.rs
+++ b/pallets/storage-provider/src/tests/prove_commit_sectors.rs
@@ -10,9 +10,9 @@ use crate::{
     pallet::{Error, Event, StorageProviders},
     sector::{ProveCommitResult, ProveCommitSector},
     tests::{
-        account, events, publish_deals, register_storage_provider, run_to_block, Balances, Market,
+        account, events, publish_deals, register_storage_provider, run_to_block, Market,
         RuntimeEvent, RuntimeOrigin, SectorPreCommitInfoBuilder, StorageProvider, System, Test,
-        ALICE, BOB, CHARLIE, INITIAL_FUNDS,
+        ALICE, BOB, CHARLIE,
     },
 };
 
@@ -84,9 +84,9 @@ fn successfully_prove_sector() {
 
         // check that the funds are still locked
         assert_eq!(
-            Balances::free_balance(account(storage_provider)),
+            Market::free(&account(storage_provider)),
             // Provider reserved 70 tokens in the market pallet and 1 token is used for the pre-commit
-            INITIAL_FUNDS - 70 - 1
+            Some(20 - 1)
         );
         let sp_state = StorageProviders::<Test>::get(account(storage_provider))
             .expect("Should be able to get providers info");

--- a/primitives/src/pallets.rs
+++ b/primitives/src/pallets.rs
@@ -47,7 +47,13 @@ pub trait ProofVerification {
 }
 
 /// Represents functions that are provided by the Market Provider Pallet
-pub trait Market<AccountId, BlockNumber> {
+pub trait Market<AccountId, BlockNumber, Balance> {
+    /// Locks funds for pre-commit purposes.
+    fn lock_pre_commit_funds(who: &AccountId, amount: Balance) -> DispatchResult;
+
+    /// Slashes funds locked for pre-commit purposes.
+    fn slash_pre_commit_funds(who: &AccountId, amount: Balance) -> DispatchResult;
+
     /// Verifies a given set of storage deals is valid for sectors being PreCommitted.
     /// Computes UnsealedCID (CommD) for each sector or None for Committed Capacity sectors.
     fn verify_deals_for_activation(


### PR DESCRIPTION
### Description

Stops using the `Currency` trait for handling balances. Centralizing everything in the Market pallet.

### Important points for reviewers

If you find uses of `Balances` inside the SP pallet flag them down!
