### PR TITLE
feat: mater car reader read_block_metadata

### DIFF
--- a/mater/lib/src/async_varint.rs
+++ b/mater/lib/src/async_varint.rs
@@ -110,7 +110,7 @@ impl VarIntProcessor {
     }
 
     fn decode<VI: VarInt>(&self) -> Option<(VI, usize)> {
-        Some(VI::decode_var(&self.buf[0..self.i])?)
+        VI::decode_var(&self.buf[0..self.i])
     }
 }
 

--- a/mater/lib/src/async_varint.rs
+++ b/mater/lib/src/async_varint.rs
@@ -35,7 +35,8 @@ where
     Ok(b)
 }
 
-/// Returns either the decoded integer, or an error.
+/// Returns either the decoded integer and number of bytes used by the encoding,
+/// or an error.
 ///
 /// In general, this always reads a whole varint. If the encoded varint's value
 /// is bigger than the valid value range of `VI`, then the value is truncated.
@@ -44,7 +45,7 @@ where
 ///
 /// Borrowed from:
 /// <https://github.com/dermesser/integer-encoding-rs/blob/4f57046ae90b6b923ff235a91f0729d3cf868d72/src/reader.rs#L70>
-pub(crate) async fn read_varint<R, VI>(reader: &mut R) -> Result<VI, io::Error>
+pub(crate) async fn read_varint<R, VI>(reader: &mut R) -> Result<(VI, usize), io::Error>
 where
     R: AsyncRead + Unpin,
     VI: VarInt,
@@ -91,6 +92,7 @@ impl VarIntProcessor {
             ..VarIntProcessor::default()
         }
     }
