### PR TITLE
fix(primitives): benchmark compilation issues

### DIFF
--- a/primitives/src/proofs.rs
+++ b/primitives/src/proofs.rs
@@ -177,7 +177,8 @@ mod serde_tests {
 
 #[cfg(feature = "testing")]
 pub mod testing {
-    use sp_core::{bounded_btree_map::BoundedBTreeMap, bounded_vec::BoundedVec, ConstU32};
+    use sp_core::ConstU32;
+    use sp_runtime::{BoundedBTreeMap, BoundedVec};
 
     use crate::{
         pallets::ProofVerification,

--- a/primitives/src/sector/pre_commit.rs
+++ b/primitives/src/sector/pre_commit.rs
@@ -39,7 +39,8 @@ pub mod builder {
 
     use cid::Cid;
     use sp_core::ConstU32;
-    use sp_runtime::BoundedVec;
+    use sp_runtime::{BoundedVec, Vec};
+    use sp_std::vec;
 
     use super::SectorPreCommitInfo;
     use crate::{


### PR DESCRIPTION
### Description

This is "part of" the market benchmarks PR, I'm breaking down all the fixes I found

Fixes compilation for node benchmarks:
```
cargo run           -p polka-storage-node -r -F runtime-benchmarks --           benchmark pallet           --wasm-execution=compiled           --pallet "pallet_proofs"          --extrinsic "*"           --steps 5           --repeat 1
```

