### PR TITLE
feat: Implement p2p bootstrap improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13962,6 +13962,7 @@ dependencies = [
 name = "polka-storage-provider-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bls12_381",
  "cid 0.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13962,7 +13962,6 @@ dependencies = [
 name = "polka-storage-provider-client"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bls12_381",
  "cid 0.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor4ii"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472931dd4dfcc785075b09be910147f9c6258883fc4591d0dac6116392b2daa6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6059,6 +6068,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-ticker"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "instant",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6414,6 +6434,12 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -7964,6 +7990,7 @@ dependencies = [
  "libp2p-connection-limits 0.4.0",
  "libp2p-core 0.42.0",
  "libp2p-dns 0.42.0",
+ "libp2p-gossipsub",
  "libp2p-identify 0.45.0",
  "libp2p-identity",
  "libp2p-mdns 0.46.0",
@@ -7971,6 +7998,7 @@ dependencies = [
  "libp2p-noise 0.45.0",
  "libp2p-quic 0.11.1",
  "libp2p-rendezvous",
+ "libp2p-request-response 0.27.0",
  "libp2p-swarm 0.45.1",
  "libp2p-tcp 0.42.0",
  "libp2p-upnp 0.3.0",
@@ -8115,6 +8143,37 @@ dependencies = [
  "parking_lot 0.12.3",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
+dependencies = [
+ "asynchronous-codec 0.7.0",
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-ticker",
+ "getrandom",
+ "hex_fmt",
+ "libp2p-core 0.42.0",
+ "libp2p-identity",
+ "libp2p-swarm 0.45.1",
+ "prometheus-client 0.22.3",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.3.1",
+ "rand",
+ "regex",
+ "sha2 0.10.8",
+ "smallvec",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]
@@ -8279,6 +8338,7 @@ checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
 dependencies = [
  "futures",
  "libp2p-core 0.42.0",
+ "libp2p-gossipsub",
  "libp2p-identify 0.45.0",
  "libp2p-identity",
  "libp2p-swarm 0.45.1",
@@ -8453,6 +8513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
 dependencies = [
  "async-trait",
+ "cbor4ii 0.3.3",
  "futures",
  "futures-bounded 0.2.4",
  "futures-timer",
@@ -8460,6 +8521,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm 0.45.1",
  "rand",
+ "serde",
  "smallvec",
  "tracing",
  "void",
@@ -13812,6 +13874,7 @@ dependencies = [
 name = "polka-storage-node"
 version = "0.0.0"
 dependencies = [
+ "bincode",
  "clap",
  "color-print",
  "cumulus-client-cli",
@@ -13868,6 +13931,7 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "thiserror 2.0.8",
+ "tokio",
 ]
 
 [[package]]
@@ -19424,7 +19488,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded35fbe4ab8fdec1f1d14b4daff2206b1eada4d6e708cb451d464d2d965f493"
 dependencies = [
- "cbor4ii",
+ "cbor4ii 0.2.14",
  "ipld-core",
  "scopeguard",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13874,7 +13874,6 @@ dependencies = [
 name = "polka-storage-node"
 version = "0.0.0"
 dependencies = [
- "bincode",
  "clap",
  "color-print",
  "cumulus-client-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ async-trait = "0.1.80"
 axum = "0.7.5"
 base64 = "0.22.1"
 beetswap = "0.4.0"
+bincode = "1.3.3"
 bitflags = "2.5.0"
 blake2b_simd = { version = "1.0.2", default-features = false }
 blockstore = "0.7.1"

--- a/Justfile
+++ b/Justfile
@@ -28,9 +28,16 @@ release-testnet:
 # run the testnet without building
 run-testnet:
     mkdir -p /tmp/zombienet
-    openssl genpkey -algorithm ED25519 -out /tmp/zombienet/private.pem
-    openssl pkey -in /tmp/zombienet/private.pem -pubout -out /tmp/zombienet/public.pem # Generate public key so script can get the Peer ID
+    openssl genpkey -algorithm ED25519 -out /tmp/zombienet/charlie-private.pem
+    openssl pkey -in /tmp/zombienet/charlie-private.pem -pubout -out /tmp/zombienet/charlie-public.pem # Generate public key so script can get the Peer ID
     zombienet -p native spawn zombienet/local-testnet.toml
+
+# Run a single collator
+run-collator:
+    mkdir -p /tmp/zombienet
+    openssl genpkey -algorithm ED25519 -out /tmp/zombienet/david-private.pem
+    openssl pkey -in /tmp/zombienet/david-private.pem -pubout -out /tmp/zombienet/david-public.pem # Generate public key so script can get the Peer ID
+    zombienet -p native spawn zombienet/local-david-collator.toml
 
 # Run the testing building it before
 testnet: release-testnet run-testnet
@@ -165,8 +172,8 @@ load-to-minikube:
 
 kube-testnet:
     mkdir -p /tmp/zombienet
-    openssl genpkey -algorithm ED25519 -out /tmp/zombienet/private.pem
-    openssl pkey -in /tmp/zombienet/private.pem -pubout -out /tmp/zombienet/public.pem # Generate public key so script can get the Peer ID
+    openssl genpkey -algorithm ED25519 -out /tmp/zombienet/charlie-private.pem
+    openssl pkey -in /tmp/zombienet/charlie-private.pem -pubout -out /tmp/zombienet/charlie-public.pem # Generate public key so script can get the Peer ID
     zombienet -p kubernetes spawn zombienet/local-kube-testnet.toml
 
 # The tarpaulin calls for test coverage have the following options:

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -13,7 +13,7 @@ PROVIDER="//Charlie"
 P2P_ADDRESS="/ip4/127.0.0.1/tcp/62649"
 P2P_PUBLIC_KEY="/tmp/polka-storage-provider/public.pem"
 P2P_PRIVATE_KEY="/tmp/polka-storage-provider/private.pem"
-P2P_BOOTSTRAP_PUBLIC_KEY="/tmp/zombienet/public.pem"
+P2P_BOOTSTRAP_PUBLIC_KEY="/tmp/zombienet/charlie-public.pem"
 # Config file location
 CONFIG="/tmp/polka-storage-provider/config.toml"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -47,7 +47,7 @@ libp2p = { workspace = true, features = [
   "tokio",
   "yamux",
 ] }
-log = { workspace = true, default-features = true }
+log = { workspace = true, features = ["kv"], default-features = true }
 pallet-transaction-payment-rpc = { workspace = true, default-features = true }
 polkadot-cli = { features = ["rococo-native"], workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,7 @@ name = "polka-storage-node"
 polka-storage-runtime.workspace = true
 primitives = { workspace = true, features = ["std"] }
 
+bincode = { workspace = true }
 clap = { features = ["derive"], workspace = true }
 codec = { workspace = true, default-features = true }
 color-print = { workspace = true }
@@ -34,7 +35,18 @@ frame-benchmarking = { workspace = true, default-features = true }
 frame-benchmarking-cli = { workspace = true, default-features = true }
 futures = { workspace = true }
 jsonrpsee = { features = ["server"], workspace = true }
-libp2p = { workspace = true, features = ["identify", "macros", "noise", "rendezvous", "tcp", "tokio", "yamux"] }
+libp2p = { workspace = true, features = [
+  "cbor",
+  "gossipsub",
+  "identify",
+  "macros",
+  "noise",
+  "rendezvous",
+  "request-response",
+  "tcp",
+  "tokio",
+  "yamux",
+] }
 log = { workspace = true, default-features = true }
 pallet-transaction-payment-rpc = { workspace = true, default-features = true }
 polkadot-cli = { features = ["rococo-native"], workspace = true, default-features = true }
@@ -69,6 +81,7 @@ sp-runtime = { workspace = true, default-features = true }
 sp-timestamp = { workspace = true, default-features = true }
 substrate-frame-rpc-system = { workspace = true, default-features = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 xcm.workspace = true
 
 [build-dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,7 +17,6 @@ name = "polka-storage-node"
 polka-storage-runtime.workspace = true
 primitives = { workspace = true, features = ["std"] }
 
-bincode = { workspace = true }
 clap = { features = ["derive"], workspace = true }
 codec = { workspace = true, default-features = true }
 color-print = { workspace = true }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -129,4 +129,8 @@ pub struct RunCmd {
     /// that the bootstrap node binds to.
     #[arg(long, required = false)]
     pub p2p_listen_address: Option<Multiaddr>,
+
+    /// List of other bootstrap nodes
+    #[arg(long, required = false, num_args = 1..)]
+    pub bootstrap_addresses: Option<Vec<Multiaddr>>,
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -238,7 +238,13 @@ pub fn run() -> Result<()> {
                         .ok_or(
                             "This node is configured as authority, so it will be used as Bootstrap node for Storage Provider & Collator network, but the listen address is missing. Set the --p2p-listen-address argument of the node."
                         )?;
-                    Some(BootstrapConfig::new(p2p_key, p2p_listen_address))
+                    let bootstrap_addresses = cli
+                        .run
+                        .bootstrap_addresses
+                        .ok_or(
+                            "This node is configured as authority, so it will be used as Bootstrap node for Storage Provider & Collator network, but the bootstrap addresses are missing. Set the --bootstrap-addresses argument of the node."
+                        )?;
+                    Some(BootstrapConfig::new(p2p_key, p2p_listen_address, bootstrap_addresses))
                 } else {
                     None
                 };

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -18,7 +18,7 @@ use libp2p::{
 use log::{debug, error, info, warn};
 use primitives::p2p::{
     PeerIdRequest, PeerInfo, PeerInfoResponse, DEFAULT_REGISTRATION_TTL, GOSSIP_TOPIC,
-    IDENTIFY_PROTOCOL_VERSION, REQUEST_RESPONSE_STREAM_PROTOCOL
+    IDENTIFY_PROTOCOL_VERSION, REQUEST_RESPONSE_STREAM_PROTOCOL,
 };
 
 use crate::service::p2p::P2PError;

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -16,11 +16,12 @@ use libp2p::{
     tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use log::{debug, error, info, warn};
-use primitives::p2p::{PeerIdRequest, PeerInfo, PeerInfoResponse};
+use primitives::p2p::{
+    PeerIdRequest, PeerInfo, PeerInfoResponse, DEFAULT_REGISTRATION_TTL, GOSSIP_TOPIC,
+    IDENTIFY_PROTOCOL_VERSION, REQUEST_RESPONSE_STREAM_PROTOCOL
+};
 
-use crate::service::p2p::{P2PError, DEFAULT_REGISTRATION_TTL};
-
-const GOSSIP_TOPIC: &str = "registrar";
+use crate::service::p2p::P2PError;
 
 #[derive(NetworkBehaviour)]
 pub struct BootstrapBehaviour {
@@ -76,7 +77,7 @@ impl BootstrapConfig {
                     ),
                     // The identify behaviour is used to share the external address and the public key with connecting clients.
                     identify: identify::Behaviour::new(identify::Config::new(
-                        "identify/1.0.0".to_string(),
+                        IDENTIFY_PROTOCOL_VERSION.to_string(),
                         key.public(),
                     )),
                     gossipsub: gossipsub::Behaviour::new(
@@ -85,7 +86,7 @@ impl BootstrapConfig {
                     )?,
                     request_response: request_response::cbor::Behaviour::new(
                         [(
-                            StreamProtocol::new("/resolver/1.0.0"),
+                            StreamProtocol::new(REQUEST_RESPONSE_STREAM_PROTOCOL),
                             ProtocolSupport::Full,
                         )],
                         request_response::Config::default(),
@@ -175,20 +176,11 @@ fn on_rendezvous_event(
             let encoded_peer_info = match bincode::serialize(&peer_info) {
                 Ok(info) => info,
                 Err(..) => {
-                    error!("Failed to serialize peer_info");
+                    error!(peer_info:?; "Failed to serialize peer_info");
                     return;
                 }
             };
-            registrations
-                .entry(peer)
-                .and_modify(|info| {
-                    for addr in peer_info.multiaddrs.iter() {
-                        if !info.multiaddrs.contains(addr) {
-                            info.multiaddrs.push(addr.clone())
-                        }
-                    }
-                })
-                .or_insert(peer_info);
+            insert_or_update_registrations(registrations, peer_info);
             // Send registration information to other bootstrap nodes.
             match swarm
                 .behaviour_mut()
@@ -196,7 +188,7 @@ fn on_rendezvous_event(
                 .publish(IdentTopic::new(GOSSIP_TOPIC), encoded_peer_info)
             {
                 Ok(..) => info!("Successfully published new peer info for peer {peer}"),
-                Err(..) => error!("Failed to publish new peer info for peer {peer}"),
+                Err(e) => error!(e:?; "Failed to publish new peer info for peer {peer}"),
             }
         }
         other => debug!("Encountered other rendezvous event: {other:?}"),
@@ -222,7 +214,7 @@ fn on_gossipsub_event(
             let peer_info: PeerInfo = match bincode::deserialize(&message.data) {
                 Ok(info) => info,
                 Err(..) => {
-                    error!("Received invalid peer info");
+                    error!(message:? = message.data; "Received invalid peer info from peer {peer_id:?}");
                     return;
                 }
             };
@@ -230,16 +222,7 @@ fn on_gossipsub_event(
                 "Got registration: {:?} with id: {} from peer: {:?}",
                 peer_info, id, peer_id
             );
-            registrations
-                .entry(peer_info.peer_id)
-                .and_modify(|info| {
-                    for addr in peer_info.multiaddrs.iter() {
-                        if !info.multiaddrs.contains(addr) {
-                            info.multiaddrs.push(addr.clone())
-                        }
-                    }
-                })
-                .or_insert(peer_info);
+            insert_or_update_registrations(registrations, peer_info);
         }
         other => debug!("Encountered other gossipsub event: {other:?}"),
     }
@@ -298,4 +281,22 @@ fn on_request_response_event(
             debug!("Request with id {request_id} sent to {peer}")
         }
     }
+}
+
+/// Take the HashMap and update the entry based on peer_info.peer_id
+/// or insert a new entry.
+fn insert_or_update_registrations(
+    registrations: &mut HashMap<PeerId, PeerInfo>,
+    peer_info: PeerInfo,
+) {
+    registrations
+        .entry(peer_info.peer_id)
+        .and_modify(|info| {
+            for addr in peer_info.multiaddrs.iter() {
+                if !info.multiaddrs.contains(addr) {
+                    info.multiaddrs.push(addr.clone())
+                }
+            }
+        })
+        .or_insert(peer_info);
 }

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -112,7 +112,7 @@ pub(crate) async fn bootstrap(
     for addr in bootstrap_addresses {
         info!("Attempting to dial peer at {addr}");
         if swarm.dial(addr.clone()).is_err() {
-            warn!("Failed to dial peer");
+            warn!("Failed to dial peer at address {addr}");
         }
     }
     swarm

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -173,7 +173,7 @@ fn on_rendezvous_event(
                 multiaddrs: registration.record.addresses().to_vec(),
             };
             // Serialize PeerInfo
-            let encoded_peer_info = match bincode::serialize(&peer_info) {
+            let encoded_peer_info = match serde_json::to_vec(&peer_info) {
                 Ok(info) => info,
                 Err(..) => {
                     error!(peer_info:?; "Failed to serialize peer_info");
@@ -208,10 +208,12 @@ fn on_gossipsub_event(
             message_id: id,
             message,
         } => {
+            // Got a message from ourselves, return early.
             if peer_id == local_peer_id {
                 return;
             }
-            let peer_info: PeerInfo = match bincode::deserialize(&message.data) {
+            // Deserialize peer info
+            let peer_info: PeerInfo = match serde_json::from_slice(&message.data) {
                 Ok(info) => info,
                 Err(..) => {
                     error!(message:? = message.data; "Received invalid peer info from peer {peer_id:?}");

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -14,7 +14,7 @@ use libp2p::{
     tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use log::{debug, error, info, warn};
-use primitives::p2p::{PeerInfo, WPeerId};
+use primitives::p2p::{PeerIdRequest, PeerInfo, PeerInfoResponse};
 
 use crate::service::p2p::{P2PError, DEFAULT_REGISTRATION_TTL};
 
@@ -25,7 +25,7 @@ pub struct BootstrapBehaviour {
     pub rendezvous: rendezvous::server::Behaviour,
     pub identify: identify::Behaviour,
     pub gossipsub: gossipsub::Behaviour,
-    pub request_response: request_response::cbor::Behaviour<WPeerId, PeerInfo>,
+    pub request_response: request_response::cbor::Behaviour<PeerIdRequest, PeerInfoResponse>,
 }
 
 pub struct BootstrapConfig {
@@ -185,7 +185,7 @@ fn on_rendezvous_event(
                             info.multiaddrs.push(addr.clone())
                         }
                     }
-                }  )
+                })
                 .or_insert(peer_info);
             // Send registration information to other bootstrap nodes.
             match swarm
@@ -236,7 +236,7 @@ fn on_gossipsub_event(
                             info.multiaddrs.push(addr.clone())
                         }
                     }
-                }  )
+                })
                 .or_insert(peer_info);
         }
         other => debug!("Encountered other gossipsub event: {other:?}"),
@@ -246,7 +246,7 @@ fn on_gossipsub_event(
 /// Handles events within the request_response protocol
 fn on_request_response_event(
     swarm: &mut Swarm<BootstrapBehaviour>,
-    event: request_response::Event<WPeerId, PeerInfo>,
+    event: request_response::Event<PeerIdRequest, PeerInfoResponse>,
     registrations: &HashMap<PeerId, PeerInfo>,
 ) {
     match event {
@@ -260,20 +260,25 @@ fn on_request_response_event(
             {
                 info!("Got request with id {request_id} from {peer}");
                 let id: PeerId = request.into();
-                match registrations.get(&id) {
+                let response = match registrations.get(&id) {
                     Some(peer_info) => {
-                        // Sending the peer information back to the client who opened the channel.
-                        if swarm
-                            .behaviour_mut()
-                            .request_response
-                            .send_response(channel, peer_info.clone())
-                            .is_err()
-                        {
-                            // Could add retries here.
-                            error!("Failed to send peer info to {peer:?}");
-                        }
+                        info!("Peer {id:?} found in registrations");
+                        PeerInfoResponse::Found(peer_info.clone())
                     }
-                    None => warn!("Peer {id:?} not found in registrations"),
+                    None => {
+                        info!("Peer {id:?} not found in registrations");
+                        PeerInfoResponse::NotFound(id.into())
+                    }
+                };
+                // Sending the peer information back to the client who opened the channel.
+                // Could add retries here.
+                if swarm
+                    .behaviour_mut()
+                    .request_response
+                    .send_response(channel, response)
+                    .is_err()
+                {
+                    error!("Failed to send peer info to {peer:?}");
                 }
             }
         }

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -1,34 +1,51 @@
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::{Error, ErrorKind};
+use std::str::FromStr;
 use std::time::Duration;
 
 use libp2p::{
     futures::StreamExt,
+    gossipsub::{self, IdentTopic},
     identify,
     identity::Keypair,
     noise, rendezvous,
+    request_response::{self, Message, ProtocolSupport},
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, Swarm, SwarmBuilder,
+    tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
-use log::{debug, info};
+use log::{debug, error, info, warn};
 
-use crate::service::p2p::{P2PError, DEFAULT_REGISTRATION_TTL};
+use crate::service::p2p::{P2PError, PeerInfo, DEFAULT_REGISTRATION_TTL};
+
+const GOSSIP_TOPIC: &str = "registrar";
 
 #[derive(NetworkBehaviour)]
 pub struct BootstrapBehaviour {
     pub rendezvous: rendezvous::server::Behaviour,
     pub identify: identify::Behaviour,
+    pub gossipsub: gossipsub::Behaviour,
+    pub request_response: request_response::cbor::Behaviour<String, PeerInfo>,
 }
 
 pub struct BootstrapConfig {
     address: Multiaddr,
     keypair: Keypair,
+    bootstrap_addresses: Vec<Multiaddr>,
 }
 
 impl BootstrapConfig {
-    pub fn new(keypair: Keypair, address: Multiaddr) -> Self {
-        Self { address, keypair }
+    pub fn new(keypair: Keypair, address: Multiaddr, bootstrap_addresses: Vec<Multiaddr>) -> Self {
+        Self {
+            address,
+            keypair,
+            bootstrap_addresses,
+        }
     }
 
-    pub fn create_swarm(self) -> Result<(Swarm<BootstrapBehaviour>, Multiaddr), P2PError> {
+    pub fn create_swarm(
+        self,
+    ) -> Result<(Swarm<BootstrapBehaviour>, Multiaddr, Vec<Multiaddr>), P2PError> {
         let swarm = SwarmBuilder::with_existing_identity(self.keypair)
             .with_tokio()
             .with_tcp(
@@ -37,22 +54,47 @@ impl BootstrapConfig {
                 yamux::Config::default,
             )
             .map_err(|_| P2PError::InvalidTcpConfig)?
-            .with_behaviour(|key| BootstrapBehaviour {
-                // Rendezvous server behaviour for serving new peers to connecting nodes.
-                rendezvous: rendezvous::server::Behaviour::new(
-                    rendezvous::server::Config::default().with_max_ttl(DEFAULT_REGISTRATION_TTL), // Max TTL of 24 hours
-                ),
-                // The identify behaviour is used to share the external address and the public key with connecting clients.
-                identify: identify::Behaviour::new(identify::Config::new(
-                    "identify/1.0.0".to_string(),
-                    key.public(),
-                )),
+            .with_behaviour(|key| {
+                // To content-address message, we can take the hash of message and use it as an ID.
+                let message_id_fn = |message: &gossipsub::Message| {
+                    let mut s = DefaultHasher::new();
+                    message.data.hash(&mut s);
+                    gossipsub::MessageId::from(s.finish().to_string())
+                };
+                let gossipsub_config = gossipsub::ConfigBuilder::default()
+                    .message_id_fn(message_id_fn)
+                    .build()
+                    .map_err(|msg| Error::new(ErrorKind::Other, msg))?;
+
+                Ok(BootstrapBehaviour {
+                    // Rendezvous server behaviour for serving new peers to connecting nodes.
+                    rendezvous: rendezvous::server::Behaviour::new(
+                        rendezvous::server::Config::default()
+                            .with_max_ttl(DEFAULT_REGISTRATION_TTL), // Max TTL of 24 hours
+                    ),
+                    // The identify behaviour is used to share the external address and the public key with connecting clients.
+                    identify: identify::Behaviour::new(identify::Config::new(
+                        "identify/1.0.0".to_string(),
+                        key.public(),
+                    )),
+                    gossipsub: gossipsub::Behaviour::new(
+                        gossipsub::MessageAuthenticity::Signed(key.clone()),
+                        gossipsub_config,
+                    )?,
+                    request_response: request_response::cbor::Behaviour::new(
+                        [(
+                            StreamProtocol::new("/resolver/1.0.0"),
+                            ProtocolSupport::Full,
+                        )],
+                        request_response::Config::default(),
+                    ),
+                })
             })
             .map_err(|_| P2PError::InvalidBehaviourConfig)?
             .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(10)))
             .build();
 
-        Ok((swarm, self.address))
+        Ok((swarm, self.address, self.bootstrap_addresses))
     }
 }
 
@@ -61,46 +103,166 @@ impl BootstrapConfig {
 pub(crate) async fn bootstrap(
     mut swarm: Swarm<BootstrapBehaviour>,
     addr: Multiaddr,
+    bootstrap_addresses: Vec<Multiaddr>,
 ) -> Result<(), P2PError> {
     info!("Starting P2P bootstrap node at {addr}");
     swarm.listen_on(addr)?;
+    for addr in bootstrap_addresses {
+        info!("Dialing {addr}");
+        swarm.dial(addr)?;
+    }
+    swarm
+        .behaviour_mut()
+        .gossipsub
+        .subscribe(&IdentTopic::new(GOSSIP_TOPIC))?;
+    let mut registrations = HashMap::new();
     loop {
-        match swarm.select_next_some().await {
-            SwarmEvent::NewListenAddr { address, .. } => {
-                info!("Listening on {}", address);
+        tokio::select! {
+            event = swarm.select_next_some() => match event {
+                SwarmEvent::NewListenAddr { address, .. } => {
+                    info!("Listening on {}", address);
+                }
+                SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                    info!("Connected to {}", peer_id);
+                }
+                SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                    info!("Disconnected from {}", peer_id);
+                }
+                SwarmEvent::Behaviour(BootstrapBehaviourEvent::Rendezvous(event)) => on_rendezvous_event(&mut swarm, event, &mut registrations),
+                SwarmEvent::Behaviour(BootstrapBehaviourEvent::Gossipsub(event)) => on_gossipsub_event(event, *swarm.local_peer_id(), &mut registrations),
+                SwarmEvent::Behaviour(BootstrapBehaviourEvent::RequestResponse(event)) => on_request_response_event(&mut swarm, event, &registrations),
+                other => debug!("Encountered event: {other:?}"),
             }
-            SwarmEvent::Behaviour(BootstrapBehaviourEvent::Rendezvous(
-                rendezvous::server::Event::PeerRegistered { peer, registration },
-            )) => {
-                info!(
-                    "Peer {} registered for namespace '{}' for {} seconds",
-                    peer, registration.namespace, registration.ttl
-                );
+        }
+    }
+}
+
+/// Handles events within the rendezvous protocol
+fn on_rendezvous_event(
+    swarm: &mut Swarm<BootstrapBehaviour>,
+    event: rendezvous::server::Event,
+    registrations: &mut HashMap<PeerId, PeerInfo>,
+) {
+    match event {
+        rendezvous::server::Event::RegistrationExpired(registration) => {
+            info!(
+                "Registration for peer {} expired in namespace {}",
+                registration.record.peer_id(),
+                registration.namespace
+            );
+        }
+        rendezvous::server::Event::PeerRegistered { peer, registration } => {
+            info!(
+                "Peer {} registered for namespace '{}' for {} seconds",
+                peer, registration.namespace, registration.ttl
+            );
+            let peer_info = PeerInfo {
+                peer_id: peer,
+                multiaddrs: registration.record.addresses().to_vec(),
+            };
+            let encoded_peer_info = match bincode::serialize(&peer_info) {
+                Ok(info) => info,
+                Err(..) => {
+                    error!("Failed to serialize peer_info");
+                    return;
+                }
+            };
+            registrations.insert(peer, peer_info);
+            match swarm
+                .behaviour_mut()
+                .gossipsub
+                .publish(IdentTopic::new(GOSSIP_TOPIC), encoded_peer_info)
+            {
+                Ok(..) => info!("Successfully published new peer info"),
+                Err(..) => error!("Failed to publish new peer info"),
             }
-            SwarmEvent::Behaviour(BootstrapBehaviourEvent::Rendezvous(
-                rendezvous::server::Event::DiscoverServed {
-                    enquirer,
-                    registrations,
-                },
-            )) => {
-                if !registrations.is_empty() {
-                    info!(
-                        "Served peer {} with {} new registrations",
-                        enquirer,
-                        registrations.len()
-                    );
+        }
+        other => debug!("Encountered other rendezvous event: {other:?}"),
+    }
+}
+
+/// Handles events within the gossipsub protocol
+fn on_gossipsub_event(
+    event: gossipsub::Event,
+    local_peer_id: PeerId,
+    registrations: &mut HashMap<PeerId, PeerInfo>,
+) {
+    match event {
+        gossipsub::Event::Message {
+            propagation_source: peer_id,
+            message_id: id,
+            message,
+        } => {
+            if peer_id == local_peer_id {
+                return;
+            }
+            let peer_info: PeerInfo = match bincode::deserialize(&message.data) {
+                Ok(info) => info,
+                Err(..) => {
+                    error!("Received invalid peer info");
+                    return;
+                }
+            };
+            info!(
+                "Got registration: {:?} with id: {} from peer: {:?}",
+                peer_info, id, peer_id
+            );
+            registrations.insert(peer_info.peer_id, peer_info);
+        }
+        other => debug!("Encountered other gossipsub event: {other:?}"),
+    }
+}
+
+/// Handles events within the request_response protocol
+fn on_request_response_event(
+    swarm: &mut Swarm<BootstrapBehaviour>,
+    event: request_response::Event<String, PeerInfo>,
+    registrations: &HashMap<PeerId, PeerInfo>,
+) {
+    match event {
+        request_response::Event::Message { peer, message } => {
+            if let Message::Request {
+                request,
+                channel,
+                request_id,
+            } = message
+            {
+                info!("Got request with id {request_id} from {peer}");
+                let id = match PeerId::from_str(&request) {
+                    Ok(id) => id,
+                    Err(..) => {
+                        error!("Received invalid peer ID");
+                        return;
+                    }
+                };
+                info!("Looking up {id:?}");
+                match registrations.get(&id) {
+                    Some(peer_info) => {
+                        if swarm
+                            .behaviour_mut()
+                            .request_response
+                            .send_response(channel, peer_info.clone())
+                            .is_err()
+                        {
+                            error!("Failed to send peer info to {peer:?}");
+                        }
+                    }
+                    None => warn!("Peer {id:?} not found in registrations"),
                 }
             }
-            SwarmEvent::Behaviour(BootstrapBehaviourEvent::Rendezvous(
-                rendezvous::server::Event::RegistrationExpired(registration),
-            )) => {
-                info!(
-                    "Registration for peer {} expired in namespace {}",
-                    registration.record.peer_id(),
-                    registration.namespace
-                );
-            }
-            other => debug!("Encountered event: {other:?}"),
+        }
+        request_response::Event::OutboundFailure {
+            peer,
+            request_id,
+            error,
+        } => warn!("Failed to send message with id {request_id} to {peer}: {error}"),
+        request_response::Event::InboundFailure {
+            peer,
+            request_id,
+            error,
+        } => warn!("Failed to receive message with id {request_id} from {peer}: {error}"),
+        request_response::Event::ResponseSent { peer, request_id } => {
+            info!("Request with id {request_id} sent to {peer}")
         }
     }
 }

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
-use std::io::{Error, ErrorKind};
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    hash::{DefaultHasher, Hash, Hasher},
+    io::{Error, ErrorKind},
+    time::Duration,
+};
 
 use libp2p::{
     futures::StreamExt,

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::{Error, ErrorKind};
-use std::str::FromStr;
 use std::time::Duration;
 
 use libp2p::{
@@ -15,7 +14,7 @@ use libp2p::{
     tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use log::{debug, error, info, warn};
-use primitives::p2p::PeerInfo;
+use primitives::p2p::{PeerInfo, WPeerId};
 
 use crate::service::p2p::{P2PError, DEFAULT_REGISTRATION_TTL};
 
@@ -26,7 +25,7 @@ pub struct BootstrapBehaviour {
     pub rendezvous: rendezvous::server::Behaviour,
     pub identify: identify::Behaviour,
     pub gossipsub: gossipsub::Behaviour,
-    pub request_response: request_response::cbor::Behaviour<String, PeerInfo>,
+    pub request_response: request_response::cbor::Behaviour<WPeerId, PeerInfo>,
 }
 
 pub struct BootstrapConfig {
@@ -109,8 +108,10 @@ pub(crate) async fn bootstrap(
     info!("Starting P2P bootstrap node at {addr}");
     swarm.listen_on(addr)?;
     for addr in bootstrap_addresses {
-        info!("Dialing {addr}");
-        swarm.dial(addr)?;
+        info!("Attempting to dial peer at {addr}");
+        if swarm.dial(addr.clone()).is_err() {
+            warn!("Failed to dial peer");
+        }
     }
     swarm
         .behaviour_mut()
@@ -146,11 +147,18 @@ fn on_rendezvous_event(
 ) {
     match event {
         rendezvous::server::Event::RegistrationExpired(registration) => {
+            let id = registration.record.peer_id();
             info!(
                 "Registration for peer {} expired in namespace {}",
-                registration.record.peer_id(),
-                registration.namespace
+                id, registration.namespace
             );
+            // Registration expired, remove entry from hashmap
+            if registrations.remove(&id).is_none() {
+                error!(
+                    "Could not remove registration for {:?} because it was not found",
+                    id
+                );
+            }
         }
         rendezvous::server::Event::PeerRegistered { peer, registration } => {
             info!(
@@ -161,6 +169,7 @@ fn on_rendezvous_event(
                 peer_id: peer,
                 multiaddrs: registration.record.addresses().to_vec(),
             };
+            // Serialize PeerInfo
             let encoded_peer_info = match bincode::serialize(&peer_info) {
                 Ok(info) => info,
                 Err(..) => {
@@ -168,14 +177,24 @@ fn on_rendezvous_event(
                     return;
                 }
             };
-            registrations.insert(peer, peer_info);
+            registrations
+                .entry(peer)
+                .and_modify(|info| {
+                    for addr in peer_info.multiaddrs.iter() {
+                        if !info.multiaddrs.contains(addr) {
+                            info.multiaddrs.push(addr.clone())
+                        }
+                    }
+                }  )
+                .or_insert(peer_info);
+            // Send registration information to other bootstrap nodes.
             match swarm
                 .behaviour_mut()
                 .gossipsub
                 .publish(IdentTopic::new(GOSSIP_TOPIC), encoded_peer_info)
             {
-                Ok(..) => info!("Successfully published new peer info"),
-                Err(..) => error!("Failed to publish new peer info"),
+                Ok(..) => info!("Successfully published new peer info for peer {peer}"),
+                Err(..) => error!("Failed to publish new peer info for peer {peer}"),
             }
         }
         other => debug!("Encountered other rendezvous event: {other:?}"),
@@ -189,6 +208,7 @@ fn on_gossipsub_event(
     registrations: &mut HashMap<PeerId, PeerInfo>,
 ) {
     match event {
+        // Received a message with peer information from another bootstrap node.
         gossipsub::Event::Message {
             propagation_source: peer_id,
             message_id: id,
@@ -208,7 +228,16 @@ fn on_gossipsub_event(
                 "Got registration: {:?} with id: {} from peer: {:?}",
                 peer_info, id, peer_id
             );
-            registrations.insert(peer_info.peer_id, peer_info);
+            registrations
+                .entry(peer_info.peer_id)
+                .and_modify(|info| {
+                    for addr in peer_info.multiaddrs.iter() {
+                        if !info.multiaddrs.contains(addr) {
+                            info.multiaddrs.push(addr.clone())
+                        }
+                    }
+                }  )
+                .or_insert(peer_info);
         }
         other => debug!("Encountered other gossipsub event: {other:?}"),
     }
@@ -217,10 +246,11 @@ fn on_gossipsub_event(
 /// Handles events within the request_response protocol
 fn on_request_response_event(
     swarm: &mut Swarm<BootstrapBehaviour>,
-    event: request_response::Event<String, PeerInfo>,
+    event: request_response::Event<WPeerId, PeerInfo>,
     registrations: &HashMap<PeerId, PeerInfo>,
 ) {
     match event {
+        // Message received, looking up the mapping
         request_response::Event::Message { peer, message } => {
             if let Message::Request {
                 request,
@@ -229,22 +259,17 @@ fn on_request_response_event(
             } = message
             {
                 info!("Got request with id {request_id} from {peer}");
-                let id = match PeerId::from_str(&request) {
-                    Ok(id) => id,
-                    Err(..) => {
-                        error!("Received invalid peer ID");
-                        return;
-                    }
-                };
-                info!("Looking up {id:?}");
+                let id: PeerId = request.into();
                 match registrations.get(&id) {
                     Some(peer_info) => {
+                        // Sending the peer information back to the client who opened the channel.
                         if swarm
                             .behaviour_mut()
                             .request_response
                             .send_response(channel, peer_info.clone())
                             .is_err()
                         {
+                            // Could add retries here.
                             error!("Failed to send peer info to {peer:?}");
                         }
                     }
@@ -263,7 +288,7 @@ fn on_request_response_event(
             error,
         } => warn!("Failed to receive message with id {request_id} from {peer}: {error}"),
         request_response::Event::ResponseSent { peer, request_id } => {
-            info!("Request with id {request_id} sent to {peer}")
+            debug!("Request with id {request_id} sent to {peer}")
         }
     }
 }

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -15,8 +15,9 @@ use libp2p::{
     tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use log::{debug, error, info, warn};
+use primitives::p2p::PeerInfo;
 
-use crate::service::p2p::{P2PError, PeerInfo, DEFAULT_REGISTRATION_TTL};
+use crate::service::p2p::{P2PError, DEFAULT_REGISTRATION_TTL};
 
 const GOSSIP_TOPIC: &str = "registrar";
 

--- a/node/src/service/p2p/mod.rs
+++ b/node/src/service/p2p/mod.rs
@@ -1,5 +1,9 @@
+use std::str::FromStr;
+
 use bootstrap::bootstrap;
+use libp2p::{Multiaddr, PeerId};
 use log::info;
+use serde::{de, Deserialize, Serialize, Serializer};
 
 mod bootstrap;
 
@@ -19,15 +23,37 @@ pub enum P2PError {
     InvalidBehaviourConfig,
     #[error(transparent)]
     P2PTransport(#[from] libp2p::TransportError<std::io::Error>),
+    #[error(transparent)]
+    P2PSubscription(#[from] libp2p::gossipsub::SubscriptionError),
 }
 
 /// Runs a bootstrap node from the given config.
 /// The `CancellationToken` is used for a graceful shutdown if the user presses ctrl+c
 pub async fn run_bootstrap_node(config: BootstrapConfig) {
     info!("Starting P2P bootstrap node");
-    let (swarm, addr) = config.create_swarm().expect("Could not create swarm");
+    let (swarm, addr, bootstrap_addresses) = config
+        .create_swarm()
+        .expect("Could not create bootstrap swarm");
 
-    bootstrap(swarm, addr)
+    bootstrap(swarm, addr, bootstrap_addresses)
         .await
         .expect("Could not run bootstrap node");
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PeerInfo {
+    #[serde(serialize_with = "serialize_peer_id")]
+    #[serde(deserialize_with = "deserialize_peer_id")]
+    pub peer_id: PeerId,
+    pub multiaddrs: Vec<Multiaddr>,
+}
+
+fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(d: D) -> Result<PeerId, D::Error> {
+    let s: String = de::Deserialize::deserialize(d)?;
+    PeerId::from_str(&s).map_err(de::Error::custom)
+}
+
+fn serialize_peer_id<S: Serializer>(id: &PeerId, serializer: S) -> Result<S::Ok, S::Error> {
+    let id = id.to_string();
+    serializer.collect_str(&id)
 }

--- a/node/src/service/p2p/mod.rs
+++ b/node/src/service/p2p/mod.rs
@@ -5,8 +5,6 @@ mod bootstrap;
 
 pub(crate) use bootstrap::BootstrapConfig;
 
-const DEFAULT_REGISTRATION_TTL: u64 = 86400;
-
 #[derive(Debug, thiserror::Error)]
 pub enum P2PError {
     #[error(transparent)]

--- a/node/src/service/p2p/mod.rs
+++ b/node/src/service/p2p/mod.rs
@@ -1,9 +1,5 @@
-use std::str::FromStr;
-
 use bootstrap::bootstrap;
-use libp2p::{Multiaddr, PeerId};
 use log::info;
-use serde::{de, Deserialize, Serialize, Serializer};
 
 mod bootstrap;
 
@@ -38,22 +34,4 @@ pub async fn run_bootstrap_node(config: BootstrapConfig) {
     bootstrap(swarm, addr, bootstrap_addresses)
         .await
         .expect("Could not run bootstrap node");
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PeerInfo {
-    #[serde(serialize_with = "serialize_peer_id")]
-    #[serde(deserialize_with = "deserialize_peer_id")]
-    pub peer_id: PeerId,
-    pub multiaddrs: Vec<Multiaddr>,
-}
-
-fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(d: D) -> Result<PeerId, D::Error> {
-    let s: String = de::Deserialize::deserialize(d)?;
-    PeerId::from_str(&s).map_err(de::Error::custom)
-}
-
-fn serialize_peer_id<S: Serializer>(id: &PeerId, serializer: S) -> Result<S::Ok, S::Error> {
-    let id = id.to_string();
-    serializer.collect_str(&id)
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -8,6 +8,7 @@ pub mod sector;
 
 #[cfg(feature = "std")]
 pub mod p2p;
+
 #[cfg(feature = "testing")]
 pub mod testing {
     // NOTE(@jmg-duarte,22/01/2025): Since there's only one thing, star import for now.

--- a/primitives/src/p2p.rs
+++ b/primitives/src/p2p.rs
@@ -1,8 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use ed25519_dalek::{pkcs8::DecodePrivateKey, SigningKey};
-use libp2p::identity::Keypair;
-use libp2p::{Multiaddr, PeerId};
+use libp2p::{Multiaddr, PeerId, identity::Keypair};
 use serde::{de, Deserialize, Serialize, Serializer};
 
 /// Parses a ED25519 private key into a Keypair.

--- a/primitives/src/p2p.rs
+++ b/primitives/src/p2p.rs
@@ -2,6 +2,8 @@ use std::{path::PathBuf, str::FromStr};
 
 use ed25519_dalek::{pkcs8::DecodePrivateKey, SigningKey};
 use libp2p::identity::Keypair;
+use libp2p::{Multiaddr, PeerId};
+use serde::{de, Deserialize, Serialize, Serializer};
 
 /// Parses a ED25519 private key into a Keypair.
 /// Takes in a private key or the path to a PEM file, depending on the @ prefix.
@@ -18,4 +20,26 @@ pub fn keypair_value_parser(src: &str) -> Result<Keypair, String> {
         SigningKey::try_from(hex_key.as_slice()).map_err(|e| e.to_string())?
     };
     Keypair::ed25519_from_bytes(key.to_bytes()).map_err(|e| e.to_string())
+}
+
+/// Struct holds peer information.
+/// - PeerId: Registered Peer ID.
+/// - multiaddrs: Vec of multiaddresses the peer has registered.
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PeerInfo {
+    #[serde(serialize_with = "serialize_peer_id")]
+    #[serde(deserialize_with = "deserialize_peer_id")]
+    pub peer_id: PeerId,
+    pub multiaddrs: Vec<Multiaddr>,
+}
+
+fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(d: D) -> Result<PeerId, D::Error> {
+    let s: String = de::Deserialize::deserialize(d)?;
+    PeerId::from_str(&s).map_err(de::Error::custom)
+}
+
+fn serialize_peer_id<S: Serializer>(id: &PeerId, serializer: S) -> Result<S::Ok, S::Error> {
+    let id = id.to_string();
+    serializer.collect_str(&id)
 }

--- a/primitives/src/p2p.rs
+++ b/primitives/src/p2p.rs
@@ -4,9 +4,13 @@ use ed25519_dalek::{pkcs8::DecodePrivateKey, SigningKey};
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use serde::{de, Deserialize, Serialize, Serializer};
 
+pub const GOSSIP_TOPIC: &str = "registrar";
+pub const IDENTIFY_PROTOCOL_VERSION: &str = "identify/1.0.0";
+pub const REQUEST_RESPONSE_STREAM_PROTOCOL: &str = "/resolver/1.0.0";
+pub const DEFAULT_REGISTRATION_TTL: u64 = 86400;
+
 /// Parses a ED25519 private key into a Keypair.
 /// Takes in a private key or the path to a PEM file, depending on the @ prefix.
-#[cfg(feature = "std")]
 pub fn keypair_value_parser(src: &str) -> Result<Keypair, String> {
     let key = if let Some(stripped) = src.strip_prefix('@') {
         let path = PathBuf::from_str(stripped)
@@ -24,7 +28,6 @@ pub fn keypair_value_parser(src: &str) -> Result<Keypair, String> {
 /// Struct holds peer information.
 /// - PeerId: Registered Peer ID.
 /// - multiaddrs: Vec of multiaddresses the peer has registered.
-#[cfg(feature = "std")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PeerInfo {
     #[serde(serialize_with = "serialize_peer_id")]
@@ -37,7 +40,6 @@ pub struct PeerInfo {
 /// PeerInfoResponse::NotFound is returned when the requested peer ID was not found.
 /// PeerInfoResponse::Found(..) is returned when the requested peer ID was found.
 /// The latter holds the relevant [`PeerInfo`] inside.
-#[cfg(feature = "std")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PeerInfoResponse {
     Found(PeerInfo),
@@ -47,7 +49,6 @@ pub enum PeerInfoResponse {
 /// The request type used for the request response P2P protocol.
 /// We cannot use PeerId directly because it does not implement
 /// Serialize and Deserialize.
-#[cfg(feature = "std")]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PeerIdRequest(
     #[serde(serialize_with = "serialize_peer_id")]

--- a/primitives/src/p2p.rs
+++ b/primitives/src/p2p.rs
@@ -43,3 +43,25 @@ fn serialize_peer_id<S: Serializer>(id: &PeerId, serializer: S) -> Result<S::Ok,
     let id = id.to_string();
     serializer.collect_str(&id)
 }
+
+/// Wrapper struct for Peer ID so we can implement `Deserialize` and `Serialize`
+/// and use this type in the request response behaviour.
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WPeerId(
+    #[serde(serialize_with = "serialize_peer_id")]
+    #[serde(deserialize_with = "deserialize_peer_id")]
+    PeerId,
+);
+
+impl From<PeerId> for WPeerId {
+    fn from(value: PeerId) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<PeerId> for WPeerId {
+    fn into(self) -> PeerId {
+        self.0
+    }
+}

--- a/primitives/src/p2p.rs
+++ b/primitives/src/p2p.rs
@@ -34,6 +34,40 @@ pub struct PeerInfo {
     pub multiaddrs: Vec<Multiaddr>,
 }
 
+/// This enum is used in the request response P2P protocol.
+/// PeerInfoResponse::NotFound is returned when the requested peer ID was not found.
+/// PeerInfoResponse::Found(..) is returned when the requested peer ID was found.
+/// The latter holds the relevant [`PeerInfo`] inside.
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum PeerInfoResponse {
+    Found(PeerInfo),
+    NotFound(PeerIdRequest),
+}
+
+/// The request type used for the request response P2P protocol.
+/// We cannot use PeerId directly because it does not implement
+/// Serialize and Deserialize.
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PeerIdRequest(
+    #[serde(serialize_with = "serialize_peer_id")]
+    #[serde(deserialize_with = "deserialize_peer_id")]
+    PeerId,
+);
+
+impl From<PeerId> for PeerIdRequest {
+    fn from(value: PeerId) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<PeerId> for PeerIdRequest {
+    fn into(self) -> PeerId {
+        self.0
+    }
+}
+
 fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(d: D) -> Result<PeerId, D::Error> {
     let s: String = de::Deserialize::deserialize(d)?;
     PeerId::from_str(&s).map_err(de::Error::custom)
@@ -42,26 +76,4 @@ fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(d: D) -> Result<PeerId, D:
 fn serialize_peer_id<S: Serializer>(id: &PeerId, serializer: S) -> Result<S::Ok, S::Error> {
     let id = id.to_string();
     serializer.collect_str(&id)
-}
-
-/// Wrapper struct for Peer ID so we can implement `Deserialize` and `Serialize`
-/// and use this type in the request response behaviour.
-#[cfg(feature = "std")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WPeerId(
-    #[serde(serialize_with = "serialize_peer_id")]
-    #[serde(deserialize_with = "deserialize_peer_id")]
-    PeerId,
-);
-
-impl From<PeerId> for WPeerId {
-    fn from(value: PeerId) -> Self {
-        Self(value)
-    }
-}
-
-impl Into<PeerId> for WPeerId {
-    fn into(self) -> PeerId {
-        self.0
-    }
 }

--- a/primitives/src/p2p.rs
+++ b/primitives/src/p2p.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use ed25519_dalek::{pkcs8::DecodePrivateKey, SigningKey};
-use libp2p::{Multiaddr, PeerId, identity::Keypair};
+use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use serde::{de, Deserialize, Serialize, Serializer};
 
 /// Parses a ED25519 private key into a Keypair.

--- a/storage-provider/client/Cargo.toml
+++ b/storage-provider/client/Cargo.toml
@@ -36,7 +36,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }
 
 [dev-dependencies]
-libp2p = { workspace = true, features = ["identify", "macros", "noise", "rendezvous", "tcp", "tokio", "yamux"] }
+anyhow = { workspace = true }
+libp2p = { workspace = true, features = ["cbor", "macros", "noise", "request-response", "tcp", "tokio", "yamux"] }
 
 [lints]
 workspace = true

--- a/storage-provider/client/Cargo.toml
+++ b/storage-provider/client/Cargo.toml
@@ -36,7 +36,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 libp2p = { workspace = true, features = ["cbor", "macros", "noise", "request-response", "tcp", "tokio", "yamux"] }
 
 [lints]

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -8,7 +8,6 @@
 //! to the bootstrap node.
 use std::time::Duration;
 
-use anyhow::{bail, Result};
 use clap::Parser;
 use libp2p::{
     futures::StreamExt,
@@ -22,14 +21,15 @@ use tracing_subscriber::EnvFilter;
 
 /// Create a discovery swarm
 fn create_discover_swarm(
-) -> Result<Swarm<request_response::cbor::Behaviour<PeerIdRequest, PeerInfoResponse>>> {
+) -> Result<Swarm<request_response::cbor::Behaviour<PeerIdRequest, PeerInfoResponse>>, String> {
     let swarm = SwarmBuilder::with_new_identity()
         .with_tokio()
         .with_tcp(
             tcp::Config::default(),
             noise::Config::new,
             yamux::Config::default,
-        )?
+        )
+        .map_err(|e| format!("{e:?}"))?
         .with_behaviour(|_| {
             request_response::cbor::Behaviour::new(
                 [(
@@ -38,7 +38,8 @@ fn create_discover_swarm(
                 )],
                 request_response::Config::default(),
             )
-        })?
+        })
+        .map_err(|e| format!("{e:?}"))?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(10)))
         .build();
     Ok(swarm)
@@ -50,8 +51,8 @@ async fn run_discover(
     bootstrap_addr: Multiaddr,
     bootstrap_id: &PeerId,
     resolve_id: PeerId,
-) -> Result<PeerInfoResponse> {
-    swarm.dial(bootstrap_addr)?;
+) -> Result<PeerInfoResponse, String> {
+    swarm.dial(bootstrap_addr).map_err(|e| format!("{e:?}"))?;
 
     loop {
         tokio::select! {
@@ -73,7 +74,7 @@ async fn run_discover(
                         error,
                     } => {
                         tracing::error!("Failed to send message with id {request_id} to {peer}: {error}");
-                        bail!("Failed to send message with id {request_id} to {peer}: {error}");
+                        return Err(format!("Failed to send message with id {request_id} to {peer}: {error}"));
                     }
                     request_response::Event::InboundFailure {
                         peer,
@@ -81,7 +82,7 @@ async fn run_discover(
                         error,
                     } => {
                         tracing::error!("Failed to receive message with id {request_id} from {peer}: {error}");
-                        bail!("Failed to receive message with id {request_id} from {peer}: {error}")
+                        return Err(format!("Failed to receive message with id {request_id} from {peer}: {error}"));
                     }
                     other => tracing::debug!("Unreachable event: {other:?}")
                 },
@@ -109,7 +110,7 @@ struct Cli {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), String> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -8,7 +8,7 @@
 //! to the bootstrap node.
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
 use libp2p::futures::StreamExt;
 use libp2p::request_response::{Message, ProtocolSupport};
@@ -16,12 +16,11 @@ use libp2p::swarm::SwarmEvent;
 use libp2p::{
     noise, request_response, tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
-use primitives::p2p::PeerInfo;
+use primitives::p2p::{PeerInfo, WPeerId};
 use tracing_subscriber::EnvFilter;
 
 /// Create a discovery swarm
-fn create_discover_swarm() -> Result<Swarm<request_response::cbor::Behaviour<String, PeerInfo>>>
-{
+fn create_discover_swarm() -> Result<Swarm<request_response::cbor::Behaviour<WPeerId, PeerInfo>>> {
     let swarm = SwarmBuilder::with_new_identity()
         .with_tokio()
         .with_tcp(
@@ -45,7 +44,7 @@ fn create_discover_swarm() -> Result<Swarm<request_response::cbor::Behaviour<Str
 
 /// Run the discovery swarm and request the peer ID to multiaddrs mapping.
 async fn run_discover(
-    mut swarm: Swarm<request_response::cbor::Behaviour<String, PeerInfo>>,
+    mut swarm: Swarm<request_response::cbor::Behaviour<WPeerId, PeerInfo>>,
     bootstrap_addr: Multiaddr,
     bootstrap_id: &PeerId,
     resolve_id: PeerId,
@@ -56,26 +55,37 @@ async fn run_discover(
         tokio::select! {
             event = swarm.select_next_some() => match event {
                 SwarmEvent::Behaviour(event) => match event {
-                    libp2p::request_response::Event::Message { peer, message } =>
-                    if let Message::Response { request_id, response } = message {
-                        tracing::info!("Received response with id {request_id} from {peer}");
-                        return Ok(response);
-                    },
-                    libp2p::request_response::Event::OutboundFailure {
+                    request_response::Event::Message { peer, message } => {
+                        if let Message::Response {
+                            request_id,
+                            response,
+                        } = message
+                        {
+                            tracing::info!("Received response with id {request_id} from {peer}");
+                            return Ok(response);
+                        }
+                    }
+                    request_response::Event::OutboundFailure {
                         peer,
                         request_id,
                         error,
-                    } => tracing::warn!("Failed to send message with id {request_id} to {peer}: {error}"),
-                    libp2p::request_response::Event::InboundFailure {
+                    } => {
+                        tracing::error!("Failed to send message with id {request_id} to {peer}: {error}");
+                        bail!("Failed to send message with id {request_id} to {peer}: {error}");
+                    }
+                    request_response::Event::InboundFailure {
                         peer,
                         request_id,
                         error,
-                    } => tracing::warn!("Failed to receive message with id {request_id} from {peer}: {error}"),
-                    libp2p::request_response::Event::ResponseSent { peer, request_id } => tracing::info!("Request with id {request_id} sent to {peer}"),
+                    } => {
+                        tracing::error!("Failed to receive message with id {request_id} from {peer}: {error}");
+                        bail!("Failed to receive message with id {request_id} from {peer}: {error}")
+                    }
+                    other => tracing::debug!("Unreachable event: {other:?}")
                 },
                 SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                     tracing::info!("Connected to {}", peer_id);
-                    swarm.behaviour_mut().send_request(bootstrap_id, resolve_id.to_string());
+                    swarm.behaviour_mut().send_request(bootstrap_id, resolve_id.into());
                 }
                 other => tracing::debug!("Received other event: {other:?}"),
             }
@@ -107,7 +117,7 @@ async fn main() -> Result<()> {
     let peer_info =
         run_discover(swarm, cli.bootstrap_addr, &cli.bootstrap_id, cli.resolve_id).await?;
     println!(
-        "Got multiaddrs {:?} for peer {:?}",
+        "Got multiaddrs {:#?} for peer {:?}",
         peer_info.multiaddrs, peer_info.peer_id
     );
     Ok(())

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -10,11 +10,12 @@ use std::time::Duration;
 
 use anyhow::{bail, Result};
 use clap::Parser;
-use libp2p::futures::StreamExt;
-use libp2p::request_response::{Message, ProtocolSupport};
-use libp2p::swarm::SwarmEvent;
 use libp2p::{
-    noise, request_response, tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
+    futures::StreamExt,
+    noise,
+    request_response::{self, Message, ProtocolSupport},
+    swarm::SwarmEvent,
+    tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use primitives::p2p::{PeerIdRequest, PeerInfoResponse};
 use tracing_subscriber::EnvFilter;

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -16,7 +16,7 @@ use libp2p::{
     swarm::SwarmEvent,
     tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
-use primitives::p2p::{PeerIdRequest, PeerInfoResponse};
+use primitives::p2p::{PeerIdRequest, PeerInfoResponse, REQUEST_RESPONSE_STREAM_PROTOCOL};
 use tracing_subscriber::EnvFilter;
 
 /// Create a discovery swarm
@@ -33,7 +33,7 @@ fn create_discover_swarm(
         .with_behaviour(|_| {
             request_response::cbor::Behaviour::new(
                 [(
-                    StreamProtocol::new("/resolver/1.0.0"),
+                    StreamProtocol::new(REQUEST_RESPONSE_STREAM_PROTOCOL),
                     ProtocolSupport::Full,
                 )],
                 request_response::Config::default(),

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -1,133 +1,103 @@
-//! Peer Resolver example
-//!
-//! This example shows how to use the rendezvous client protocol to
-//! connect to rendezvous bootstrap, and send a discovery message,
-//! requesting the bootstrap node to return their registrations.
-//! Then it will check the registrations to see if a given Peer ID
-//! is contained in them to get a Peer ID to multiaddr mapping.
-//! If the bootstrap node does not have information on the given Peer
-//! ID, the example will return an error.
-//! NOTE: This example is to be removed and implemented into the
-//! client at some point.
-use std::{error::Error, time::Duration};
+use std::time::Duration;
 
+use anyhow::Result;
 use clap::Parser;
+use libp2p::futures::StreamExt;
+use libp2p::request_response::{Message, ProtocolSupport};
+use libp2p::swarm::SwarmEvent;
 use libp2p::{
-    futures::StreamExt,
-    noise,
-    rendezvous::client::{Behaviour, Event},
-    swarm::SwarmEvent,
-    tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
+    noise, request_response, tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
+use primitives::p2p::PeerInfo;
 use tracing_subscriber::EnvFilter;
 
-#[derive(Debug)]
-struct PeerInfo {
-    peer_id: PeerId,
-    multiaddresses: Vec<Multiaddr>,
-}
-
-#[derive(Parser)]
-struct Cli {
-    /// Peer ID to resolve
-    #[arg(long)]
-    peer_id: PeerId,
-
-    /// Rendezvous point address of the bootstrap node
-    #[arg(long)]
-    rendezvous_point_address: Multiaddr,
-
-    /// PeerID of the bootstrap node
-    #[arg(long)]
-    rendezvous_point: PeerId,
-}
-
-fn create_swarm() -> Result<Swarm<Behaviour>, Box<dyn Error>> {
-    Ok(SwarmBuilder::with_new_identity()
+/// Create a discovery swarm
+fn create_discover_swarm() -> Result<Swarm<request_response::cbor::Behaviour<String, PeerInfo>>>
+{
+    let swarm = SwarmBuilder::with_new_identity()
         .with_tokio()
         .with_tcp(
             tcp::Config::default(),
             noise::Config::new,
             yamux::Config::default,
         )?
-        .with_behaviour(|key| Behaviour::new(key.clone()))?
+        .with_behaviour(|_| {
+            request_response::cbor::Behaviour::new(
+                [(
+                    StreamProtocol::new("/resolver/1.0.0"),
+                    ProtocolSupport::Full,
+                )],
+                request_response::Config::default(),
+            )
+        })?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(10)))
-        .build())
+        .build();
+    Ok(swarm)
 }
 
-async fn discover(
-    swarm: &mut Swarm<Behaviour>,
-    peer_id_to_find: PeerId,
-    rendezvous_point_address: Multiaddr,
-    rendezvous_point: PeerId,
-) -> Result<PeerInfo, Box<dyn Error>> {
-    // Dial in to the rendezvous point.
-    swarm.dial(rendezvous_point_address)?;
+/// Run the discovery swarm and request the peer ID to multiaddrs mapping.
+async fn run_discover(
+    mut swarm: Swarm<request_response::cbor::Behaviour<String, PeerInfo>>,
+    bootstrap_addr: Multiaddr,
+    bootstrap_id: &PeerId,
+    resolve_id: PeerId,
+) -> Result<PeerInfo> {
+    swarm.dial(bootstrap_addr)?;
 
     loop {
-        match swarm.select_next_some().await {
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-                if peer_id == rendezvous_point {
-                    tracing::info!("Connection established with rendezvous point {}", peer_id);
-
-                    // Requesting rendezvous point for peer discovery
-                    swarm
-                        .behaviour_mut()
-                        .discover(None, None, None, rendezvous_point);
+        tokio::select! {
+            event = swarm.select_next_some() => match event {
+                SwarmEvent::Behaviour(event) => match event {
+                    libp2p::request_response::Event::Message { peer, message } =>
+                    if let Message::Response { request_id, response } = message {
+                        tracing::info!("Received response with id {request_id} from {peer}");
+                        return Ok(response);
+                    },
+                    libp2p::request_response::Event::OutboundFailure {
+                        peer,
+                        request_id,
+                        error,
+                    } => tracing::warn!("Failed to send message with id {request_id} to {peer}: {error}"),
+                    libp2p::request_response::Event::InboundFailure {
+                        peer,
+                        request_id,
+                        error,
+                    } => tracing::warn!("Failed to receive message with id {request_id} from {peer}: {error}"),
+                    libp2p::request_response::Event::ResponseSent { peer, request_id } => tracing::info!("Request with id {request_id} sent to {peer}"),
+                },
+                SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                    tracing::info!("Connected to {}", peer_id);
+                    swarm.behaviour_mut().send_request(bootstrap_id, resolve_id.to_string());
                 }
+                other => tracing::debug!("Received other event: {other:?}"),
             }
-            // Received discovered event from the rendezvous point
-            SwarmEvent::Behaviour(Event::Discovered { registrations, .. }) => {
-                // Check registrations
-                for registration in &registrations {
-                    // Get peer ID from the registration record
-                    let peer_id = registration.record.peer_id();
-                    // skip self
-                    if &peer_id == swarm.local_peer_id() {
-                        continue;
-                    }
-                    if peer_id == peer_id_to_find {
-                        return Ok(PeerInfo {
-                            peer_id,
-                            multiaddresses: registration.record.addresses().to_vec(),
-                        });
-                    }
-                }
-                return Err(format!(
-                    "No registered multi-addresses found for Peer ID {peer_id_to_find}"
-                )
-                .into());
-            }
-
-            other => tracing::debug!("Other event: {other:?}"),
         }
     }
+}
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long)]
+    bootstrap_addr: Multiaddr,
+    #[arg(long)]
+    bootstrap_id: PeerId,
+    #[arg(long)]
+    resolve_id: PeerId,
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<()> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
-    let args = Cli::parse();
-
-    let mut swarm = create_swarm()?;
-    match discover(
-        &mut swarm,
-        args.peer_id,
-        args.rendezvous_point_address,
-        args.rendezvous_point,
-    )
-    .await
-    {
-        Ok(peer_info) => {
-            println!("Found peer with Peer ID {}", args.peer_id);
-            println!("Peer Info:");
-            println!("Peer ID: {}", peer_info.peer_id);
-            println!("Multiaddresses: {:?}", peer_info.multiaddresses);
-        }
-        Err(e) => eprintln!("{e}"),
-    }
-
+    let cli = Cli::parse();
+    let swarm = create_discover_swarm()?;
+    println!("Attempting to get multiaddrs for peer {:?}", cli.resolve_id);
+    let peer_info =
+        run_discover(swarm, cli.bootstrap_addr, &cli.bootstrap_id, cli.resolve_id).await?;
+    println!(
+        "Got multiaddrs {:?} for peer {:?}",
+        peer_info.multiaddrs, peer_info.peer_id
+    );
     Ok(())
 }

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -16,11 +16,12 @@ use libp2p::swarm::SwarmEvent;
 use libp2p::{
     noise, request_response, tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
-use primitives::p2p::{PeerInfo, WPeerId};
+use primitives::p2p::{PeerIdRequest, PeerInfoResponse};
 use tracing_subscriber::EnvFilter;
 
 /// Create a discovery swarm
-fn create_discover_swarm() -> Result<Swarm<request_response::cbor::Behaviour<WPeerId, PeerInfo>>> {
+fn create_discover_swarm(
+) -> Result<Swarm<request_response::cbor::Behaviour<PeerIdRequest, PeerInfoResponse>>> {
     let swarm = SwarmBuilder::with_new_identity()
         .with_tokio()
         .with_tcp(
@@ -44,11 +45,11 @@ fn create_discover_swarm() -> Result<Swarm<request_response::cbor::Behaviour<WPe
 
 /// Run the discovery swarm and request the peer ID to multiaddrs mapping.
 async fn run_discover(
-    mut swarm: Swarm<request_response::cbor::Behaviour<WPeerId, PeerInfo>>,
+    mut swarm: Swarm<request_response::cbor::Behaviour<PeerIdRequest, PeerInfoResponse>>,
     bootstrap_addr: Multiaddr,
     bootstrap_id: &PeerId,
     resolve_id: PeerId,
-) -> Result<PeerInfo> {
+) -> Result<PeerInfoResponse> {
     swarm.dial(bootstrap_addr)?;
 
     loop {
@@ -116,9 +117,12 @@ async fn main() -> Result<()> {
     println!("Attempting to get multiaddrs for peer {:?}", cli.resolve_id);
     let peer_info =
         run_discover(swarm, cli.bootstrap_addr, &cli.bootstrap_id, cli.resolve_id).await?;
-    println!(
-        "Got multiaddrs {:#?} for peer {:?}",
-        peer_info.multiaddrs, peer_info.peer_id
-    );
+    match peer_info {
+        PeerInfoResponse::NotFound(peer) => println!("Peer {:?} is not registered", peer),
+        PeerInfoResponse::Found(info) => println!(
+            "Got multiaddrs {:#?} for peer {:?}",
+            info.multiaddrs, info.peer_id
+        ),
+    }
     Ok(())
 }

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -1,3 +1,11 @@
+//! This example show how to connect to a bootstrap node within the P2P network
+//! and request a Peer ID to Multiaddrs mapping.
+//! This client uses libp2p's request response protocol to request a Multiaddrs
+//! connected to a given Peer ID.
+//! The Multiaddr of the bootstrap node needs to be known because the client
+//! needs to dial (connect) to the bootstrap node to send a request.
+//! The Peer ID of the bootstrap node needs to be known to send the request
+//! to the bootstrap node.
 use std::time::Duration;
 
 use anyhow::Result;
@@ -77,10 +85,13 @@ async fn run_discover(
 
 #[derive(Parser)]
 struct Cli {
+    /// Multiaddr of the bootstrap node.
     #[arg(long)]
     bootstrap_addr: Multiaddr,
+    /// PeerID of the bootstrap node.
     #[arg(long)]
     bootstrap_id: PeerId,
+    /// Peer ID to request the Multiaddrs for.
     #[arg(long)]
     resolve_id: PeerId,
 }

--- a/storage-provider/server/src/config.rs
+++ b/storage-provider/server/src/config.rs
@@ -8,7 +8,7 @@ use clap::Args;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use polka_storage_provider_common::config::sealing::SealingConfiguration;
 use primitives::{
-    p2p::keypair_value_parser,
+    p2p::{keypair_value_parser, DEFAULT_REGISTRATION_TTL},
     proofs::{RegisteredPoStProof, RegisteredSealProof},
 };
 use serde::Deserialize;
@@ -18,8 +18,6 @@ use crate::{
     p2p::{deser_keypair, deserialize_string_to_peer_id},
     DEFAULT_NODE_ADDRESS,
 };
-
-pub const DEFAULT_REGISTRATION_TTL: u64 = 86400;
 
 /// Default address to bind the RPC server to.
 const fn default_rpc_listen_address() -> SocketAddr {

--- a/zombienet/local-david-collator.toml
+++ b/zombienet/local-david-collator.toml
@@ -10,11 +10,7 @@ default_args = ["--detailed-log-output", "-lparachain=debug,xcm=trace,runtime=tr
 default_command = "polkadot"
 
 [[relaychain.nodes]]
-name = "alice"
-validator = true
-
-[[relaychain.nodes]]
-name = "bob"
+name = "erin"
 validator = true
 
 [[parachains]]
@@ -25,17 +21,17 @@ cumulus_based = true
 # We'll have a proper Parachain ID in the *future*, but for now, let's stick to 1000 (which is AssetHub and trusted).
 id = 1000
 
-# run charlie as parachain collator
+# run david as parachain collator
 [[parachains.collators]]
 args = [
-  "--bootstrap-addresses=/ip4/127.0.0.1/tcp/1337",
-  "--detailed-log-output",
-  "--p2p-key=@/tmp/zombienet/charlie-private.pem",
-  "--p2p-listen-address=/ip4/127.0.0.1/tcp/62649",
-  "--pool-type=fork-aware",
-  "-lparachain=debug,xcm=trace,runtime=trace,txpool=debug,basic-authorship=debug",
+    "--bootstrap-addresses=/ip4/127.0.0.1/tcp/62649",
+    "--detailed-log-output",
+    "--p2p-key=@/tmp/zombienet/david-private.pem",
+    "--p2p-listen-address=/ip4/127.0.0.1/tcp/1337",
+    "--pool-type=fork-aware",
+    "-lparachain=debug,xcm=trace,runtime=trace,txpool=debug,basic-authorship=debug",
 ]
 command = "target/release/polka-storage-node"
-name = "charlie"
+name = "david"
 validator = true
-ws_port = 42069
+ws_port = 42068

--- a/zombienet/local-david-collator.toml
+++ b/zombienet/local-david-collator.toml
@@ -24,12 +24,12 @@ id = 1000
 # run david as parachain collator
 [[parachains.collators]]
 args = [
-    "--bootstrap-addresses=/ip4/127.0.0.1/tcp/62649",
-    "--detailed-log-output",
-    "--p2p-key=@/tmp/zombienet/david-private.pem",
-    "--p2p-listen-address=/ip4/127.0.0.1/tcp/1337",
-    "--pool-type=fork-aware",
-    "-lparachain=debug,xcm=trace,runtime=trace,txpool=debug,basic-authorship=debug",
+  "--bootstrap-addresses=/ip4/127.0.0.1/tcp/62649",
+  "--detailed-log-output",
+  "--p2p-key=@/tmp/zombienet/david-private.pem",
+  "--p2p-listen-address=/ip4/127.0.0.1/tcp/1337",
+  "--pool-type=fork-aware",
+  "-lparachain=debug,xcm=trace,runtime=trace,txpool=debug,basic-authorship=debug",
 ]
 command = "target/release/polka-storage-node"
 name = "david"

--- a/zombienet/local-kube-testnet.toml
+++ b/zombienet/local-kube-testnet.toml
@@ -28,7 +28,7 @@ id = 1000
 args = [
   "--bootstrap-addresses=/ip4/127.0.0.1/tcp/1337",
   "--detailed-log-output",
-  "--p2p-key=@/tmp/zombienet/private.pem",
+  "--p2p-key=@/tmp/zombienet/charlie-private.pem",
   "--p2p-listen-address=/ip4/127.0.0.1/tcp/62649",
   "-lparachain=debug,xcm=trace,runtime=trace",
 ]
@@ -36,19 +36,4 @@ command = "polka-storage-node"
 image = "polkadotstorage.azurecr.io/parachain-node:0.1.0"
 name = "charlie"
 rpc_port = 42069
-validator = true
-
-# run david as parachain collator
-[[parachains.collators]]
-args = [
-  "--bootstrap-addresses=/ip4/127.0.0.1/tcp/62649",
-  "--detailed-log-output",
-  "--p2p-key=@/tmp/zombienet/private.pem",
-  "--p2p-listen-address=/ip4/127.0.0.1/tcp/1337",
-  "-lparachain=debug,xcm=trace,runtime=trace",
-]
-command = "polka-storage-node"
-image = "polkadotstorage.azurecr.io/parachain-node:0.1.0"
-name = "david"
-rpc_port = 42068
 validator = true

--- a/zombienet/local-kube-testnet.toml
+++ b/zombienet/local-kube-testnet.toml
@@ -26,6 +26,7 @@ id = 1000
 # run charlie as parachain collator
 [[parachains.collators]]
 args = [
+  "--bootstrap-addresses=/ip4/127.0.0.1/tcp/1337",
   "--detailed-log-output",
   "--p2p-key=@/tmp/zombienet/private.pem",
   "--p2p-listen-address=/ip4/127.0.0.1/tcp/62649",
@@ -35,4 +36,19 @@ command = "polka-storage-node"
 image = "polkadotstorage.azurecr.io/parachain-node:0.1.0"
 name = "charlie"
 rpc_port = 42069
+validator = true
+
+# run david as parachain collator
+[[parachains.collators]]
+args = [
+  "--bootstrap-addresses=/ip4/127.0.0.1/tcp/62649",
+  "--detailed-log-output",
+  "--p2p-key=@/tmp/zombienet/private.pem",
+  "--p2p-listen-address=/ip4/127.0.0.1/tcp/1337",
+  "-lparachain=debug,xcm=trace,runtime=trace",
+]
+command = "polka-storage-node"
+image = "polkadotstorage.azurecr.io/parachain-node:0.1.0"
+name = "david"
+rpc_port = 42068
 validator = true


### PR DESCRIPTION
### Description

This PR adds gossipsub and request-response libp2p protocols to the bootstrap node.
The gossipsub protocol is used for bootstrap nodes to exchange peer information between each other, storing the information in a hashmap.
The request-response protocol is used for clients to request a peer id to multiaddrs mapping.

#### Layout of the P2P connections

![p2p](https://github.com/user-attachments/assets/ecf75a82-1925-4328-95f6-57058b214df8)

### Testing

- build and run the zombienet with `just t`
- run the david collator with `just run-collator`
- run the start_sp script in example `example/start_sp.sh`
- wait for registration to complete, while running the script keep note of the generated peer id, we will look up the multiaddrs using this peer ID.
```shell
examples/start_sp.sh
Generated new peer ID for //Charlie: 12D3KooWLDeoZ3MCdCgjdoEtymitioS7Q1r2u3CUme45XMQpxLPg
```
`12D3KooWLDeoZ3MCdCgjdoEtymitioS7Q1r2u3CUme45XMQpxLPg` will be our resolve-id
- check the collator david's log and search for the multiaddr and peer ID:
```shell
2025-02-12 15:05:25.944  INFO tokio-runtime-worker libp2p_swarm: [Parachain] local_peer_id=12D3KooWPNWqWXMGqufZErv8v6dBamCHNpFv58WXgWShfdB8tUCz <- we need this
2025-02-12 15:05:25.944  INFO tokio-runtime-worker polka_storage_node::service::p2p::bootstrap: [Parachain] Starting P2P bootstrap node at /ip4/127.0.0.1/tcp/1337 <- we need this
2025-02-12 15:05:25.944  INFO tokio-runtime-worker polka_storage_node::service::p2p::bootstrap: [Parachain] Dialing /ip4/127.0.0.1/tcp/62649    
2025-02-12 15:05:25.944  INFO tokio-runtime-worker polka_storage_node::service::p2p::bootstrap: [Parachain] Listening on /ip4/127.0.0.1/tcp/1337    
``` 
`12D3KooWPNWqWXMGqufZErv8v6dBamCHNpFv58WXgWShfdB8tUCz` will be out bootstrap-id
`/ip4/127.0.0.1/tcp/1337` will be our bootstrap-addr

- build and run the peer-resolver example with the values you extracted.
```
cargo build -p polka-storage-provider-client --example peer-resolver
...
RUST_LOG=info ./target/debug/examples/peer-resolver --bootstrap-addr "/ip4/127.0.0.1/tcp/1337" --bootstrap-id "12D3KooWPNWqWXMGqufZErv8v6dBamCHNpFv58WXgWShfdB8tUCz" --resolve-id "12D3KooWLDeoZ3MCdCgjdoEtymitioS7Q1r2u3CUme45XMQpxLPg"
2025-02-12T14:24:48.128725Z  INFO libp2p_swarm: local_peer_id=12D3KooWEgFkcaEYFyYent4UXwekLKPR8fqX2LTSNmqH7YsbSnos
Attempting to get multiaddrs for peer PeerId("12D3KooWLDeoZ3MCdCgjdoEtymitioS7Q1r2u3CUme45XMQpxLPg")
2025-02-12T14:24:48.142060Z  INFO peer_resolver: Connected to 12D3KooWPNWqWXMGqufZErv8v6dBamCHNpFv58WXgWShfdB8tUCz
2025-02-12T14:24:48.263090Z  INFO peer_resolver: Received response with id 1 from 12D3KooWPNWqWXMGqufZErv8v6dBamCHNpFv58WXgWShfdB8tUCz
Got multiaddrs [/ip4/127.0.0.1/tcp/46706] for peer PeerId("12D3KooWLDeoZ3MCdCgjdoEtymitioS7Q1r2u3CUme45XMQpxLPg")
```

These are quite a few steps. Should I write a script to test all of this?

### Improvements

Currently, bootstrap nodes do not recover their in memory db in the event that they go down.
This recovery can either be done by requesting all peers through the gossipsub protocol or adding an on-disk database that the bootstrap node writes to.