+
     fn push(&mut self, b: u8) -> Result<(), io::Error> {
         if self.i >= self.maxsize {
             return Err(io::Error::new(
@@ -102,11 +104,13 @@ impl VarIntProcessor {
         self.i += 1;
         Ok(())
     }
+
     fn finished(&self) -> bool {
         self.i > 0 && (self.buf[self.i - 1] & MSB == 0)
     }
-    fn decode<VI: VarInt>(&self) -> Option<VI> {
-        Some(VI::decode_var(&self.buf[0..self.i])?.0)
+
+    fn decode<VI: VarInt>(&self) -> Option<(VI, usize)> {
+        Some(VI::decode_var(&self.buf[0..self.i])?)
     }
 }
 

--- a/mater/lib/src/cid.rs
+++ b/mater/lib/src/cid.rs
@@ -1,0 +1,88 @@
+use ipld_core::cid::{multihash::Multihash, CidGeneric, Error, Version};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::{async_varint::read_varint, IDENTITY_CODE};
+
+pub trait MultihashExt {
+    async fn read_async<R>(r: R) -> Result<(Self, usize), Error>
+    where
+        Self: Sized,
+        R: AsyncRead + Unpin;
+}
+
+pub trait CidExt {
+    async fn read_bytes_async<R>(r: R) -> Result<(Self, usize), Error>
+    where
+        Self: Sized,
+        R: AsyncRead + Unpin;
+
+    /// Returns Some(data) if the CID is an identity. If not, None is returned.
+    fn get_identity_data(&self) -> Option<&[u8]>;
+}
+
+impl<const S: usize> CidExt for CidGeneric<S> {
+    fn get_identity_data(&self) -> Option<&[u8]> {
+        (self.hash().code() == IDENTITY_CODE).then(|| self.hash().digest())
+    }
+
+    /// Async implementation of
+    /// https://github.com/multiformats/rust-cid/blob/eb03f566e9bfb19bad79b2691dbcb2541627c0b3/src/cid.rs#L143C12-L143C22
+    async fn read_bytes_async<R>(mut r: R) -> Result<(Self, usize), Error>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let (version, version_bytes_read): (u64, usize) = read_varint(&mut r).await?;
+        let (codec, codec_bytes_read): (u64, usize) = read_varint(&mut r).await?;
+
+        // CIDv0 has the fixed `0x12 0x20` prefix
+        if [version, codec] == [0x12, 0x20] {
+            const DIGEST_SIZE: usize = 32;
+            let mut digest = [0u8; DIGEST_SIZE];
+            r.read_exact(&mut digest).await?;
+            let mh = Multihash::wrap(version, &digest).expect("Digest is always 32 bytes.");
+
+            let bytes_read = version_bytes_read + codec_bytes_read + DIGEST_SIZE;
+            return Ok((Self::new_v0(mh)?, bytes_read));
+        }
+
+        let version = Version::try_from(version)?;
+        match version {
+            Version::V0 => Err(Error::InvalidExplicitCidV0),
+            Version::V1 => {
+                let (mh, multihash_bytes_read) = Multihash::read_async(r).await?;
+                let bytes_read = version_bytes_read + codec_bytes_read + multihash_bytes_read;
+                Ok((Self::new(version, codec, mh)?, bytes_read))
+            }
+        }
+    }
+}
+
+impl<const S: usize> MultihashExt for Multihash<S> {
+    /// Async implementation of
+    /// https://github.com/multiformats/rust-multihash/blob/90a6c19ec71ced09469eec164a3586aafeddfbbd/src/multihash.rs#L271
+    async fn read_async<R>(mut r: R) -> Result<(Self, usize), Error>
+    where
+        Self: Sized,
+        R: AsyncRead + Unpin,
+    {
+        let (code, code_bytes_read): (u64, usize) = read_varint(&mut r).await?;
+        let (size, size_bytes_read): (u8, usize) = read_varint(&mut r).await?;
+
+        if size > S as u8 || size > u8::MAX {
+            return Err(Error::ParsingError);
+        }
+
+        let mut digest = [0; S];
+        r.read_exact(&mut digest[..size as usize])
+            .await
+            .map_err(|_| Error::ParsingError)?;
+
+        let multihash = Multihash::wrap(code, &digest)
+            .map_err(|_| Error::ParsingError)?
+            .truncate(size);
+
+        let bytes_read = code_bytes_read + size_bytes_read + size as usize;
+
+        Ok((multihash, bytes_read))
+    }
+}

--- a/mater/lib/src/cid.rs
+++ b/mater/lib/src/cid.rs
@@ -3,13 +3,6 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::{async_varint::read_varint, IDENTITY_CODE};
 
-pub trait MultihashExt {
-    async fn read_async<R>(r: R) -> Result<(Self, usize), Error>
-    where
-        Self: Sized,
-        R: AsyncRead + Unpin;
-}
-
 pub trait CidExt {
     async fn read_bytes_async<R>(r: R) -> Result<(Self, usize), Error>
     where
@@ -18,6 +11,13 @@ pub trait CidExt {
 
     /// Returns Some(data) if the CID is an identity. If not, None is returned.
     fn get_identity_data(&self) -> Option<&[u8]>;
+}
+
+pub trait MultihashExt {
+    async fn read_async<R>(r: R) -> Result<(Self, usize), Error>
+    where
+        Self: Sized,
+        R: AsyncRead + Unpin;
 }
 
 impl<const S: usize> CidExt for CidGeneric<S> {
@@ -84,5 +84,66 @@ impl<const S: usize> MultihashExt for Multihash<S> {
         let bytes_read = code_bytes_read + size_bytes_read + size as usize;
 
         Ok((multihash, bytes_read))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Cursor, str::FromStr};
+
+    use ipld_core::cid::{multihash::Multihash, Cid};
+
+    use crate::{
+        cid::{CidExt, MultihashExt},
+        multicodec::SHA_256_CODE,
+        RAW_CODE,
+    };
+
+    #[tokio::test]
+    async fn cid_v0_read_bytes_async() {
+        let mh = Multihash::<64>::wrap(SHA_256_CODE, &[0u8; 32]).unwrap();
+        let original_cid = Cid::new_v0(mh).unwrap();
+
+        let cid_bytes = Cursor::new(original_cid.to_bytes());
+        let (cid, bytes_read) = Cid::read_bytes_async(cid_bytes).await.unwrap();
+
+        assert_eq!(original_cid, cid);
+        // In case of CIDv0. Multihash has an explicit size and codec. Because
+        // of that, they are not part of the format and we are not reading them.
+        // 34 = cid_version(1) + cid_codec(1) + multihash_digest_size(32)
+        assert_eq!(bytes_read, 34);
+    }
+
+    #[tokio::test]
+    async fn cid_v1_read_bytes_async() {
+        let original_cid =
+            Cid::from_str("bafkreiczsrdrvoybcevpzqmblh3my5fu6ui3tgag3jm3hsxvvhaxhswpyu").unwrap();
+
+        let cid_bytes = Cursor::new(original_cid.to_bytes());
+        let (cid, bytes_read) = Cid::read_bytes_async(cid_bytes).await.unwrap();
+
+        assert_eq!(original_cid, cid);
+        // 36 = cid_version(1) + cid_codec(1) + mh_code(1) + mh_size(1) + multihash_digest_size(32)
+        assert_eq!(bytes_read, 36);
+    }
+
+    #[tokio::test]
+    async fn multihash_read_async() {
+        let original_mh = Multihash::<64>::wrap(RAW_CODE, b"Hello World!").unwrap();
+
+        let mh_bytes = Cursor::new(original_mh.to_bytes());
+        let (mh, bytes_read) = Multihash::<64>::read_async(mh_bytes).await.unwrap();
+
+        assert_eq!(original_mh, mh);
+        // 10 = mh_code(1) + mh_size(1) + multihash_digest_size(12)
+        assert_eq!(bytes_read, 14);
+    }
+
+    #[tokio::test]
+    async fn multihash_read_async_digest_size_error() {
+        let original_mh = Multihash::<64>::wrap(RAW_CODE, b"Hello World!").unwrap();
+
+        let mh_bytes = Cursor::new(original_mh.to_bytes());
+        assert!(Multihash::<5>::read_async(mh_bytes).await.is_err());
     }
 }

--- a/mater/lib/src/cid.rs
+++ b/mater/lib/src/cid.rs
@@ -66,9 +66,9 @@ impl<const S: usize> MultihashExt for Multihash<S> {
         R: AsyncRead + Unpin,
     {
         let (code, code_bytes_read): (u64, usize) = read_varint(&mut r).await?;
-        let (size, size_bytes_read): (u8, usize) = read_varint(&mut r).await?;
+        let (size, size_bytes_read): (u64, usize) = read_varint(&mut r).await?;
 
-        if size > S as u8 || size > u8::MAX {
+        if size > S as u64 || size > u8::MAX as u64 {
             return Err(Error::ParsingError);
         }
 
@@ -79,7 +79,7 @@ impl<const S: usize> MultihashExt for Multihash<S> {
 
         let multihash = Multihash::wrap(code, &digest)
             .map_err(|_| Error::ParsingError)?
-            .truncate(size);
+            .truncate(size as u8);
 
         let bytes_read = code_bytes_read + size_bytes_read + size as usize;
 

--- a/mater/lib/src/lib.rs
+++ b/mater/lib/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(unsafe_code)]
 
 mod async_varint;
+mod cid;
 mod multicodec;
 mod stores;
 mod unixfs;

--- a/mater/lib/src/multicodec.rs
+++ b/mater/lib/src/multicodec.rs
@@ -2,7 +2,7 @@
 //! as per the [code table](https://github.com/multiformats/multicodec/blob/c954a787dc6a17d099653e5f90d26fbd177d2074/table.csv).
 
 use digest::Digest;
-use ipld_core::cid::{multihash::Multihash, CidGeneric};
+use ipld_core::cid::multihash::Multihash;
 
 pub const SHA_256_CODE: u64 = 0x12;
 pub const SHA_512_CODE: u64 = 0x13;
@@ -41,9 +41,4 @@ where
     let hashed_bytes = hasher.finalize();
     Multihash::wrap(H::CODE, &hashed_bytes)
         .expect("the digest should be valid (enforced by the type system)")
-}
-
-// Returns Some(data) if the CID is an identity. If not, None is returned.
-pub fn get_identity_data<const S: usize>(cid: &CidGeneric<S>) -> Option<&[u8]> {
-    (cid.hash().code() == IDENTITY_CODE).then(|| cid.hash().digest())
 }

--- a/mater/lib/src/stores/file.rs
+++ b/mater/lib/src/stores/file.rs
@@ -10,7 +10,8 @@ use tokio::{
 };
 
 use crate::{
-    multicodec::{get_identity_data, SHA_256_CODE},
+    cid::CidExt,
+    multicodec::SHA_256_CODE,
     v1::{self, read_block, write_block},
     v2::{self},
     CarV1Header, CarV2Header, Characteristics, Error, Index, IndexEntry, MultihashIndexSorted,
@@ -138,7 +139,7 @@ impl FileBlockstore {
     /// Check if the store contains a block with the cid. In case of IDENTITY
     /// CID it always returns true.
     pub async fn has(&self, cid: Cid) -> Result<bool, Error> {
-        if get_identity_data(&cid).is_some() {
+        if cid.get_identity_data().is_some() {
             return Ok(true);
         }
 
@@ -150,7 +151,7 @@ impl FileBlockstore {
     /// from the cid is returned.
     pub async fn get(&self, cid: Cid) -> Result<Option<Vec<u8>>, Error> {
         // If CID is an identity
-        if let Some(data) = get_identity_data(&cid) {
+        if let Some(data) = cid.get_identity_data() {
             return Ok(Some(data.to_owned()));
         }
 
@@ -186,7 +187,7 @@ impl FileBlockstore {
     /// expect that the CID correctly represents the data being passed. In case
     /// of the identity CID, nothing is written to the store.
     pub async fn put_keyed(&self, cid: &Cid, data: &[u8]) -> Result<(), Error> {
-        if get_identity_data(&cid).is_some() {
+        if cid.get_identity_data().is_some() {
             return Ok(());
         }
 

--- a/mater/lib/src/v1/mod.rs
+++ b/mater/lib/src/v1/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::multicodec::{RAW_CODE, SHA_256_CODE};
 pub use crate::v1::{reader::Reader, writer::Writer};
 pub(crate) use crate::v1::{
-    reader::{read_block, read_header},
+    reader::{read_block, read_header, skip_block},
     writer::{write_block, write_header},
 };
 
@@ -60,6 +60,18 @@ impl Default for Header {
             roots: vec![default_cid],
         }
     }
+}
+
+/// BlockMetadata contains metadata about a block's section in a CAR file/stream.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BlockMetadata {
+    /// Cid of the block
+    cid: Cid,
+    /// Offset of the data section relative to the start of the underlying
+    /// reader.
+    data_offset_source: u64,
+    /// Size of the data section of the block
+    data_size: u64,
 }
 
 #[cfg(test)]

--- a/mater/lib/src/v1/mod.rs
+++ b/mater/lib/src/v1/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::multicodec::{RAW_CODE, SHA_256_CODE};
 pub use crate::v1::{reader::Reader, writer::Writer};
 pub(crate) use crate::v1::{
-    reader::{read_block, read_header, skip_block},
+    reader::{read_block, read_block_metadata, read_header},
     writer::{write_block, write_header},
 };
 

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -1,16 +1,17 @@
-use std::io::Cursor;
+use std::io::SeekFrom;
 
 use ipld_core::{cid::Cid, codec::Codec};
 use serde_ipld_dagcbor::codec::DagCborCodec;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 
-use crate::{async_varint::read_varint, v1::Header, v2::PRAGMA, Error};
+use super::BlockMetadata;
+use crate::{async_varint::read_varint, cid::CidExt, v1::Header, v2::PRAGMA, Error};
 
 pub(crate) async fn read_header<R>(mut reader: R) -> Result<Header, Error>
 where
     R: AsyncRead + Unpin,
 {
-    let header_length: usize = read_varint(&mut reader).await?;
+    let header_length: usize = read_varint(&mut reader).await?.0;
     let mut header_buffer = vec![0; header_length];
     reader.read_exact(&mut header_buffer).await?;
 
@@ -45,19 +46,39 @@ pub(crate) async fn read_block<R>(mut reader: R) -> Result<(Cid, Vec<u8>), Error
 where
     R: AsyncRead + Unpin,
 {
-    let full_block_length: usize = read_varint(&mut reader).await?;
-    let mut full_block_buffer = vec![0; full_block_length];
-    reader.read_exact(&mut full_block_buffer).await?;
+    let (full_block_length, _): (u64, usize) = read_varint(&mut reader).await?;
+    let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
+    dbg!(&cid);
 
-    // We're cheating to get Seek
-    let mut full_block_cursor = Cursor::new(full_block_buffer);
-    let cid = Cid::read_bytes(&mut full_block_cursor)?;
+    let data_size = full_block_length as usize - cid_bytes_read;
+    let mut data_buffer = vec![0; data_size];
+    reader.read_exact(&mut data_buffer).await?;
 
-    let data_start_position = full_block_cursor.position() as usize;
-    let mut full_block_buffer = full_block_cursor.into_inner();
+    Ok((cid, data_buffer))
+}
 
-    // NOTE(@jmg-duarte,19/05/2024): could we avoid getting a new vector here and just drop the beginning?
-    Ok((cid, full_block_buffer.split_off(data_start_position)))
+pub(crate) async fn skip_block<R>(mut reader: R) -> Result<BlockMetadata, Error>
+where
+    R: AsyncRead + AsyncSeek + Unpin,
+{
+    // Length of the block. This length contains the length of the cid and data.
+    let (full_block_length, _): (u64, usize) = read_varint(&mut reader).await?;
+
+    // Cid of the block
+    let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
+
+    // Data section position and size
+    let data_offset_source = reader.stream_position().await?;
+    let data_size = full_block_length - cid_bytes_read as u64;
+
+    // Skip block data section
+    reader.seek(SeekFrom::Current(data_size as i64)).await?;
+
+    Ok(BlockMetadata {
+        cid,
+        data_offset_source,
+        data_size,
+    })
 }
 
 /// Low-level CARv1 reader.
@@ -104,15 +125,27 @@ where
     }
 }
 
+impl<R> Reader<R>
+where
+    R: AsyncRead + AsyncSeek + Unpin,
+{
+    /// Reads a [`BlockMetadata`] and skips its content.
+    pub async fn skip_block(&mut self) -> Result<BlockMetadata, Error> {
+        skip_block(&mut self.reader).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::{os::unix::fs::MetadataExt, str::FromStr};
+
     use ipld_core::cid::Cid;
     use sha2::Sha256;
     use tokio::{fs::File, io::BufReader};
 
     use crate::{
         multicodec::{generate_multihash, RAW_CODE},
-        v1::reader::Reader,
+        v1::{reader::Reader, BlockMetadata},
         Error,
     };
 
@@ -156,6 +189,29 @@ mod tests {
         let (cid, block) = reader.read_block().await.unwrap();
         assert_eq!(cid, contents_cid);
         assert_eq!(block, contents);
+    }
+
+    #[tokio::test]
+    async fn block_metadata_reader() {
+        let contents = tokio::fs::read("tests/fixtures/original/lorem.txt")
+            .await
+            .unwrap();
+        let contents_multihash = generate_multihash::<Sha256, _>(&contents);
+        let contents_cid = Cid::new_v1(RAW_CODE, contents_multihash);
+
+        let file = File::open("tests/fixtures/car_v1/lorem.car").await.unwrap();
+        let reader = BufReader::new(file);
+        let mut reader = Reader::new(reader);
+        let header = reader.read_header().await.unwrap();
+
+        assert_eq!(header.version, 1);
+        assert_eq!(header.roots.len(), 1);
+        assert_eq!(header.roots[0], contents_cid);
+
+        let metadata = reader.skip_block().await.unwrap();
+        assert_eq!(metadata.cid, contents_cid);
+        assert_eq!(metadata.data_offset_source, 97);
+        assert_eq!(metadata.data_size as usize, contents.len());
     }
 
     #[tokio::test]

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -48,7 +48,6 @@ where
 {
     let (full_block_length, _): (u64, usize) = read_varint(&mut reader).await?;
     let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
-    dbg!(&cid);
 
     let data_size = full_block_length as usize - cid_bytes_read;
     let mut data_buffer = vec![0; data_size];

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -137,15 +137,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{os::unix::fs::MetadataExt, str::FromStr};
-
     use ipld_core::cid::Cid;
     use sha2::Sha256;
     use tokio::{fs::File, io::BufReader};
 
     use crate::{
         multicodec::{generate_multihash, RAW_CODE},
-        v1::{reader::Reader, BlockMetadata},
+        v1::reader::Reader,
         Error,
     };
 

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -46,7 +46,7 @@ pub(crate) async fn read_block<R>(mut reader: R) -> Result<(Cid, Vec<u8>), Error
 where
     R: AsyncRead + Unpin,
 {
-    let (full_block_length, _): (u64, usize) = read_varint(&mut reader).await?;
+    let (full_block_length, _): (u64, _) = read_varint(&mut reader).await?;
     let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
 
     let data_size = full_block_length as usize - cid_bytes_read;
@@ -56,12 +56,12 @@ where
     Ok((cid, data_buffer))
 }
 
-pub(crate) async fn skip_block<R>(mut reader: R) -> Result<BlockMetadata, Error>
+pub(crate) async fn read_block_metadata<R>(mut reader: R) -> Result<BlockMetadata, Error>
 where
     R: AsyncRead + AsyncSeek + Unpin,
 {
     // Length of the block. This length contains the length of the cid and data.
-    let (full_block_length, _): (u64, usize) = read_varint(&mut reader).await?;
+    let (full_block_length, _): (u64, _) = read_varint(&mut reader).await?;
 
     // Cid of the block
     let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
@@ -129,9 +129,10 @@ where
     R: AsyncRead + AsyncSeek + Unpin,
 {
     /// Skips the next block and only returns a [`BlockMetadata`]. This is
-    /// useful in cases when we don't need the block's content.
-    pub async fn skip_block(&mut self) -> Result<BlockMetadata, Error> {
-        skip_block(&mut self.reader).await
+    /// useful in cases when we only need the block's metadata and don't care
+    /// about the content.
+    pub async fn read_block_metadata(&mut self) -> Result<BlockMetadata, Error> {
+        read_block_metadata(&mut self.reader).await
     }
 }
 
@@ -206,7 +207,7 @@ mod tests {
         assert_eq!(header.roots.len(), 1);
         assert_eq!(header.roots[0], contents_cid);
 
-        let metadata = reader.skip_block().await.unwrap();
+        let metadata = reader.read_block_metadata().await.unwrap();
         assert_eq!(metadata.cid, contents_cid);
         assert_eq!(metadata.data_offset_source, 97);
         assert_eq!(metadata.data_size as usize, contents.len());

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -128,7 +128,8 @@ impl<R> Reader<R>
 where
     R: AsyncRead + AsyncSeek + Unpin,
 {
-    /// Reads a [`BlockMetadata`] and skips its content.
+    /// Skips the next block and only returns a [`BlockMetadata`]. This is
+    /// useful in cases when we don't need the block's content.
     pub async fn skip_block(&mut self) -> Result<BlockMetadata, Error> {
         skip_block(&mut self.reader).await
     }

--- a/mater/lib/src/v2/index.rs
+++ b/mater/lib/src/v2/index.rs
@@ -293,7 +293,7 @@ pub(crate) async fn read_index<R>(mut reader: R) -> Result<Index, Error>
 where
     R: AsyncRead + Unpin,
 {
-    let index_type: u64 = read_varint(&mut reader).await?;
+    let index_type: u64 = read_varint(&mut reader).await?.0;
     return match index_type {
         INDEX_SORTED_CODE => Ok(Index::IndexSorted(read_index_sorted(&mut reader).await?)),
         MULTIHASH_INDEX_SORTED_CODE => Ok(Index::MultihashIndexSorted(

--- a/mater/lib/src/v2/reader.rs
+++ b/mater/lib/src/v2/reader.rs
@@ -157,7 +157,6 @@ where
 {
     /// Skips the next block and only returns a [`BlockMetadata`]. This is
     /// useful in cases when we don't need the block's content.
-
     pub async fn skip_block(&mut self) -> Result<BlockMetadata, Error> {
         crate::v1::skip_block(&mut self.reader).await
     }

--- a/mater/lib/src/v2/reader.rs
+++ b/mater/lib/src/v2/reader.rs
@@ -1,8 +1,9 @@
 use ipld_core::cid::Cid;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWriteExt, BufReader};
 
 use super::index::read_index;
 use crate::{
+    v1::BlockMetadata,
     v2::{index::Index, Characteristics, Header, PRAGMA},
     Error,
 };
@@ -147,6 +148,18 @@ where
     /// [`Reader`] does not natively support.
     pub fn get_inner_mut(&mut self) -> &mut R {
         &mut self.reader
+    }
+}
+
+impl<R> Reader<R>
+where
+    R: AsyncRead + AsyncSeek + Unpin,
+{
+    /// Skips the next block and only returns a [`BlockMetadata`]. This is
+    /// useful in cases when we don't need the block's content.
+
+    pub async fn skip_block(&mut self) -> Result<BlockMetadata, Error> {
+        crate::v1::skip_block(&mut self.reader).await
     }
 }
 

--- a/mater/lib/src/v2/reader.rs
+++ b/mater/lib/src/v2/reader.rs
@@ -156,9 +156,10 @@ where
     R: AsyncRead + AsyncSeek + Unpin,
 {
     /// Skips the next block and only returns a [`BlockMetadata`]. This is
-    /// useful in cases when we don't need the block's content.
-    pub async fn skip_block(&mut self) -> Result<BlockMetadata, Error> {
-        crate::v1::skip_block(&mut self.reader).await
+    /// useful in cases when we only need the block's metadata and don't care
+    /// about the content.
+    pub async fn read_block_metadata(&mut self) -> Result<BlockMetadata, Error> {
+        crate::v1::read_block_metadata(&mut self.reader).await
     }
 }
 


### PR DESCRIPTION
### Description

Enable mater car readers to be able to read the blocks metadata while reading the car archive. If the `read_block_metadata` is used, that means that the block content is not loaded into memory and only the block's metadata is returned.

This is needed for the storage provider server for when the sector is being indexed. The provider will index the sectors after they are successfully prove committed. The indexing process opens unesaled sector files and reads the car blocks directly from the file. For indexing purposes, we don't need the content in the block. This pr enables the sector indexer to only read the metadata of the car block and saves that to the index.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Did you document new (or modified) APIs?
