### PR TITLE
feat: extract DummyProofsVerification to primitives

### DIFF
--- a/pallets/market/Cargo.toml
+++ b/pallets/market/Cargo.toml
@@ -39,6 +39,7 @@ env_logger = { workspace = true }
 pallet-balances = { workspace = true, default-features = false }
 pallet-proofs = { workspace = true, default-features = false }
 pallet-storage-provider = { workspace = true, default-features = false }
+primitives = { workspace = true, default-features = false, features = ["builder", "testing"] }
 sp-core = { workspace = true, default-features = false }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true, default-features = false }
@@ -49,6 +50,8 @@ runtime-benchmarks = [
   "frame-benchmarking/runtime-benchmarks",
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
+  "primitives/builder",
+  "primitives/testing",
   "sp-runtime/runtime-benchmarks",
 ]
 std = [

--- a/pallets/market/src/mock.rs
+++ b/pallets/market/src/mock.rs
@@ -122,7 +122,7 @@ impl pallet_storage_provider::Config for Test {
     type PeerId = BoundedVec<u8, ConstU32<PEER_ID_MAX_BYTES>>; // https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
     type Currency = Balances;
     type Market = Market;
-    type ProofVerification = Proofs;
+    type ProofVerification = primitives::testing::DummyProofsVerification;
     type WPoStProvingPeriod = WpostProvingPeriod;
     type WPoStChallengeWindow = WpostChallengeWindow;
     type WPoStChallengeLookBack = WpostChallengeLookBack;

--- a/pallets/storage-provider/Cargo.toml
+++ b/pallets/storage-provider/Cargo.toml
@@ -38,7 +38,7 @@ env_logger = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 pallet-balances = { workspace = true, default-features = false }
 pallet-market = { workspace = true, default-features = false }
-primitives = { workspace = true, default-features = false, features = ["builder"] }
+primitives = { workspace = true, default-features = false, features = ["builder", "testing"] }
 rstest = { workspace = true }
 sp-io = { workspace = true }
 
@@ -48,6 +48,7 @@ runtime-benchmarks = [
   "frame-benchmarking/runtime-benchmarks",
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
+  "primitives/testing",
   "sp-runtime/runtime-benchmarks",
 ]
 std = [

--- a/pallets/storage-provider/src/tests/mod.rs
+++ b/pallets/storage-provider/src/tests/mod.rs
@@ -3,22 +3,16 @@ use alloc::collections::BTreeSet;
 
 use codec::Encode;
 use frame_support::{
-    assert_ok, derive_impl,
-    pallet_prelude::ConstU32,
-    parameter_types,
-    sp_runtime::{BoundedBTreeMap, BoundedVec},
-    traits::Hooks,
-    PalletId,
+    assert_ok, derive_impl, pallet_prelude::ConstU32, parameter_types, sp_runtime::BoundedVec,
+    traits::Hooks, PalletId,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_market::{BalanceOf, ClientDealProposal, DealProposal, DealState};
 use primitives::{
-    commitment::{CommP, Commitment, RawCommitment},
-    pallets::ProofVerification,
-    proofs::{ProverId, PublicReplicaInfo, RegisteredPoStProof, RegisteredSealProof, Ticket},
+    commitment::{CommP, Commitment},
+    proofs::RegisteredPoStProof,
     sector::SectorNumber,
-    PartitionNumber, MAX_PARTITIONS_PER_DEADLINE, MAX_POST_PROOF_BYTES, MAX_PROOFS_PER_BLOCK,
-    MAX_REPLICAS_PER_BLOCK, MAX_SEAL_PROOF_BYTES, MAX_TERMINATIONS_PER_CALL, PEER_ID_MAX_BYTES,
+    PartitionNumber, MAX_PARTITIONS_PER_DEADLINE, MAX_TERMINATIONS_PER_CALL, PEER_ID_MAX_BYTES,
 };
 use sp_arithmetic::traits::Zero;
 use sp_core::{bounded_vec, Pair};
@@ -80,46 +74,6 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
     type AccountStore = System;
-}
-
-pub const INVALID_PROOF: [u8; 2] = [0xd, 0xe];
-
-/// This is dummy proofs pallet implementation.
-/// All PoRep proofs are accepted as valid.
-/// All PoSt proofs are accepted as valid unless first of them is [`INVALID_PROOF`].
-pub struct DummyProofsVerification;
-impl ProofVerification for DummyProofsVerification {
-    fn verify_porep(
-        _prover_id: ProverId,
-        _seal_proof: RegisteredSealProof,
-        _comm_r: RawCommitment,
-        _comm_d: RawCommitment,
-        _sector: SectorNumber,
-        _ticket: Ticket,
-        _seed: Ticket,
-        _proof: BoundedVec<u8, ConstU32<MAX_SEAL_PROOF_BYTES>>,
-    ) -> sp_runtime::DispatchResult {
-        Ok(())
-    }
-
-    fn verify_post(
-        _post_type: RegisteredPoStProof,
-        _randomness: Ticket,
-        _replicas: BoundedBTreeMap<
-            SectorNumber,
-            PublicReplicaInfo,
-            ConstU32<MAX_REPLICAS_PER_BLOCK>,
-        >,
-        proofs: BoundedVec<
-            BoundedVec<u8, ConstU32<MAX_POST_PROOF_BYTES>>,
-            ConstU32<MAX_PROOFS_PER_BLOCK>,
-        >,
-    ) -> sp_runtime::DispatchResult {
-        if *proofs[0] == INVALID_PROOF {
-            return Err(sp_runtime::DispatchError::Other("invalid proof"));
-        }
-        Ok(())
-    }
 }
 
 impl pallet_market::Config for Test {
@@ -199,7 +153,7 @@ impl pallet_storage_provider::Config for Test {
     type PeerId = BoundedVec<u8, ConstU32<PEER_ID_MAX_BYTES>>; // https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
     type Currency = Balances;
     type Market = Market;
-    type ProofVerification = DummyProofsVerification;
+    type ProofVerification = primitives::testing::DummyProofsVerification;
     type WPoStProvingPeriod = WPoStProvingPeriod;
     type WPoStChallengeWindow = WPoStChallengeWindow;
     type WPoStChallengeLookBack = WPoStChallengeLookBack;

--- a/pallets/storage-provider/src/tests/submit_windowed_post.rs
+++ b/pallets/storage-provider/src/tests/submit_windowed_post.rs
@@ -1,5 +1,5 @@
 use frame_support::{assert_noop, assert_ok};
-use primitives::PartitionNumber;
+use primitives::{testing::INVALID_PROOF, PartitionNumber};
 use rstest::rstest;
 use sp_core::bounded_vec;
 use sp_runtime::{BoundedVec, DispatchError};
@@ -12,7 +12,7 @@ use crate::{
         account, declare_faults::setup_sp_with_many_sectors_multiple_partitions, events,
         new_test_ext, register_storage_provider, run_to_block, DealProposalBuilder, Market,
         RuntimeEvent, RuntimeOrigin, SectorPreCommitInfoBuilder, StorageProvider,
-        SubmitWindowedPoStBuilder, System, Test, ALICE, BOB, INVALID_PROOF,
+        SubmitWindowedPoStBuilder, System, Test, ALICE, BOB,
     },
     Config,
 };

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -50,3 +50,6 @@ std = [
   "sp-std/std",
   "thiserror/std",
 ]
+# This feature provides testing utilities,
+# e.g. a dummy proof verifier
+testing = []

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -6,6 +6,12 @@ pub mod proofs;
 pub mod randomness;
 pub mod sector;
 
+#[cfg(feature = "testing")]
+pub mod testing {
+    // NOTE(@jmg-duarte,22/01/2025): Since there's only one thing, star import for now.
+    pub use crate::proofs::testing::*;
+}
+
 pub type DealId = u64;
 
 pub type PartitionNumber = u32;

--- a/primitives/src/proofs.rs
+++ b/primitives/src/proofs.rs
@@ -174,3 +174,60 @@ mod serde_tests {
         );
     }
 }
+
+#[cfg(feature = "testing")]
+pub mod testing {
+    use sp_core::{bounded_btree_map::BoundedBTreeMap, bounded_vec::BoundedVec, ConstU32};
+
+    use crate::{
+        pallets::ProofVerification,
+        proofs::{
+            ProverId, PublicReplicaInfo, RawCommitment, RegisteredPoStProof, RegisteredSealProof,
+            Ticket,
+        },
+        sector::SectorNumber,
+        MAX_POST_PROOF_BYTES, MAX_PROOFS_PER_BLOCK, MAX_REPLICAS_PER_BLOCK, MAX_SEAL_PROOF_BYTES,
+    };
+
+    /// A sentinel value for an invalid proof, everything else will be considered valid.
+    pub const INVALID_PROOF: [u8; 2] = [0xd, 0xe];
+
+    /// This is dummy proofs pallet implementation.
+    /// All PoRep proofs are accepted as valid.
+    /// All PoSt proofs are accepted as valid unless first of them is [`INVALID_PROOF`].
+    pub struct DummyProofsVerification;
+
+    impl ProofVerification for DummyProofsVerification {
+        fn verify_porep(
+            _prover_id: ProverId,
+            _seal_proof: RegisteredSealProof,
+            _comm_r: RawCommitment,
+            _comm_d: RawCommitment,
+            _sector: SectorNumber,
+            _ticket: Ticket,
+            _seed: Ticket,
+            _proof: BoundedVec<u8, ConstU32<MAX_SEAL_PROOF_BYTES>>,
+        ) -> sp_runtime::DispatchResult {
+            Ok(())
+        }
+
+        fn verify_post(
+            _post_type: RegisteredPoStProof,
+            _randomness: Ticket,
+            _replicas: BoundedBTreeMap<
+                SectorNumber,
+                PublicReplicaInfo,
+                ConstU32<MAX_REPLICAS_PER_BLOCK>,
+            >,
+            proofs: BoundedVec<
+                BoundedVec<u8, ConstU32<MAX_POST_PROOF_BYTES>>,
+                ConstU32<MAX_PROOFS_PER_BLOCK>,
+            >,
+        ) -> sp_runtime::DispatchResult {
+            if *proofs[0] == INVALID_PROOF {
+                return Err(sp_runtime::DispatchError::Other("invalid proof"));
+            }
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
### Description

De-duplicates the `DummyProofsVerification` mechanism, extracting it to `primitives` where it is gated by `testing`

