### PR TITLE
feat(storage-provider): add sealing configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13896,6 +13896,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "cid 0.11.1",
+ "clap",
  "filecoin-hashers",
  "filecoin-proofs",
  "fr32",

--- a/storage-provider/common/Cargo.toml
+++ b/storage-provider/common/Cargo.toml
@@ -29,6 +29,8 @@ tokio = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 
+clap = { workspace = true, features = ["derive"], optional = true }
+
 [dev-dependencies]
 filecoin-proofs.workspace = true
 

--- a/storage-provider/common/src/config/mod.rs
+++ b/storage-provider/common/src/config/mod.rs
@@ -1,0 +1,1 @@
+pub mod sealing;

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -1,0 +1,79 @@
+//! Configuration for the the sealing pipeline.
+//!
+//! `clap` and `serde` compatible.
+//!
+//! Contains custom parsers for both `clap` and `serde`, the custom parsers ensure a better UX
+//! for both error reporting as well as providing friendlier formats. The duration format is very
+//! simple on purpose — for example, if the user needs second-level granularity, they should specify
+//! the full value in seconds (90s) instead of some mix of values (1m30s); this makes it easy to
+//! maintain for us and straightforward for the user to use.
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Returns the default fill percentage.
+const fn default_fill_percentage() -> u8 {
+    95
+}
+
+fn validate_percentage(percentage: u8) -> Result<u8, String> {
+    if percentage > 100 {
+        return Err(format!(
+            "percentage value must be between 0 and 100, got {} instead",
+            percentage
+        ));
+    }
+    Ok(percentage)
+}
+
+fn fill_percentage_deserializer<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    u8::deserialize(deserializer)
+        .and_then(|percentage| validate_percentage(percentage).map_err(serde::de::Error::custom))
+}
+
+/// Configuration for the sealing process.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "clap", derive(::clap::Args))]
+pub struct SealingConfiguration {
+    /// The percentage above which a sector is considered "full", defaults to 95% of the registered
+    /// sector size.
+    ///
+    /// Lower values will inevitably waste space, however, for smaller sector values, this enables
+    /// sectors not to wait long for "the perfect piece"; alternatively, keep this value at 100%
+    /// while lowering [`wait_deals_delay`](`Self::wait_deals_delay`).
+    #[serde(
+        default = "default_fill_percentage",
+        // The custom serializer enables custom validations
+        deserialize_with = "fill_percentage_deserializer"
+    )]
+    #[cfg_attr(feature = "clap", arg(
+        long,
+        default_value_t = default_fill_percentage(),
+        value_parser = fill_percentage_parser
+    ))]
+    pub fill_percentage: u8,
+}
+
+// This default is implemented for when `sealing_configuration` is missing from the config file,
+// this is necessary since `serde` behaves differently in the face of `{ sealing: {} }` and `{}`,
+// the former is able to use the configuration defaults defined inside the structure while the
+// latter is only able to use the `Default` implementation.
+impl Default for SealingConfiguration {
+    fn default() -> Self {
+        Self {
+            fill_percentage: default_fill_percentage(),
+        }
+    }
+}
+
+/// Parses an integer between 0 and 100, values outside the range are considered invalid
+/// and return an error.
+#[cfg(feature = "clap")]
+fn fill_percentage_parser(src: &str) -> Result<u8, String> {
+    src.trim()
+        .parse::<u8>()
+        .map_err(|err| err.to_string())
+        .and_then(validate_percentage)
+}

--- a/storage-provider/common/src/lib.rs
+++ b/storage-provider/common/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::unwrap_used)]
 
 pub mod commp;
+pub mod config;
 pub mod deadline;
 pub mod rpc;
 pub mod sector;

--- a/storage-provider/common/src/rpc/mod.rs
+++ b/storage-provider/common/src/rpc/mod.rs
@@ -14,6 +14,7 @@ use storagext::types::market::{
 };
 use subxt::ext::sp_core::crypto::Ss58Codec;
 
+use crate::config::sealing::SealingConfiguration;
 pub use crate::rpc::error::RpcError;
 
 #[rpc(server, client, namespace = "v0")]
