### PR TITLE
feat: configure feature flags for OpenCL and CUDA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,6 +3014,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "cumulus-client-cli"
 version = "0.7.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412#967989c5d94cb5d2060083ca7ddc5ac2cc2dd543"
@@ -5024,6 +5042,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fil-rustacuda"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40666d4072d5353fd2fd3aa26e4ddb225c38c6440e8c467cae9b17688ae6191c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cuda-driver-sys",
+ "rustacuda_core",
+ "rustacuda_derive",
+]
+
+[[package]]
 name = "file-guard"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5051,7 +5081,6 @@ checksum = "85413176cea16bfe171caafab023044820c0033b243b535b19116776ffd3f285"
 dependencies = [
  "anyhow",
  "bellperson",
- "blake2s_simd 1.0.2",
  "blstrs",
  "ff",
  "generic-array 0.14.7",
@@ -9787,9 +9816,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+checksum = "c9bdb1fb680e609c2e0930c1866cafdd0be7e7c7a1ecf92aec71ed8d99d3e133"
 dependencies = [
  "num-integer",
  "num-iter",
@@ -17171,6 +17200,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0ce78d5548a74fad25177825d0c20f4cfbc6eaf796bcee53afe792e39ede4e2"
 dependencies = [
+ "fil-rustacuda",
  "hex",
  "home",
  "log",
@@ -17179,6 +17209,23 @@ dependencies = [
  "sha2 0.10.8",
  "temp-env",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustacuda_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
+
+[[package]]
+name = "rustacuda_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,13 +156,13 @@ storagext = { path = "storagext/lib" }
 bellpepper-core = "0.2"
 bellperson = "0.26"
 blstrs = "0.7"
-filecoin-hashers = "13.1.0"
-filecoin-proofs = "18.1.0"
+filecoin-hashers = { version = "13.1.0", default-features = false }
+filecoin-proofs = { version = "18.1.0", default-features = false }
 fr32 = "11.1.0"
 generic-array = "1.1.0"
-storage-proofs-core = "18.1.0"
-storage-proofs-porep = "18.1.0"
-storage-proofs-post = "18.1.0"
+storage-proofs-core = { version = "18.1.0", default-features = false }
+storage-proofs-porep = { version = "18.1.0", default-features = false }
+storage-proofs-post = { version = "18.1.0", default-features = false }
 
 # Substrate
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2412" }

--- a/Justfile
+++ b/Justfile
@@ -48,11 +48,19 @@ build-polka-storage-node:
 
 # Build the polka storage provider client
 build-polka-storage-provider-client:
-  cargo build --release -p polka-storage-provider-client
+  if [ -n "${POLKA_STORAGE_CUDA+x}" ] && [ "${POLKA_STORAGE_CUDA}" = "true" ]; then \
+    cargo build --release -p polka-storage-provider-client --no-default-features --features cuda; \
+  else \
+    cargo build --release -p polka-storage-provider-client; \
+  fi
 
 # Build the polka storage provider server
 build-polka-storage-provider-server:
-  cargo build --release -p polka-storage-provider-server
+  if [ -n "${POLKA_STORAGE_CUDA+x}" ] && [ "${POLKA_STORAGE_CUDA}" = "true" ]; then \
+    cargo build --release -p polka-storage-provider-server --no-default-features --features cuda; \
+  else \
+    cargo build --release -p polka-storage-provider-server; \
+  fi
 
 build-polka-storage-provider: build-polka-storage-provider-server build-polka-storage-provider-client
 

--- a/docs/src/getting-started/building/source.md
+++ b/docs/src/getting-started/building/source.md
@@ -43,9 +43,28 @@ $ sudo apt install -y libhwloc-dev \
     curl
 ```
 
+### CUDA
+
+Running `polka-storage-provider-client` & `polka-storage-provider-server` via CUDA gives significant performance boosts
+as parts of the proving algorithm can be sent-off to the GPU. By default components are compiled with OpenCL.
+It's not possible to compile client without NVIDIA Graphics card.
+
 <div class="warning">
+**FOR DEVELOPERS**: It's possible to run CUDA on your WSL2, however the setup is different than for native linux installation.
+Details can be found <a href="https://docs.nvidia.com/cuda/wsl-user-guide/index.html">here</a>.
+</div>
+
+Requirements:
+* GCC 13
+* NVIDIA GPU
+* [Cuda drivers & toolkit (nvcc)](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#overview)
+
+
+<div class="warning">
+
 Not all of the binaries can be built from the polka-storage repository!
 We depend on the <a href="https://github.com/paritytech/zombienet/releases/tag/v1.3.116">zombienet</a> and <a href="https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2409-2">polkadot, polkadot-prepare-worker, polkadot-execute-worker</a> binaries which need to be downloaded regardless (if not using <a href="#using-nix">Nix</a>).
+
 </div>
 
 ## Using Nix
@@ -95,12 +114,20 @@ Where `<BINARY-NAME>` is one of:
 - `storagext-cli`
 - `mater-cli`
 
+If you want to use proofs with CUDA enabled acceleration, you need to set `cuda` feature flags for both `polka-storage-provider-client` and `polka-storage-provider-server`.
+
+```bash
+cargo build --release -p polka-storage-provider-client --no-default-features --features cuda
+cargo build --release -p polka-storage-provider-client --no-default-features --features cuda
+```
+
 
 For more information on what each binary does, refer to [Building](./index.md).
 
 ### Just recipes
 
 To simplify the building process, we've written some [Just](https://github.com/casey/just) recipes.
+If you set environment variable `POLKA_STORAGE_CUDA=true`,the commands below build both `polka-storage-provider-client` and `polka-storage-provider-server` with CUDA support.
 
 | Command                               | Description                                                                                                         |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/docs/src/getting-started/building/source.md
+++ b/docs/src/getting-started/building/source.md
@@ -47,7 +47,7 @@ $ sudo apt install -y libhwloc-dev \
 
 Running `polka-storage-provider-client` & `polka-storage-provider-server` via CUDA gives significant performance boosts
 as parts of the proving algorithm can be sent-off to the GPU. By default components are compiled with OpenCL.
-It's not possible to compile client without NVIDIA Graphics card.
+It's not possible to compile client without NVIDIA Graphics card if the CUDA feature is enabled.
 
 <div class="warning">
 **FOR DEVELOPERS**: It's possible to run CUDA on your WSL2, however the setup is different than for native linux installation.
@@ -117,7 +117,7 @@ Where `<BINARY-NAME>` is one of:
 If you want to use proofs with CUDA enabled acceleration, you need to set `cuda` feature flags for both `polka-storage-provider-client` and `polka-storage-provider-server`.
 
 ```bash
-cargo build --release -p polka-storage-provider-client --no-default-features --features cuda
+cargo build --release -p polka-storage-provider-server --no-default-features --features cuda
 cargo build --release -p polka-storage-provider-client --no-default-features --features cuda
 ```
 
@@ -127,7 +127,7 @@ For more information on what each binary does, refer to [Building](./index.md).
 ### Just recipes
 
 To simplify the building process, we've written some [Just](https://github.com/casey/just) recipes.
-If you set environment variable `POLKA_STORAGE_CUDA=true`,the commands below build both `polka-storage-provider-client` and `polka-storage-provider-server` with CUDA support.
+If you set environment variable `POLKA_STORAGE_CUDA=true`, the commands below build both `polka-storage-provider-client` and `polka-storage-provider-server` with CUDA support.
 
 | Command                               | Description                                                                                                         |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/lib/polka-storage-proofs/Cargo.toml
+++ b/lib/polka-storage-proofs/Cargo.toml
@@ -39,9 +39,9 @@ rstest = { workspace = true }
 workspace = true
 
 [features]
+cuda = ["filecoin-proofs?/cuda", "filecoin-proofs?/multicore-sdr", "std"]
 default = ["opencl"]
-cuda = ["std", "filecoin-proofs?/cuda",  "filecoin-proofs?/multicore-sdr"]
-opencl = ["std", "filecoin-proofs?/opencl",  "filecoin-proofs?/multicore-sdr"]
+opencl = ["filecoin-proofs?/multicore-sdr", "filecoin-proofs?/opencl", "std"]
 std = [
   "codec?/std",
   "dep:anyhow",

--- a/lib/polka-storage-proofs/Cargo.toml
+++ b/lib/polka-storage-proofs/Cargo.toml
@@ -39,7 +39,9 @@ rstest = { workspace = true }
 workspace = true
 
 [features]
-default = ["std"]
+default = ["opencl"]
+cuda = ["std", "filecoin-proofs?/cuda",  "filecoin-proofs?/multicore-sdr"]
+opencl = ["std", "filecoin-proofs?/opencl",  "filecoin-proofs?/multicore-sdr"]
 std = [
   "codec?/std",
   "dep:anyhow",

--- a/maat/Cargo.toml
+++ b/maat/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["target-debug", "target-release"]
+default = ["target-debug", "target-release", "opencl"]
 # Target the polka-storage-node in `target/debug` or `target/release`
 # if *both* flags are enabled, it will first check for `target/release`
 # and if not found, check for `target-debug`
@@ -17,6 +17,8 @@ default = ["target-debug", "target-release"]
 # `--no-default-features` flag and `--features` with your desired feature
 target-debug = []
 target-release = []
+opencl = ["polka-storage-proofs/opencl"]
+cuda = ["polka-storage-proofs/cuda"]
 
 [dependencies]
 bls12_381 = { workspace = true }

--- a/maat/Cargo.toml
+++ b/maat/Cargo.toml
@@ -8,17 +8,17 @@ repository.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["target-debug", "target-release", "opencl"]
+default = ["opencl", "target-debug", "target-release"]
 # Target the polka-storage-node in `target/debug` or `target/release`
 # if *both* flags are enabled, it will first check for `target/release`
 # and if not found, check for `target-debug`
 #
 # To forcefully test one of them only, run `cargo test` with the
 # `--no-default-features` flag and `--features` with your desired feature
+cuda = ["polka-storage-proofs/cuda"]
+opencl = ["polka-storage-proofs/opencl"]
 target-debug = []
 target-release = []
-opencl = ["polka-storage-proofs/opencl"]
-cuda = ["polka-storage-proofs/cuda"]
 
 [dependencies]
 bls12_381 = { workspace = true }

--- a/storage-provider/client/Cargo.toml
+++ b/storage-provider/client/Cargo.toml
@@ -42,6 +42,6 @@ libp2p = { workspace = true, features = ["identify", "macros", "noise", "rendezv
 workspace = true
 
 [features]
+cuda = ["polka-storage-proofs/cuda", "polka-storage-proofs/std", "polka-storage-proofs/substrate"]
 default = ["opencl"]
-cuda = ["polka-storage-proofs/std", "polka-storage-proofs/cuda", "polka-storage-proofs/substrate"]
-opencl = ["polka-storage-proofs/std", "polka-storage-proofs/opencl", "polka-storage-proofs/substrate"]
+opencl = ["polka-storage-proofs/opencl", "polka-storage-proofs/std", "polka-storage-proofs/substrate"]

--- a/storage-provider/client/Cargo.toml
+++ b/storage-provider/client/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 # "Homegrown" crates
 mater = { workspace = true }
-polka-storage-proofs = { workspace = true, features = ["std", "substrate"] }
+polka-storage-proofs = { workspace = true, default-features = false }
 polka-storage-provider-common = { workspace = true }
 primitives = { workspace = true, features = ["clap", "std"] }
 storagext = { workspace = true, features = ["clap"] }
@@ -40,3 +40,8 @@ libp2p = { workspace = true, features = ["identify", "macros", "noise", "rendezv
 
 [lints]
 workspace = true
+
+[features]
+default = ["opencl"]
+cuda = ["polka-storage-proofs/std", "polka-storage-proofs/cuda", "polka-storage-proofs/substrate"]
+opencl = ["polka-storage-proofs/std", "polka-storage-proofs/opencl", "polka-storage-proofs/substrate"]

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -8,13 +8,15 @@ repository.workspace = true
 version = "0.1.0"
 
 [features]
-default = []
+default = ["opencl"]
 delia = []
+cuda = ["polka-storage-proofs/std", "polka-storage-proofs/substrate", "polka-storage-proofs/cuda"]
+opencl = ["polka-storage-proofs/std", "polka-storage-proofs/substrate", "polka-storage-proofs/opencl"]
 
 [dependencies]
 # "Homegrown" crates
 mater = { workspace = true }
-polka-storage-proofs = { workspace = true, features = ["std", "substrate"] }
+polka-storage-proofs = { workspace = true, default-features = false }
 polka-storage-provider-common = { workspace = true, features = ["clap"] }
 primitives = { workspace = true, features = ["clap", "serde", "std"] }
 storagext = { workspace = true, features = ["clap"] }

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 version = "0.1.0"
 
 [features]
+cuda = ["polka-storage-proofs/cuda", "polka-storage-proofs/std", "polka-storage-proofs/substrate"]
 default = ["opencl"]
 delia = []
-cuda = ["polka-storage-proofs/std", "polka-storage-proofs/substrate", "polka-storage-proofs/cuda"]
-opencl = ["polka-storage-proofs/std", "polka-storage-proofs/substrate", "polka-storage-proofs/opencl"]
+opencl = ["polka-storage-proofs/opencl", "polka-storage-proofs/std", "polka-storage-proofs/substrate"]
 
 [dependencies]
 # "Homegrown" crates


### PR DESCRIPTION
### Description

We are not adding CUDA support directly to nix, because it doesn't make much sense for development.
I added instructions and tested both CUDA and OpenCL locally.

Hardware:
- Ryzen 9 3900X 12-Core Processor
- RTX 2070

512MiB sector -> CUDA 24min, OpenCL 26min.

Closes #723.


## OpenCL


```bash
$ FIL_PROOFS_USE_GPU_COLUMN_BUILDER=true FIL_PROOFS_USE_GPU_TREE_BUILDER=true RUST_LOG=debug ./target/debug/polka-storage-provider-client proofs porep --sr25519-key "//Charlie" --seal-proof 512MiB --proof-parameters-path ./target/porep_params_512MiB --sector-id 1 --seal-randomness-height 20 --pre-commit-block-number 30 --cache-directory /tmp/tst-cache ./examples/big_file_184k.car baga6ea4seaqhx2sxpfc2f3k2o75m3acskihug7me3g4coyw6adjqnd6ioszfqay
Entropy: 90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22
[...]
2025-02-12T00:40:56.974362Z DEBUG rust_gpu_tools::opencl::utils: loaded devices: [Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: Some((7, 7)), pci_id: PciId(11520), uuid: Some(00000000-0000-0000-0000-000000000000), device: Device { id: 139865216142320 } }]    
2025-02-12T00:40:56.974451Z DEBUG rust_gpu_tools::device: loaded devices: [Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: Some((7, 7)), pci_id: PciId(11520), uuid: Some(00000000-0000-0000-0000-000000000000), opencl: Some(Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: Some((7, 7)), pci_id: PciId(11520), uuid: Some(00000000-0000-0000-0000-000000000000), device: Device { id: 139865216142320 } }) }]    
2025-02-12T00:40:57.100086Z DEBUG rust_gpu_tools::opencl: Creating OpenCL program from source.    
2025-02-12T00:40:57.108374Z DEBUG rust_gpu_tools::opencl: Building kernel (/home/th7nder/.rust-gpu-tools/5483dbef4bdc1c27ef6da644dea433afa0a445e8c6241a2b7411fe16e182166f.bin) from source…    
2025-02-12T00:41:22.582228Z DEBUG rust_gpu_tools::opencl: Building kernel (/home/th7nder/.rust-gpu-tools/5483dbef4bdc1c27ef6da644dea433afa0a445e8c6241a2b7411fe16e182166f.bin) from source: done.    
[...]
2025-02-12T00:43:49.090913Z  INFO ec_gpu_gen::multiexp: Multiexp: Device 0: NVIDIA GeForce RTX 2070 (Chunk-size: 24604013)    
2025-02-12T00:43:49.090949Z  INFO bellperson::gpu::locks: GPU Multiexp kernel instantiated!    
2025-02-12T00:43:52.256124Z DEBUG bellperson::gpu::locks: GPU lock released at "/tmp/bellman.gpu.lock"    
2025-02-12T00:43:52.256702Z DEBUG bellperson::groth16::prover::native: proofs    
2025-02-12T00:43:52.257821Z  INFO bellperson::groth16::prover::native: prover time: 93.119206785s    
CommD: baga6ea4seaqnuopmbfcj3q7tj5vl2pszli2lnemxauvc7ul2zzb2a7tiawhhiei
CommR: bagboea4b5abcbmghocqaclelmfpugvc4gc4uz7ti62ge7gyj6cljqzocoswuexak
Proof: [Proof { a: G1Affine { x: Fp(0x0cb7f4647d69fdff5926fc6f8eeb06534d2bc305e7678dfc40320fa78ea7630297bf2899c2fb920eed02fa273b11ff0d), y: Fp
```

## CUDA


```
th7nder@stormheim:~/workspace/eiger/polka-storage$ FIL_PROOFS_USE_GPU_COLUMN_BUILDER=true FIL_PROOFS_USE_GPU_TREE_BUILDER=true RUST_LOG=debug ./target/debug/polka-storage-provider-client proofs porep --sr25519-key "//Charlie" --seal-proof 512MiB --proof-parameters-path ./target/porep_params_512MiB --sector-id 1 --seal-randomness-height 20 --pre-commit-block-number 30 --cache-directory /tmp/tst-cache ./examples/big_file_184k.car baga6ea4seaqhx2sxpfc2f3k2o75m3acskihug7me3g4coyw6adjqnd6ioszfqay
Entropy: 90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22
[...]
2025-02-12T01:18:07.066144Z  INFO storage_proofs_porep::stacked::vanilla::proof: Building column hashes    
2025-02-12T01:18:07.666715Z DEBUG rust_gpu_tools::opencl::utils: loaded devices: [Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: Some((7, 7)), pci_id: PciId(11520), uuid: Some(00000000-0000-0000-0000-000000000000), device: Device { id: 140321824850720 } }]    
2025-02-12T01:18:07.780588Z DEBUG rust_gpu_tools::cuda::utils: Loaded CUDA devices: [Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: (7, 5), pci_id: PciId(11520), uuid: Some(e80b78f9-1b43-1bf2-5e8b-afbad68262a8), context: UnownedContext { inner: 0x7f9f3943efc0 } }]    
2025-02-12T01:18:07.780698Z DEBUG rust_gpu_tools::device: loaded devices: [Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: Some((7, 7)), pci_id: PciId(11520), uuid: Some(00000000-0000-0000-0000-000000000000), cuda: Some(Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: (7, 5), pci_id: PciId(11520), uuid: Some(e80b78f9-1b43-1bf2-5e8b-afbad68262a8), context: UnownedContext { inner: 0x7f9f3943efc0 } }), opencl: Some(Device { vendor: Nvidia, name: "NVIDIA GeForce RTX 2070", memory: 8589475840, compute_units: 36, compute_capability: Some((7, 7)), pci_id: PciId(11520), uuid: Some(00000000-0000-0000-0000-000000000000), device: Device { id: 140321824850720 } }) }]    
2025-02-12T01:18:07.910196Z DEBUG rust_gpu_tools::cuda: Creating CUDA program from bytes.    
2025-02-12T01:18:07.974885Z DEBUG rust_gpu_tools::cuda: Creating CUDA program from bytes.   
[...]
2025-02-12T01:18:50.233742Z  INFO ec_gpu_gen::multiexp: Multiexp: Device 0: NVIDIA GeForce RTX 2070 (Chunk-size: 24604013)    
2025-02-12T01:18:50.233776Z  INFO bellperson::gpu::locks: GPU Multiexp kernel instantiated!    
2025-02-12T01:18:51.780959Z DEBUG bellperson::gpu::locks: GPU lock released at "/tmp/bellman.gpu.lock"    
2025-02-12T01:18:51.781543Z DEBUG bellperson::groth16::prover::native: proofs    
2025-02-12T01:18:51.782322Z  INFO bellperson::groth16::prover::native: prover time: 9.532915591s    
CommD: baga6ea4seaqnuopmbfcj3q7tj5vl2pszli2lnemxauvc7ul2zzb2a7tiawhhiei
CommR: bagboea4b5abcbmghocqaclelmfpugvc4gc4uz7ti62ge7gyj6cljqzocoswuexak
Proof: [Proof { a: G1Affine { x: Fp(0x11a28c5c73b9eb9b5efa2a799e66663f03416ef5417a06977022c79d77945c7b2df0c5c11c80ed8b198761c4a9739f36), y: Fp
```

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
- [X] Were there any alternative implementations considered?
