### PR TITLE
fix(storage-provider): concurrency & logic bugs in add_piece

### DIFF
--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -42,7 +42,10 @@ echo '{
     "porep_parameters": "2KiB.porep.params",
     "post_parameters": "2KiB.post.params",
     "p2p_key": "@/tmp/private.pem",
-    "rendezvous_point_address": "/ip4/127.0.0.1/tcp/62649"
+    "rendezvous_point_address": "/ip4/127.0.0.1/tcp/62649",
+    "sealing_configuration": {
+        "fill_percentage": 75
+    }
 }' > /tmp/storage_provider.config.json
 RUST_LOG=debug target/release/polka-storage-provider-server \
     --sr25519-key "$PROVIDER" \

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -11,7 +11,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Returns the default fill percentage.
-const fn default_fill_percentage() -> u8 {
+const fn default_fill_threshold() -> u8 {
     95
 }
 
@@ -25,7 +25,7 @@ fn validate_percentage(percentage: u8) -> Result<u8, String> {
     Ok(percentage)
 }
 
-fn fill_percentage_deserializer<'de, D>(deserializer: D) -> Result<u8, D::Error>
+fn fill_threshold_deserializer<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -44,16 +44,16 @@ pub struct SealingConfiguration {
     /// sectors not to wait long for "the perfect piece"; alternatively, keep this value at 100%
     /// while lowering [`wait_deals_delay`](`Self::wait_deals_delay`).
     #[serde(
-        default = "default_fill_percentage",
+        default = "default_fill_threshold",
         // The custom serializer enables custom validations
-        deserialize_with = "fill_percentage_deserializer"
+        deserialize_with = "fill_threshold_deserializer"
     )]
     #[cfg_attr(feature = "clap", arg(
         long,
-        default_value_t = default_fill_percentage(),
-        value_parser = fill_percentage_parser
+        default_value_t = default_fill_threshold(),
+        value_parser = fill_threshold_parser
     ))]
-    pub fill_percentage: u8,
+    pub fill_threshold: u8,
 }
 
 // This default is implemented for when `sealing_configuration` is missing from the config file,
