### PR TITLE
fix: Unlock pre commit desposit after proving

### DIFF
--- a/pallets/market/src/lib.rs
+++ b/pallets/market/src/lib.rs
@@ -1180,6 +1180,11 @@ pub mod pallet {
             lock_funds::<T>(who, amount)
         }
 
+        fn unlock_pre_commit_funds(who: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
+            // NOTE(@aidan,23/1/25): unsure if this should emit an event
+            unlock_funds::<T>(who, amount)
+        }
+
         fn slash_pre_commit_funds(who: &T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
             // NOTE(@jmg-duarte,21/1/25): unsure if this should emit an event
             slash_and_burn::<T>(who, amount)

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -677,7 +677,6 @@ pub mod pallet {
                 .pre_commit_deposits
                 .checked_sub(&pre_commit_deposit_to_unlock)
             {
-                log::info!("Unlocking {pre_commit_deposit_to_unlock:?} from pre-commit deposit");
                 sp.pre_commit_deposits = pre_commit_deposits
             } else {
                 log::error!(target: LOG_TARGET, "catastrophe, failed to subtract from pre_commit_deposits {:?} - {:?} < 0", sp.pre_commit_deposits, pre_commit_deposit_to_unlock);

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -374,6 +374,8 @@ pub mod pallet {
         TooManyProofs,
         /// AuthorVRF lookup failed.
         MissingAuthorVRF,
+        /// After proving failed to return pre commit deposit.
+        FailedToReturnPreCommitDeposit,
         /// Inner pallet errors
         GeneralPalletError(crate::error::GeneralPalletError),
     }
@@ -670,9 +672,20 @@ pub mod pallet {
                 .try_into()
                 .expect("Programmer error: ProveCommitResult's should fit in bound of MAX_SECTORS");
 
-            StorageProviders::<T>::set(owner.clone(), Some(sp));
+            // Reduce pre commit deposit amount in state
+            if let Some(pre_commit_deposits) = sp
+                .pre_commit_deposits
+                .checked_sub(&pre_commit_deposit_to_unlock)
+            {
+                log::info!("Unlocking {pre_commit_deposit_to_unlock:?} from pre-commit deposit");
+                sp.pre_commit_deposits = pre_commit_deposits
+            } else {
+                log::error!(target: LOG_TARGET, "catastrophe, failed to subtract from pre_commit_deposits {:?} - {:?} < 0", sp.pre_commit_deposits, pre_commit_deposit_to_unlock);
+                return Err(Error::<T>::FailedToReturnPreCommitDeposit.into());
+            };
             // Unlock pre commit deposit funds.
             T::Market::unlock_pre_commit_funds(&owner, pre_commit_deposit_to_unlock)?;
+            StorageProviders::<T>::set(owner.clone(), Some(sp));
             Self::deposit_event(Event::SectorsProven {
                 owner,
                 sectors: sectors_proven,

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -572,6 +572,7 @@ pub mod pallet {
             let mut new_sectors = BoundedVec::new();
             let mut sector_numbers: BoundedVec<SectorNumber, ConstU32<MAX_SECTORS_PER_CALL>> =
                 BoundedVec::new();
+            let mut pre_commit_deposit_to_unlock = BalanceOf::<T>::zero();
 
             for sector in sectors {
                 // Get pre-committed sector. This is the sector we are currently
@@ -604,6 +605,8 @@ pub mod pallet {
                 new_sectors
                     .try_push(new_sector)
                     .expect("Programmer error: New sectors should fit in bound of MAX_SECTORS");
+
+                pre_commit_deposit_to_unlock += calculate_pre_commit_deposit::<T>();
             }
 
             // Activate the deals for the sectors that will be proven. This
@@ -668,6 +671,8 @@ pub mod pallet {
                 .expect("Programmer error: ProveCommitResult's should fit in bound of MAX_SECTORS");
 
             StorageProviders::<T>::set(owner.clone(), Some(sp));
+            // Unlock pre commit deposit funds.
+            T::Market::unlock_pre_commit_funds(&owner, pre_commit_deposit_to_unlock)?;
             Self::deposit_event(Event::SectorsProven {
                 owner,
                 sectors: sectors_proven,

--- a/pallets/storage-provider/src/tests/pre_commit_sector_hook.rs
+++ b/pallets/storage-provider/src/tests/pre_commit_sector_hook.rs
@@ -78,13 +78,14 @@ fn pre_commit_hook_slashed_deal() {
         assert!(sp.sectors.contains_key(&second_sector.sector_number));
         // First sector removed from here because it was slashed, second one because it was proven.
         assert!(sp.pre_committed_sectors.is_empty());
-        // Pre-commit from the second deal is still there, as pre-commit deposits are until sector expired.
-        assert_eq!(sp.pre_commit_deposits, DEAL_PRECOMMIT_DEPOSIT);
+        // No pre-commit deposit as the second deal has been proven and the first one is expired and thus slashed.
+        assert_eq!(sp.pre_commit_deposits, 0);
         // 1 deal got slashed so the respective locked funds *vanished*
         assert_eq!(
             Market::locked(&account(storage_provider)),
             // The cast is kind of an hack but we know it is safe
-            Some(((2 * DEAL_COLLATERAL + DEAL_PRECOMMIT_DEPOSIT) as u32).into())
+            // Not add the DEAL_PRECOMMIT_DEPOSIT because this has been unlocked after proving.
+            Some(((2 * DEAL_COLLATERAL) as u32).into())
         );
         let mut expected_faulty_sectors = BoundedBTreeSet::new();
         expected_faulty_sectors

--- a/pallets/storage-provider/src/tests/prove_commit_sectors.rs
+++ b/pallets/storage-provider/src/tests/prove_commit_sectors.rs
@@ -82,11 +82,11 @@ fn successfully_prove_sector() {
             ]
         );
 
-        // check that the funds are still locked
+        // check that the funds are unlocked
         assert_eq!(
             Market::free(&account(storage_provider)),
             // Provider reserved 70 tokens in the market pallet and 1 token is used for the pre-commit
-            Some(20 - 1)
+            Some(20)
         );
         let sp_state = StorageProviders::<Test>::get(account(storage_provider))
             .expect("Should be able to get providers info");
@@ -190,12 +190,8 @@ fn successfully_prove_multiple_sectors() {
             ]
         );
 
-        // check that the funds are still locked
-        assert_eq!(
-            Market::free(&account(storage_provider)),
-            // 70 - 25 * 2 = 20
-            Some(20 - SECTORS_TO_COMMIT as u64)
-        );
+        // check that the funds are unlocked
+        assert_eq!(Market::free(&account(storage_provider)), Some(20));
         let sp_state = StorageProviders::<Test>::get(account(storage_provider))
             .expect("Should be able to get providers info");
 

--- a/primitives/src/pallets.rs
+++ b/primitives/src/pallets.rs
@@ -51,6 +51,9 @@ pub trait Market<AccountId, BlockNumber, Balance> {
     /// Locks funds for pre-commit purposes.
     fn lock_pre_commit_funds(who: &AccountId, amount: Balance) -> DispatchResult;
 
+    /// Unlocks funds for pre-commit purposes.
+    fn unlock_pre_commit_funds(who: &AccountId, amount: Balance) -> DispatchResult;
+
     /// Slashes funds locked for pre-commit purposes.
     fn slash_pre_commit_funds(who: &AccountId, amount: Balance) -> DispatchResult;
 


### PR DESCRIPTION
### Description

Unlock the pre-commit deposit after the sector has been proven. Before this, the pre-commit deposit funds were never returned to the storage provider. The tests have been updated to reflect this change.

References:
[FC 1](https://github.com/filecoin-project/builtin-actors/blob/d5ef63537774b9b144ea5e332077540f9d3a1842/actors/miner/src/lib.rs#L5567)
[FC 2](https://github.com/filecoin-project/builtin-actors/blob/d5ef63537774b9b144ea5e332077540f9d3a1842/actors/miner/src/lib.rs#L5613-L5616)