@@ -51,6 +52,8 @@ pub struct ServerInfo {
 
     pub post_proof: RegisteredPoStProof,
     pub proving_period_start: u64,
+
+    pub sealing_configuration: SealingConfiguration,
 }
 
 impl ServerInfo {
@@ -60,6 +63,7 @@ impl ServerInfo {
         seal_proof: RegisteredSealProof,
         post_proof: RegisteredPoStProof,
         proving_period_start: u64,
+        sealing_configuration: SealingConfiguration,
     ) -> Self {
         Self {
             start_time: Utc::now(),
@@ -67,6 +71,7 @@ impl ServerInfo {
             seal_proof,
             post_proof,
             proving_period_start,
+            sealing_configuration,
         }
     }
 }

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -15,7 +15,7 @@ delia = []
 # "Homegrown" crates
 mater = { workspace = true }
 polka-storage-proofs = { workspace = true, features = ["std", "substrate"] }
-polka-storage-provider-common = { workspace = true }
+polka-storage-provider-common = { workspace = true, features = ["clap"] }
 primitives = { workspace = true, features = ["clap", "serde", "std"] }
 storagext = { workspace = true, features = ["clap"] }
 

--- a/storage-provider/server/src/config.rs
+++ b/storage-provider/server/src/config.rs
@@ -6,6 +6,7 @@ use std::{
 
 use clap::Args;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
+use polka_storage_provider_common::config::sealing::SealingConfiguration;
 use primitives::proofs::{RegisteredPoStProof, RegisteredSealProof};
 use serde::Deserialize;
 use url::Url;
@@ -135,4 +136,8 @@ pub struct ConfigurationArgs {
     #[serde(default = "default_registration_ttl")]
     #[arg(long, default_value_t = DEFAULT_REGISTRATION_TTL, required = false)]
     pub(crate) registration_ttl: u64,
+
+    #[clap(flatten)]
+    #[serde(default)]
+    pub(crate) sealing_configuration: SealingConfiguration,
 }

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -23,7 +23,7 @@ use polka_storage_proofs::{
     porep::{self, PoRepParameters},
     post::{self, PoStParameters},
 };
-use polka_storage_provider_common::rpc::ServerInfo;
+use polka_storage_provider_common::{config::sealing::SealingConfiguration, rpc::ServerInfo};
 use primitives::proofs::{RegisteredPoStProof, RegisteredSealProof};
 use rand::Rng;
 use storagext::{
@@ -276,6 +276,9 @@ pub struct Server {
 
     /// TTL of the p2p registration in seconds
     registration_ttl: u64,
+
+    /// Sealing parameters (e.g. how long to wait before sealing).
+    sealing_configuration: SealingConfiguration,
 }
 
 impl TryFrom<ServerCli> for Server {
@@ -358,6 +361,7 @@ impl TryFrom<ServerCli> for Server {
             rendezvous_point_address: args.rendezvous_point_address,
             rendezvous_point: args.rendezvous_point,
             registration_ttl: args.registration_ttl,
+            sealing_configuration: args.sealing_configuration,
         })
     }
 }
@@ -458,6 +462,7 @@ impl Server {
                 self.seal_proof,
                 self.post_proof,
                 storage_provider_info.proving_period_start,
+                self.sealing_configuration,
             ),
             deal_db: deal_database.clone(),
             car_piece_storage_dir: car_piece_storage_dir.clone(),

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -28,10 +28,6 @@ use types::{
 
 use crate::db::{DBError, DealDB};
 
-/// Size percentage to seal and pre-commit a sector.
-// NOTE(@jmg-duarte,05/02/2025): this is a placeholder until the time-based approach is done
-const OCCUPATION_FACTOR: u64 = 75;
-
 #[derive(Debug, thiserror::Error)]
 pub enum PipelineError {
     #[error(transparent)]
@@ -328,11 +324,12 @@ async fn add_piece(
 
     // TODO: break maat to ensure this works, probably using a small file in the 8mb thing works
     let occupation_percent = sector.occupation_percent();
-    if occupation_percent > OCCUPATION_FACTOR {
+    let fill_threshold = state.server_info.sealing_configuration.fill_percentage as u64;
+    if occupation_percent > fill_threshold {
         tracing::debug!(
             "Occupation above {} > {}%; pre-committing",
             occupation_percent,
-            OCCUPATION_FACTOR,
+            fill_threshold,
         );
         // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
         // Ideally sector won't be finalized after one piece has been added and the precommit will depend on the start_block?


### PR DESCRIPTION
### Description

Blocked by #732 

Basically replaces the `OCCUPATION_FACTOR` with a configuration.
Smaller PR to prepare the bigger time based one — #733 

### Checklist


- [x] Make sure that you described what this change does.
- [x] Have you tested this solution?
- [x] Were there any alternative implementations considered?
- [x] Did you document new (or modified) APIs?
