### PR TITLE
fix: use older nixpkgs to make nix work on macos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Description

https://github.com/NixOS/nixpkgs/pull/323869#issuecomment-2633773890

There was a flag added to the nixpkgs that breaks downstream builds.
Downgrading nixpkgs for now, it won't affect polkadot's version as we're not using nixpkgs for that.

