### PR TITLE
feat(storage-provider): add time-based sector sealing

### DIFF
--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -55,7 +55,8 @@ rendezvous_point_address = '$P2P_ADDRESS'
 p2p_key = '@$P2P_PRIVATE_KEY'
 rendezvous_point = '$P2P_BOOTSTRAP_PEER_ID'
 [sealing_configuration]
-fill_percentage = 75" > "$CONFIG"
+fill_threshold = 80
+wait_deals_delay = '2m'" > "$CONFIG"
 
 RUST_LOG=debug target/release/polka-storage-provider-server \
     --sr25519-key "$PROVIDER" \

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -8,7 +8,15 @@
 //! the full value in seconds (90s) instead of some mix of values (1m30s); this makes it easy to
 //! maintain for us and straightforward for the user to use.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Deserializer, Serialize};
+
+/// Default amount of time to wait to seal an unfilled sector.
+const fn default_wait_deals_delay() -> Duration {
+    // 24 hours * 60 minutes * 60 seconds =
+    Duration::from_secs(24 * 60 * 60)
+}
 
 /// Returns the default fill percentage.
 const fn default_fill_threshold() -> u8 {
@@ -33,6 +41,48 @@ where
         .and_then(|percentage| validate_percentage(percentage).map_err(serde::de::Error::custom))
 }
 
+/// Parses a string in with the format `<number><prefix>`, where `<prefix>` is either
+/// `s`, `m` or `h`, for seconds, minutes and hours, respectively.
+fn duration_value_parser(src: &str) -> Result<Duration, String> {
+    /// Returns the error string for the parsing function.
+    // Scoped inside this function since it doesn't make sense outside of it.
+    #[inline(always)]
+    fn fmt_error(src: &str) -> String {
+        format!(
+            concat!(
+                "Invalid duration value: {}.",
+                "Only the \"<number><prefix>\" format is supported,",
+                "valid prefixes are \"s\", \"m\" and \"h\".",
+            ),
+            src
+        )
+    }
+    // In the case of clap, this trim is kinda useless unless the user is trying to mess with us;
+    // in the case of serde, this trim is defensive as `str::parse<u64>` does not handle spaces.
+    let src = src.trim();
+    let split_index = src.len() - 1;
+    // Try to parse the duration upfront
+    let duration = src[..split_index]
+        .parse::<u64>()
+        .map_err(|_| fmt_error(src))?;
+
+    // Look for the last character, match against the known prefixes, act accordingly.
+    Ok(match &src[split_index..] {
+        "s" => Duration::from_secs(duration),
+        "m" => Duration::from_secs(duration * 60),
+        "h" => Duration::from_secs(duration * 60 * 60),
+        _ => return Err(fmt_error(src)),
+    })
+}
+
+fn duration_deserializer<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)
+        .and_then(|duration| duration_value_parser(&duration).map_err(serde::de::Error::custom))
+}
+
 /// Configuration for the sealing process.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "clap", derive(::clap::Args))]
@@ -54,6 +104,15 @@ pub struct SealingConfiguration {
         value_parser = fill_threshold_parser
     ))]
     pub fill_threshold: u8,
+
+    /// The amount of time to wait before sealing an unfilled sector, defaults to 24 hours.
+    /// If the sector is empty, it will not be sealed.
+    #[serde(
+        default = "default_wait_deals_delay",
+        deserialize_with = "duration_deserializer"
+    )]
+    #[cfg_attr(feature = "clap", arg(long, default_value = "24h", value_parser = duration_value_parser))]
+    pub wait_deals_delay: Duration,
 }
 
 // This default is implemented for when `sealing_configuration` is missing from the config file,
@@ -64,6 +123,7 @@ impl Default for SealingConfiguration {
     fn default() -> Self {
         Self {
             fill_threshold: default_fill_threshold(),
+            wait_deals_delay: default_wait_deals_delay(),
         }
     }
 }

--- a/storage-provider/server/src/db.rs
+++ b/storage-provider/server/src/db.rs
@@ -5,7 +5,9 @@ use std::{
 
 use polka_storage_provider_common::sector::UnsealedSector;
 use primitives::sector::{SectorNumber, SectorNumberError};
-use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, Options as DBOptions, DB as RocksDB};
+use rocksdb::{
+    ColumnFamily, ColumnFamilyDescriptor, Options as DBOptions, TransactionDB, TransactionDBOptions,
+};
 use serde::{de::DeserializeOwned, Serialize};
 use storagext::types::market::{ConversionError, DealProposal};
 
