### PR TITLE
fix: update polkadot to 2412 and subxt-cli to 0.38.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732069891,
-        "narHash": "sha256-moKx8AVJrViCSdA0e0nSsG8b1dAsObI4sRAtbqbvBY8=",
+        "lastModified": 1738203884,
+        "narHash": "sha256-H48s0D1+p9G0XcP2ggMLQ9QVI2SfpgZsJGrkzp5EmyU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8509a51241c407d583b1963d5079585a992506e8",
+        "rev": "86a1ccaaca8ba20a8b4187aa8ca75c319aea16fa",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "process-compose": "process-compose"
       },
       "locked": {
-        "lastModified": 1730354470,
-        "narHash": "sha256-LfFP7LgcvVwsxUGUQmMVfZkxiw1GeEac0oo/Quxc0zA=",
+        "lastModified": 1737475205,
+        "narHash": "sha256-Z32CQ47K0lCL8AYN4yNKhz2S/gmigY3X8k0Szaycyxc=",
         "owner": "paritytech",
         "repo": "zombienet",
-        "rev": "64f303d99865f3e813390e769385a0e9e03dd3dc",
+        "rev": "236781bcc1d3dac3087dace5847e0105bfc0283d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,7 @@
   outputs = { self, nixpkgs, flake-utils, rust-overlay, zombienet }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [
-          (import rust-overlay)
-          zombienet.overlays.default
-        ];
+        overlays = [ (import rust-overlay) zombienet.overlays.default ];
         pkgs = import nixpkgs {
           inherit system overlays;
 

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
           LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
           PROTOC = "${protobuf}/bin/protoc";
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library/";
+          # Workaround https://github.com/NixOS/nixpkgs/issues/370494#issuecomment-2625163369.
           CFLAGS = "-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE";
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
         overlays = [ (import rust-overlay) zombienet.overlays.default ];
         pkgs = import nixpkgs {
           inherit system overlays;
-
         };
         rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,13 @@
   outputs = { self, nixpkgs, flake-utils, rust-overlay, zombienet }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [ (import rust-overlay) zombienet.overlays.default ];
+        overlays = [
+          (import rust-overlay)
+          zombienet.overlays.default
+        ];
         pkgs = import nixpkgs {
           inherit system overlays;
+
         };
         rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         buildInputs = with pkgs; [
@@ -58,6 +62,7 @@
           LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
           PROTOC = "${protobuf}/bin/protoc";
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library/";
+          CFLAGS = "-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE";
         };
       }
     );


### PR DESCRIPTION
### Description

Upgrades polkadot to 2412 and subxt to 0.38.
Fixes #650, via a workaroundish way.
Details here: https://github.com/NixOS/nixpkgs/issues/370494#issuecomment-2625163369.

Tested and it works. 
```
cargo clean && cargo build
```

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