@@ -63,7 +63,7 @@ pub struct SealingConfiguration {
 impl Default for SealingConfiguration {
     fn default() -> Self {
         Self {
-            fill_percentage: default_fill_percentage(),
+            fill_threshold: default_fill_threshold(),
         }
     }
 }
@@ -71,7 +71,7 @@ impl Default for SealingConfiguration {
 /// Parses an integer between 0 and 100, values outside the range are considered invalid
 /// and return an error.
 #[cfg(feature = "clap")]
-fn fill_percentage_parser(src: &str) -> Result<u8, String> {
+fn fill_threshold_parser(src: &str) -> Result<u8, String> {
     src.trim()
         .parse::<u8>()
         .map_err(|err| err.to_string())

--- a/storage-provider/common/src/sector.rs
+++ b/storage-provider/common/src/sector.rs
@@ -263,6 +263,11 @@ impl UnsealedSector {
         .await?)
     }
 
+    /// Returns the free space in the sector.
+    pub fn free_space(&self) -> u64 {
+        self.seal_proof.sector_size().bytes() - self.occupied_sector_space
+    }
+
     /// Returns the percentage of occupied space.
     pub fn occupation_percent(&self) -> u64 {
         (self.occupied_sector_space * 100) / self.seal_proof.sector_size().bytes()

--- a/storage-provider/common/src/sector.rs
+++ b/storage-provider/common/src/sector.rs
@@ -269,7 +269,7 @@ impl UnsealedSector {
     }
 
     /// Returns the percentage of occupied space.
-    pub fn occupation_percent(&self) -> u64 {
+    pub fn fill_percentage(&self) -> u64 {
         (self.occupied_sector_space * 100) / self.seal_proof.sector_size().bytes()
     }
 }

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -36,7 +36,7 @@ use storagext::{
 };
 use subxt::{self, tx::Signer};
 use tokio::{
-    sync::{mpsc::UnboundedReceiver, Semaphore},
+    sync::{mpsc::UnboundedReceiver, Mutex, Semaphore},
     task::{JoinError, JoinHandle},
 };
 use tokio_util::sync::CancellationToken;
@@ -93,12 +93,12 @@ struct SetupOutput {
 
 fn main() -> Result<(), ServerError> {
     // Logger initialization.
-    let file_appender = tracing_appender::rolling::daily("logs", "sp_server");
+    let file_appender = tracing_appender::rolling::daily("logs", "sp_server.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     tracing_subscriber::registry()
         .with(fmt::layer())
-        .with(fmt::layer().with_writer(non_blocking).with_ansi(false))
+        .with(fmt::layer().with_ansi(false).with_writer(non_blocking))
         .with(
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::INFO.into())
@@ -484,6 +484,7 @@ impl Server {
             xt_keypair: self.multi_pair_signer,
             pipeline_sender: pipeline_tx,
             prove_commit_throttle: Arc::new(Semaphore::new(self.parallel_prove_commits)),
+            add_piece_serializer: Mutex::new(()),
         };
 
         let p2p_state = P2PState {

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -18,7 +18,7 @@ use primitives::{
 use storagext::{types::market::DealProposal, StorageProviderClientExt};
 use tokio::sync::{
     mpsc::{error::SendError, UnboundedReceiver, UnboundedSender},
-    Semaphore,
+    Mutex, Semaphore,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use types::{
@@ -63,6 +63,19 @@ pub struct PipelineState {
     pub xt_keypair: storagext::multipair::MultiPairSigner,
     pub pipeline_sender: UnboundedSender<PipelineMessage>,
     pub prove_commit_throttle: Arc<Semaphore>,
+
+    // NOTE(@jmg-duarte,10/02/2025):
+    // This is the wrong way of implementing serialization for `add_piece`!
+    // However, the right way involves a major refactor :(
+    //
+    // To improve on this, `add_piece` needs it's own task and a message queue to ensure it
+    // can't act on more than a single message at a time; instead of a new task being spawned for
+    // each incoming add_piece request.
+    //
+    // To have multiple add_piece running concurrently, we need to make use of RocksDB's
+    // transactions + get_for_update(exclusive: true)
+    // This is not trivial and requires a refactor on the DB side!
+    pub add_piece_serializer: Mutex<()>,
 }
 
 #[tracing::instrument(skip_all)]
@@ -236,7 +249,9 @@ fn process(
     token: CancellationToken,
 ) {
     match msg {
-        PipelineMessage::AddPiece(msg) => tracker.add_piece(state.clone(), msg, token.clone()),
+        PipelineMessage::AddPiece(msg) => {
+            tracker.add_piece(state.clone(), msg, token.clone());
+        }
         PipelineMessage::PreCommit(msg) => tracker.precommit(state.clone(), msg),
         PipelineMessage::ProveCommit(msg) => {
             tracker.prove_commit(state.clone(), msg, token.clone())
@@ -256,12 +271,19 @@ fn process(
 #[tracing::instrument(skip_all)]
 async fn find_or_create_sector_for_piece(
     state: &Arc<PipelineState>,
-    piece_size: u64,
+    deal: &DealProposal, // We pass the DealProposal instead of the sector number for better logs
 ) -> Result<UnsealedSector, PipelineError> {
-    tracing::debug!("Searching for sector for piece with size: {}", piece_size);
+    tracing::debug!(
+        "Searching for sector for piece with size: {}",
+        deal.piece_size
+    );
     // Find the first sector with enough space for the piece
     let sector = state.db.iter_unsealed_sectors().find(|res| match res {
-        Ok(unsealed_sector) => unsealed_sector.occupied_sector_space > piece_size,
+        Ok(unsealed_sector) => {
+            let free_space = unsealed_sector.free_space();
+            tracing::debug!(sector_number = %unsealed_sector.sector_number, free_space = free_space, "Checking sector...");
+            free_space > deal.piece_size
+        },
         // Errors return false since, well, they're not valid sectors
         _ => false,
     });
@@ -276,7 +298,7 @@ async fn find_or_create_sector_for_piece(
             .inspect(|sector| {
                 tracing::debug!(
                     sector_number = %sector.sector_number,
-                    "Found sector for piece"
+                    "Found sector for piece!",
                 );
             })
             .map_err(PipelineError::from);
@@ -290,6 +312,8 @@ async fn find_or_create_sector_for_piece(
         .db
         .next_sector_number()
         .map_err(|err| PipelineError::CustomError(err.to_string()))?;
+    tracing::debug!(%sector_number, "Could not find a sector for piece, creating a new one...");
+
     let unsealed_path = state.unsealed_sectors_dir.join(sector_number.to_string());
     let sector =
         UnsealedSector::create(state.server_info.seal_proof, sector_number, unsealed_path).await?;
@@ -309,25 +333,31 @@ async fn add_piece(
     deal: DealProposal,
     deal_id: u64,
 ) -> Result<(), PipelineError> {
-    tracing::info!("Adding a piece...");
-    let mut sector = find_or_create_sector_for_piece(&state, deal.piece_size).await?;
+    // Mutex scope
+    let sector = {
+        let _guard = state.add_piece_serializer.lock().await;
 
-    sector
-        .add_piece(deal_id, deal, piece_path, commitment)
-        .await?;
-    tracing::info!("Finished adding a piece");
+        tracing::info!("Adding a piece...");
+        let mut sector = find_or_create_sector_for_piece(&state, &deal).await?;
 
-    // Update the database with the latest sector information
-    state
-        .db
-        .insert_unsealed_sector(sector.sector_number, &sector)?;
+        sector
+            .add_piece(deal_id, deal, piece_path, commitment)
+            .await?;
+        tracing::info!("Finished adding a piece");
 
-    // TODO: break maat to ensure this works, probably using a small file in the 8mb thing works
+        // Update the database with the latest sector information
+        state
+            .db
+            .insert_unsealed_sector(sector.sector_number, &sector)?;
+
+        sector
+    };
+
     let occupation_percent = sector.occupation_percent();
     let fill_threshold = state.server_info.sealing_configuration.fill_percentage as u64;
-    if occupation_percent > fill_threshold {
+    if sector.occupation_percent() > fill_threshold {
         tracing::debug!(
-            "Occupation above {} > {}%; pre-committing",
+            "Occupation level at {}%, above limit of {}% - pre-committing",
             occupation_percent,
             fill_threshold,
         );

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -353,12 +353,12 @@ async fn add_piece(
         sector
     };
 
-    let occupation_percent = sector.occupation_percent();
-    let fill_threshold = state.server_info.sealing_configuration.fill_percentage as u64;
-    if sector.occupation_percent() > fill_threshold {
+    let fill_percentage = sector.fill_percentage();
+    let fill_threshold = state.server_info.sealing_configuration.fill_threshold as u64;
+    if fill_percentage > fill_threshold {
         tracing::debug!(
             "Occupation level at {}%, above limit of {}% - pre-committing",
-            occupation_percent,
+            fill_percentage,
             fill_threshold,
         );
         // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
@@ -372,7 +372,7 @@ async fn add_piece(
         tracing::debug!(
             sector_number = %sector.sector_number,
             "Occupation at {}; not pre-committing yet",
-            occupation_percent
+            fill_percentage
         );
     }
 


### PR DESCRIPTION
### Description

Fixes a BIG logic bug in the find sector logic & fixes a concurrency bug/issue in the overall process for add piece.

Blocking #733 

To test, apply the following change to `start_sp.sh`

```diff
diff --git a/examples/start_sp.sh b/examples/start_sp.sh
index eca6231d..b1ac1e31 100755
--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -31,16 +31,16 @@ wait
 # It's a test setup based on the local verifying keys, everyone can run those extrinsics currently.
 # Each of the keys is different, because the processes are running in parallel.
 # If they were running in parallel on the same account, they'd conflict with each other on the transaction nonce.
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Charlie" storage-provider register "$PEER_ID" &
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Alice" proofs set-porep-verifying-key @2KiB.porep.vk.scale &
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Bob" proofs set-post-verifying-key @2KiB.post.vk.scale &
+RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Charlie" storage-provider register --post-proof 8MiB "$PEER_ID" &
+RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Alice" proofs set-porep-verifying-key @8MiB.porep.vk.scale &
+RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Bob" proofs set-post-verifying-key @8MiB.post.vk.scale &
 wait
 
 echo '{
-    "seal_proof": "2KiB",
-    "post_proof": "2KiB",
-    "porep_parameters": "2KiB.porep.params",
-    "post_parameters": "2KiB.post.params",
+    "seal_proof": "8MiB",
+    "post_proof": "8MiB",
+    "porep_parameters": "8MiB.porep.params",
+    "post_parameters": "8MiB.post.params",
     "p2p_key": "@/tmp/private.pem",
     "rendezvous_point_address": "/ip4/127.0.0.1/tcp/62649",
     "sealing_configuration": {
```

And run `examples/rpc_publish_multiple_sectors.sh` with a file (for easier testing) around ~3MB

### Checklist

- [x] Have you tested this solution?
- [x] Did you document new (or modified) APIs?