@@ -37,7 +39,7 @@ const UNSEALED_SECTORS_CF: &str = "unsealed_sectors";
 const COLUMN_FAMILIES: [&str; 3] = [ACCEPTED_DEAL_PROPOSALS_CF, SECTORS_CF, UNSEALED_SECTORS_CF];
 
 pub struct DealDB {
-    database: RocksDB,
+    database: TransactionDB,
     last_sector_number: AtomicU32,
 }
 
@@ -50,12 +52,15 @@ impl DealDB {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
+        // Lock timeout of 1s by default
+        let tx_opts = TransactionDBOptions::default();
+
         let cfs = COLUMN_FAMILIES
             .into_iter()
             .map(|cf_name| ColumnFamilyDescriptor::new(cf_name, DBOptions::default()));
 
         let db = Self {
-            database: RocksDB::open_cf_descriptors(&opts, path, cfs)?,
+            database: TransactionDB::open_cf_descriptors(&opts, &tx_opts, path, cfs)?,
             last_sector_number: AtomicU32::new(0),
         };
 
@@ -206,32 +211,36 @@ impl DealDB {
         Ok(self.database.put_cf(cf_handle, key, json)?)
     }
 
-    /// Get an unsealed sector.
-    pub fn get_unsealed_sector(
+    /// Removes and returns a given [`UnsealedSector`], if it doesn't exist, returns `None`.
+    /// Locks the passed key for the duration of this operation!
+    ///
+    /// Removal is only done on success!
+    pub fn remove_unsealed_sector(
         &self,
         sector_number: SectorNumber,
     ) -> Result<Option<UnsealedSector>, DBError> {
         let cf_handle = self.cf_handle(UNSEALED_SECTORS_CF);
         let sector_number_bytes = u32::from(sector_number).to_le_bytes();
 
-        let Some(slice) = self
-            .database
-            .get_pinned_cf(cf_handle, sector_number_bytes)?
-        else {
-            return Ok(None);
+        let txn = self.database.transaction();
+
+        // Effectively *lock* the row
+        let unsealed_sector = {
+            let Some(slice) = txn.get_pinned_for_update_cf(cf_handle, sector_number_bytes, true)?
+            else {
+                return Ok(None);
+            };
+            // This serialization error *should* never happen if you didn't f-up any insert calls
+            serde_json::from_reader(slice.as_ref()).map_err(DBError::InvalidSectorData)?
         };
 
-        // This serialization error *should* never happen if you didn't f-up any insert calls
-        serde_json::from_reader(slice.as_ref())
-            .map(Some)
-            .map_err(DBError::InvalidSectorData)
-    }
+        // Delete the row
+        txn.delete_cf(cf_handle, u32::from(sector_number).to_le_bytes())
+            .map_err(DBError::from)?;
 
-    pub fn remove_unsealed_sector(&self, sector_number: SectorNumber) -> Result<(), DBError> {
-        let cf_handle = self.cf_handle(UNSEALED_SECTORS_CF);
-        self.database
-            .delete_cf(cf_handle, u32::from(sector_number).to_le_bytes())
-            .map_err(DBError::from)
+        txn.commit()?;
+
+        Ok(Some(unsealed_sector))
     }
 
     /// Iterator over unsealed sectors.

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -94,8 +94,10 @@ fn main() -> Result<(), ServerError> {
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     tracing_subscriber::registry()
-        .with(fmt::layer())
+        // File appender *MUST* go first, otherwise `with_ansi` isn't respected
+        // More info: https://github.com/tokio-rs/tracing/issues/3089
         .with(fmt::layer().with_ansi(false).with_writer(non_blocking))
+        .with(fmt::layer())
         .with(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::INFO.into())

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -21,6 +21,7 @@ use tokio::sync::{
     Mutex, Semaphore,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::Instrument;
 use types::{
     AddPieceMessage, PipelineMessage, PreCommitMessage, ProveCommitMessage,
     SubmitWindowedPoStMessage,
@@ -48,6 +49,8 @@ pub enum PipelineError {
     SchedulingError,
     #[error("Custom error: {0}")]
     CustomError(String),
+    #[error(transparent)]
+    JoinError(#[from] tokio::task::JoinError),
 }
 /// Pipeline shared state.
 pub struct PipelineState {
@@ -139,10 +142,11 @@ impl PipelineOperations for TaskTracker {
             piece_path,
             commitment,
         } = msg;
+        let tracker = self.clone();
         self.spawn(async move {
             tokio::select! {
                 // AddPiece is cancellation safe, as it can be retried and the state will be fine.
-                res = add_piece(state, piece_path, commitment, deal, published_deal_id) => {
+                res = add_piece(tracker, state, piece_path, commitment, deal, published_deal_id) => {
                     match res {
                         Ok(_) => tracing::info!("Add Piece for piece {}, deal id {}, finished successfully.", commitment, published_deal_id),
                         Err(err) => tracing::error!(%err, "Add Piece for piece {}, deal id {}, failed!", commitment, published_deal_id),
@@ -263,7 +267,8 @@ fn process(
     }
 }
 
-/// Finds or creates a sector for the given piece.
+/// Finds or creates a sector for the given piece. Returns the [`UnsealedSector`] and a `bool`
+/// indicating if the sector was created or not.
 ///
 /// * If no sectors exist, it creates one and returns it.
 /// * If no sectors with enough size to harbor the piece exist, it creates one and returns it.
@@ -272,7 +277,7 @@ fn process(
 async fn find_or_create_sector_for_piece(
     state: &Arc<PipelineState>,
     deal: &DealProposal, // We pass the DealProposal instead of the sector number for better logs
-) -> Result<UnsealedSector, PipelineError> {
+) -> Result<(UnsealedSector, bool), PipelineError> {
     tracing::debug!(
         "Searching for sector for piece with size: {}",
         deal.piece_size
@@ -292,14 +297,17 @@ async fn find_or_create_sector_for_piece(
     // NOTE(@jmg-duarte,03/02/2025): we can't keep creating sectors forever just because they dont fit
     // (or maybe we can) but FC keeps a limit on new sectors, I don't have a solution for this NOW
     // but we can keep this here while this implementation develops
+    // (possible) SOLUTION: pre-check sector availability when receiving deals and decide there
+    // whether we're taking the deal or not
     if let Some(sector) = sector {
         // NOTE(@jmg-duarte,03/02/2025): as per our filter, errors return false, as such an error couldn't be returned
         return sector
-            .inspect(|sector| {
+            .map(|sector| {
                 tracing::debug!(
                     sector_number = %sector.sector_number,
                     "Found sector for piece!",
                 );
+                (sector, false)
             })
             .map_err(PipelineError::from);
     }
@@ -318,7 +326,7 @@ async fn find_or_create_sector_for_piece(
     let sector =
         UnsealedSector::create(state.server_info.seal_proof, sector_number, unsealed_path).await?;
 
-    Ok(sector)
+    Ok((sector, true))
 }
 
 /// Finds a sector to which a piece will fit and adds it to the sector.
@@ -327,31 +335,33 @@ async fn find_or_create_sector_for_piece(
 /// When dropped when waiting, the sector state won't be preserved and adding piece can be retried.
 #[tracing::instrument(skip(state, deal, commitment))]
 async fn add_piece(
+    tracker: TaskTracker,
     state: Arc<PipelineState>,
     piece_path: PathBuf,
     commitment: Commitment<CommP>,
     deal: DealProposal,
     deal_id: u64,
 ) -> Result<(), PipelineError> {
-    // Mutex scope
-    let sector = {
-        let _guard = state.add_piece_serializer.lock().await;
+    // This guard MUST be scoped to the entire add_piece logic!
+    // Otherwise, depending on the fill percentage it can happen that two tasks try to send
+    // pre_commit messages that would later result in processing issues.
+    // Given a fill_threshold that is low enough, without a lock on this entire method,
+    // if two pieces are added past the fill threshold, two pre commit messages will be sent
+    // which will then race and create issues
+    let _guard = state.add_piece_serializer.lock().await;
 
-        tracing::info!("Adding a piece...");
-        let mut sector = find_or_create_sector_for_piece(&state, &deal).await?;
+    tracing::info!("Adding a piece...");
+    let (mut sector, created) = find_or_create_sector_for_piece(&state, &deal).await?;
 
-        sector
-            .add_piece(deal_id, deal, piece_path, commitment)
-            .await?;
-        tracing::info!("Finished adding a piece");
+    sector
+        .add_piece(deal_id, deal, piece_path, commitment)
+        .await?;
+    tracing::info!("Finished adding a piece");
 
-        // Update the database with the latest sector information
-        state
-            .db
-            .insert_unsealed_sector(sector.sector_number, &sector)?;
-
-        sector
-    };
+    // Update the database with the latest sector information
+    state
+        .db
+        .insert_unsealed_sector(sector.sector_number, &sector)?;
 
     let fill_percentage = sector.fill_percentage();
     let fill_threshold = state.server_info.sealing_configuration.fill_threshold as u64;
@@ -363,42 +373,84 @@ async fn add_piece(
         );
         // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
         // Ideally sector won't be finalized after one piece has been added and the precommit will depend on the start_block?
-        state
+        return Ok(state
             .pipeline_sender
             .send(PipelineMessage::PreCommit(PreCommitMessage {
                 sector_number: sector.sector_number,
-            }))?;
-    } else {
-        tracing::debug!(
-            sector_number = %sector.sector_number,
-            "Occupation at {}; not pre-committing yet",
-            fill_percentage
-        );
+            }))?);
+    }
+    tracing::debug!(
+        sector_number = %sector.sector_number,
+        "Occupation at {}; not pre-committing yet",
+        fill_percentage
+    );
+
+    // If the sector is new, we schedule it's pre-commit task submission
+    if created {
+        schedule_pre_commit(state.clone(), tracker, sector);
     }
 
     Ok(())
 }
 
-#[tracing::instrument(skip(state))]
+fn schedule_pre_commit(state: Arc<PipelineState>, tracker: TaskTracker, sector: UnsealedSector) {
+    let delay = state.server_info.sealing_configuration.wait_deals_delay;
+    let span = tracing::info_span!("add_piece");
+    tracing::info!(
+        // Since the span is moved for the instrument call, we can't span.enter()
+        // doing a span.in_scope(|| ...) is also a bit overkill for a log
+        parent: &span,
+        "Sector was created, launching task to pre-commit in {} seconds",
+        delay.as_secs()
+    );
+    // We don't care for the returned JoinHandle, but that's ok because the TaskTracker has it!
+    let _ = tracker.spawn(
+        async move {
+            tokio::time::sleep(delay).await;
+            let sector_number = sector.sector_number;
+            tracing::info!(%sector_number, "Awoken from sleep, submitting pre-commit task!");
+            match state
+                .pipeline_sender
+                .send(PipelineMessage::pre_commit(sector_number))
+            {
+                Ok(()) => tracing::info!(%sector_number, "Successfully submitted task!"),
+                // Not sure what we can do if the task fails, maybe try to re-submit?
+                // Not even sure when this can happen asides from an OOM since we're using an unbounded channel
+                Err(err) => tracing::error!(%sector_number, "Failed to submit task: {}", err),
+            }
+        }
+        .instrument(span),
+    );
+}
+
 /// Creates a replica and calls pre-commit on-chain.
 ///
 /// This method is *NOT CANCELLATION SAFE*.
 /// When interrupted while waiting for the extrinsic call to return,
 /// the Storage Provider is not consistent of the on-chain state,
 /// cancelling this task effectively breaks the state sync.
+#[tracing::instrument(skip(state))]
 async fn precommit(
     state: Arc<PipelineState>,
     sector_number: SectorNumber,
 ) -> Result<(), PipelineError> {
     tracing::info!("Starting pre-commit");
 
-    let Some(sector) = state.db.get_unsealed_sector(sector_number)? else {
-        tracing::error!("Tried to precommit non-existing sector");
-        return Err(PipelineError::SectorNotFound);
-    };
-
-    // We could probably move this down the line, to ensure some kind of durability
-    state.db.remove_unsealed_sector(sector_number)?;
+    // This unit of work effectively works as a "block", since `remove_unsealed_sector`
+    // blocks the row it removes, meaning that even if two tasks race here,
+    // the DB will stop one from doing an outdated read
+    let state_for_task = state.clone();
+    let sector = tokio::task::spawn_blocking(move || {
+        match state_for_task.db.remove_unsealed_sector(sector_number)? {
+            Some(sector) => return Ok(sector),
+            None => {
+                // This is a partial error since the sector may *just* have been pre-committed
+                tracing::warn!(%sector_number, "Tried to precommit non-existing unsealed sector");
+                return Err(PipelineError::SectorNotFound);
+            }
+        }
+    })
+    .await??;
 
     let cache_dir_path = state.sealing_cache_dir.join(sector_number.to_string());
     let sealed_path = state.sealed_sectors_dir.join(sector_number.to_string());

--- a/storage-provider/server/src/pipeline/types.rs
+++ b/storage-provider/server/src/pipeline/types.rs
@@ -21,6 +21,12 @@ pub enum PipelineMessage {
     SchedulePoSts,
 }
 
+impl PipelineMessage {
+    pub fn pre_commit(sector_number: SectorNumber) -> Self {
+        Self::PreCommit(PreCommitMessage { sector_number })
+    }
+}
+
 /// Deal to be added to a sector with its contents.
 #[derive(Debug)]
 pub struct AddPieceMessage {


### PR DESCRIPTION
### Description

Adds time-based sector sealing.

Schedules the Pre-Commit for later, when "later" arrives, tries to pre-commit.
The database keeps the source of truth for this operation.

Up next will be to consider the start block in the deals.

### Checklist

- [x] Make sure that you described what this change does.
- [x] Have you tested this solution?
- [x] Were there any alternative implementations considered?
- [x] Did you document new (or modified) APIs?
