### PR TITLE
feat(storage-provider): add status RPC

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -54,6 +54,8 @@ build-polka-storage-provider-client:
 build-polka-storage-provider-server:
   cargo build --release -p polka-storage-provider-server
 
+build-polka-storage-provider: build-polka-storage-provider-server build-polka-storage-provider-client
+
 # Build the storagext CLI binary
 build-storagext-cli:
   cargo build --release -p storagext-cli

--- a/examples/rpc_publish.sh
+++ b/examples/rpc_publish.sh
@@ -31,8 +31,11 @@ P2P_PRIVATE_KEY="/tmp/private.pem"
 P2P_ADDRESS="/ip4/127.0.0.1/tcp/62649"
 
 # Generate ED25519 private key to be replaced with a polka-storage-provider-client command
-# TODO(@aidan46, 15/01, #676)
-openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY" -outpubkey "$P2P_PUBLIC_KEY"
+# Generate ED25519 private key
+openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY"
+# -outpubkey is only available in OpenSSL 3.4.0 onwards
+# https://github.com/openssl/openssl/commit/6c03fa21ed4bbc9fd6d3013fdf9f4646d231f831
+openssl pkey -in "$P2P_PRIVATE_KEY" -pubout -out "$P2P_PUBLIC_KEY"
 
 # Convert file to CARv2 format
 target/release/mater-cli convert -q --overwrite "$INPUT_FILE" "$INPUT_TMP_FILE" &&

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -13,7 +13,10 @@ P2P_PRIVATE_KEY="/tmp/private.pem"
 P2P_ADDRESS="/ip4/127.0.0.1/tcp/62649"
 
 # Generate ED25519 private key
-openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY" -outpubkey "$P2P_PUBLIC_KEY"
+openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY"
+# -outpubkey is only available in OpenSSL 3.4.0 onwards
+# https://github.com/openssl/openssl/commit/6c03fa21ed4bbc9fd6d3013fdf9f4646d231f831
+openssl pkey -in "$P2P_PRIVATE_KEY" -pubout -out "$P2P_PUBLIC_KEY"
 
 # Generate Peer ID
 PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_PUBLIC_KEY")"

--- a/storage-provider/client/src/commands/mod.rs
+++ b/storage-provider/client/src/commands/mod.rs
@@ -8,6 +8,7 @@ use ed25519_dalek::pkcs8::{DecodePublicKey, PublicKeyBytes};
 use jsonrpsee::core::ClientError;
 use libp2p::{identity::ed25519::PublicKey as EdPubKey, PeerId};
 use polka_storage_provider_common::rpc::StorageProviderRpcClient;
