### PR TITLE
fix(primitives): reduce cid feature set

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
-cid = { workspace = true }
+cid = { workspace = true, default-features = false, features = ["alloc"] }
 clap = { workspace = true, features = ["derive"], optional = true }
 codec = { workspace = true, features = ["derive"] }
 filecoin-proofs = { workspace = true, optional = true }


### PR DESCRIPTION
### Description

WASM compilation of primitives was broken because we didn't depent on alloc. This was not noticeable anywhere else because of cargo's feature unification, when building the pallets, we depended directly on cid with the alloc feature, as such, when primitives was built, it already had the alloc feature.

You can double check this by running the following command, before and after the change:
```
cargo b --no-default-features --target wasm32-unknown-unknown
```