+use primitives::DealId;
 use storagext::{
     deser::DeserializablePath,
     multipair::{MultiPairArgs, MultiPairSigner},
@@ -99,6 +100,15 @@ pub(crate) enum Cli {
         client_deal_proposal: SxtClientDealProposal,
     },
 
+    /// Retrieve a deal proposal.
+    RetrieveDeal {
+        /// URL of the providers RPC server.
+        #[arg(long, default_value = DEFAULT_RPC_SERVER_URL)]
+        rpc_server_url: Url,
+        /// The target deal ID.
+        deal_id: DealId,
+    },
+
     /// Sign a storage deal using the provided key, will output the deal as a JSON
     /// — no information is shared across the network.
     SignDeal {
@@ -144,6 +154,10 @@ impl Cli {
                 rpc_server_url,
                 client_deal_proposal,
             } => Self::publish_deal(rpc_server_url, client_deal_proposal).await,
+            Self::RetrieveDeal {
+                rpc_server_url,
+                deal_id,
+            } => Self::retrieve_deal(rpc_server_url, deal_id).await,
             Self::SignDeal {
                 deal_proposal,
                 signer_key,
@@ -180,6 +194,13 @@ impl Cli {
         let client = PolkaStorageRpcClient::new(&rpc_server_url).await?;
         let result = client.publish_deal(client_deal_proposal).await?;
         println!("Successfully published deal of id: {}", result);
+        Ok(())
+    }
+
+    async fn retrieve_deal(rpc_server_url: Url, deal_id: DealId) -> Result<(), CliError> {
+        let client = PolkaStorageRpcClient::new(&rpc_server_url).await?;
+        let result = client.retrieve_deal(deal_id).await?;
+        println!("{}", result);
         Ok(())
     }
 

--- a/storage-provider/common/src/rpc/mod.rs
+++ b/storage-provider/common/src/rpc/mod.rs
@@ -4,7 +4,10 @@ use std::fmt;
 
 use chrono::{DateTime, Utc};
 use jsonrpsee::proc_macros::rpc;
-use primitives::proofs::{RegisteredPoStProof, RegisteredSealProof};
+use primitives::{
+    proofs::{RegisteredPoStProof, RegisteredSealProof},
+    DealId,
+};
 use serde::{Deserialize, Serialize};
 use storagext::types::market::{
     ClientDealProposal as SxtClientDealProposal, DealProposal as SxtDealProposal,
@@ -27,6 +30,10 @@ pub trait StorageProviderRpc {
     /// Publish a deal, the published deal ID will be returned.
     #[method(name = "publish_deal")]
     async fn publish_deal(&self, deal: SxtClientDealProposal) -> Result<u64, RpcError>;
+
+    /// Retrieve a deal proposal (includes the deal status).
+    #[method(name = "retrieve_deal")]
+    async fn retrieve_deal(&self, deal_id: DealId) -> Result<SxtDealProposal, RpcError>;
 }
 
 /// Storage Provider server information, such as start time and on-chain address.

--- a/storage-provider/server/src/rpc.rs
+++ b/storage-provider/server/src/rpc.rs
@@ -1,11 +1,14 @@
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use axum::http::Method;
-use jsonrpsee::server::Server;
+use jsonrpsee::{server::Server, types::error::INTERNAL_ERROR_CODE};
 use polka_storage_provider_common::rpc::{
     CidString, RpcError, ServerInfo, StorageProviderRpcServer,
 };
-use primitives::commitment::{CommP, Commitment, CommitmentKind};
+use primitives::{
+    commitment::{CommP, Commitment, CommitmentKind},
+    DealId,
+};
 use storagext::{
     types::market::{ClientDealProposal as SxtClientDealProposal, DealProposal as SxtDealProposal},
     MarketClientExt,
@@ -213,6 +216,14 @@ impl StorageProviderRpcServer for RpcServerState {
             .map_err(|e| RpcError::internal_error(e, None))?;
 
         Ok(deal_id)
+    }
+
+    async fn retrieve_deal(&self, deal_id: DealId) -> Result<SxtDealProposal, RpcError> {
+        match self.xt_client.retrieve_deal(deal_id).await {
+            Ok(Some(proposal)) => Ok(proposal.into()),
+            Ok(None) => Err(RpcError::new(404, "deal not found", None)), // find a better error code?
+            Err(err) => Err(RpcError::new(INTERNAL_ERROR_CODE, err.to_string(), None)),
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Closes #501 (and possibly #159, please discuss)

Output:
```
jmgd@parthenon:~/polka-storage$ cargo r -r -p polka-storage-provider-client -- retrieve-deal 0
    Finished `release` profile [optimized] target(s) in 0.91s
warning: the following packages contain code that will be rejected by a future version of Rust: bitflags v0.7.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/release/polka-storage-provider-client retrieve-deal 0`
Deal Proposal { piece_cid: baga6ea4seaqj527iqfb2kqhy3tmpydzroiigyaie6g3txai2kc3ooyl7kgpeipi, piece_size: 2048, provider: 5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y, client: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY, label: , start_block: 200, end_block: 250, storage_price_per_block: 500, provider_collateral: 1250, state: Active({ sector_number: 1, sector_start_block: 40, last_updated_block: None, slash_block: None }) }
```

### Checklist

- [x] Make sure that you described what this change does.
- [x] Have you tested this solution?
- [x] Did you document new (or modified) APIs?
