### PR TITLE
feat(sp-server): start_block based sealing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9817,9 +9817,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.43"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bdb1fb680e609c2e0930c1866cafdd0be7e7c7a1ecf92aec71ed8d99d3e133"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 dependencies = [
  "num-integer",
  "num-iter",

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -29,7 +29,7 @@ PIECE_CID="$(echo "$INPUT_COMMP" | jq -r ".cid")"
 PIECE_SIZE="$(echo "$INPUT_COMMP" | jq ".size")"
 
 
-for i in $(seq 194 200);
+for i in $(seq 80 90 | tac);
 do
     DEAL_JSON=$(
         jq -n \

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -6,17 +6,18 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
 
+mkdir -p /tmp/polka-storage-provider
+
 CLIENT="//Alice"
 PROVIDER="//Charlie"
 P2P_ADDRESS="/ip4/127.0.0.1/tcp/62649"
-P2P_PUBLIC_KEY="/tmp/polka-storage/public.pem"
-P2P_PRIVATE_KEY="/tmp/polka-storage/private.pem"
+P2P_PUBLIC_KEY="/tmp/polka-storage-provider/public.pem"
+P2P_PRIVATE_KEY="/tmp/polka-storage-provider/private.pem"
 P2P_BOOTSTRAP_PUBLIC_KEY="/tmp/zombienet/public.pem"
 # Config file location
-CONFIG="/tmp/storage-provider/config.toml"
+CONFIG="/tmp/polka-storage-provider/config.toml"
 
 # Generate ED25519 private key
-mkdir -p /tmp/storage-provider
 openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY"
 # -outpubkey is only available in OpenSSL 3.4.0 onwards
 # https://github.com/openssl/openssl/commit/6c03fa21ed4bbc9fd6d3013fdf9f4646d231f831
@@ -42,21 +43,22 @@ wait
 # It's a test setup based on the local verifying keys, everyone can run those extrinsics currently.
 # Each of the keys is different, because the processes are running in parallel.
 # If they were running in parallel on the same account, they'd conflict with each other on the transaction nonce.
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Charlie" storage-provider register "$P2P_SP_PEER_ID" &
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Alice" proofs set-porep-verifying-key @2KiB.porep.vk.scale &
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Bob" proofs set-post-verifying-key @2KiB.post.vk.scale &
+RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Charlie" storage-provider register --post-proof "8MiB" "$P2P_SP_PEER_ID" &
+RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Alice" proofs set-porep-verifying-key @8MiB.porep.vk.scale &
+RUST_LOG=debug target/release/storagext-cli --sr25519-key "//Bob" proofs set-post-verifying-key @8MiB.post.vk.scale &
 wait
 
-echo "seal_proof = '2KiB'
-post_proof = '2KiB'
-porep_parameters = '2KiB.porep.params'
-post_parameters = '2KiB.post.params'
+echo "seal_proof = '8MiB'
+post_proof = '8MiB'
+porep_parameters = '8MiB.porep.params'
+post_parameters = '8MiB.post.params'
 rendezvous_point_address = '$P2P_ADDRESS'
 p2p_key = '@$P2P_PRIVATE_KEY'
 rendezvous_point = '$P2P_BOOTSTRAP_PEER_ID'
 [sealing_configuration]
 fill_threshold = 80
-wait_deals_delay = '2m'" > "$CONFIG"
+wait_deals_delay = '1h'
+pre_commit_submission_slack = '1m'" > "$CONFIG"
 
 RUST_LOG=debug target/release/polka-storage-provider-server \
     --sr25519-key "$PROVIDER" \

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -60,6 +60,6 @@ fill_threshold = 80
 wait_deals_delay = '1h'
 pre_commit_submission_slack = '1m'" > "$CONFIG"
 
-RUST_LOG=debug target/release/polka-storage-provider-server \
+RUST_LOG="polka_storage_provider_server=debug" target/release/polka-storage-provider-server \
     --sr25519-key "$PROVIDER" \
     --config "$CONFIG"

--- a/primitives/src/sector/number.rs
+++ b/primitives/src/sector/number.rs
@@ -21,6 +21,7 @@ use crate::MAX_SECTORS;
     Ord,
     PartialOrd,
     Eq,
+    Hash,
     Encode,
     EncodeAsType,
     TypeInfo,

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -117,8 +117,8 @@ pub struct SealingConfiguration {
     #[cfg_attr(feature = "clap", arg(long, default_value = "6h", value_parser = duration_value_parser))]
     pub wait_deals_delay: Duration,
 
-    /// The amount of time before a sector's earliest deal expiration; once hit, the sector is
-    /// sealed & pre-committed.
+    /// The amount of time before a sector's earliest deal start; once hit, the sector is sealed &
+    /// pre-committed.
     #[serde(
         default = "default_pre_commit_submission_slack",
         deserialize_with = "duration_deserializer"

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -14,13 +14,17 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 /// Default amount of time to wait to seal an unfilled sector.
 const fn default_wait_deals_delay() -> Duration {
-    // 24 hours * 60 minutes * 60 seconds =
-    Duration::from_secs(24 * 60 * 60)
+    Duration::from_secs(6 * 60 * 60)
 }
 
 /// Returns the default fill percentage.
 const fn default_fill_threshold() -> u8 {
     95
+}
+
+/// Default amount of time before the expiration of the sectors earliest deal.
+const fn default_pre_commit_submission_slack() -> Duration {
+    Duration::from_secs(60 * 60)
 }
 
 fn validate_percentage(percentage: u8) -> Result<u8, String> {
@@ -105,14 +109,22 @@ pub struct SealingConfiguration {
     ))]
     pub fill_threshold: u8,
 
-    /// The amount of time to wait before sealing an unfilled sector, defaults to 24 hours.
-    /// If the sector is empty, it will not be sealed.
+    /// The amount of time to wait before sealing an unfilled sector, defaults to 6 hours.
     #[serde(
         default = "default_wait_deals_delay",
         deserialize_with = "duration_deserializer"
     )]
-    #[cfg_attr(feature = "clap", arg(long, default_value = "24h", value_parser = duration_value_parser))]
+    #[cfg_attr(feature = "clap", arg(long, default_value = "6h", value_parser = duration_value_parser))]
     pub wait_deals_delay: Duration,
+
+    /// The amount of time before a sector's earliest deal expiration; once hit, the sector is
+    /// sealed & pre-committed.
+    #[serde(
+        default = "default_pre_commit_submission_slack",
+        deserialize_with = "duration_deserializer"
+    )]
+    #[cfg_attr(feature = "clap", arg(long, default_value = "1h", value_parser = duration_value_parser))]
+    pub pre_commit_submission_slack: Duration,
 }
 
 // This default is implemented for when `sealing_configuration` is missing from the config file,
@@ -124,6 +136,7 @@ impl Default for SealingConfiguration {
         Self {
             fill_threshold: default_fill_threshold(),
             wait_deals_delay: default_wait_deals_delay(),
+            pre_commit_submission_slack: default_pre_commit_submission_slack(),
         }
     }
 }

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -10,7 +10,9 @@ mod pipeline;
 mod rpc;
 mod storage;
 
-use std::{env::temp_dir, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap, env::temp_dir, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration,
+};
 
 use clap::Parser;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
@@ -480,6 +482,7 @@ impl Server {
             pipeline_sender: pipeline_tx,
             prove_commit_throttle: Arc::new(Semaphore::new(self.parallel_prove_commits)),
             add_piece_serializer: Mutex::new(()),
+            scheduled_pre_commits: Mutex::new(HashMap::new()),
         };
 
         let p2p_state = P2PState {

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -390,6 +390,8 @@ impl Server {
             cancellation_token.child_token(),
         ));
 
+        tracing::info!("Successfully launched all sub-services, ready for work!");
+
         // Wait for SIGTERM on the main thread and once received "unblock"
         tokio::signal::ctrl_c()
             .await

--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -9,7 +9,7 @@ use primitives::{
     sector::SectorNumber,
 };
 use storagext::{types::market::DealProposal, SystemClientExt};
-use tokio::task::JoinHandle;
+use tokio::sync::oneshot;
 use tokio_util::task::TaskTracker;
 use tracing::Instrument;
 
@@ -164,28 +164,42 @@ async fn schedule_pre_commit(
     let deadline = Utc::now() + when;
     let mut scheduled_pre_commits = state.scheduled_pre_commits.lock().await;
     match scheduled_pre_commits.get_mut(&sector_number) {
-        Some((old_deadline, old_abort_handle)) if deadline < *old_deadline => {
-            tracing::debug!(%sector_number, old_task_id = %old_abort_handle.id(), "Existing deadline is older than the new one, aborting existing task: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
-            old_abort_handle.abort();
-
+        Some((old_deadline, old_cancellation_sender)) if deadline < *old_deadline => {
+            tracing::debug!(%sector_number, "Existing deadline is older than the new one, cancelling existing task: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
             let state_for_task = state.clone();
-            let scheduled_pre_commit =
-                schedule_send_pre_commit(state_for_task, tracker, sector_number, when);
+
+            let (cancellation_sender, cancellation_receiver) = oneshot::channel();
+            schedule_send_pre_commit(
+                state_for_task,
+                tracker,
+                sector_number,
+                when,
+                cancellation_receiver,
+            );
+
             *old_deadline = deadline;
-            *old_abort_handle = scheduled_pre_commit.abort_handle();
-            tracing::debug!(%sector_number, "Existing deadline & task have been replaced: new_task_id = {}, new_deadline = {}", scheduled_pre_commit.id(), deadline);
+            let old_abort_handle = std::mem::replace(old_cancellation_sender, cancellation_sender);
+            if old_abort_handle.send(()).is_err() {
+                tracing::error!("Failed to send cancellation value");
+            }
+
+            tracing::debug!(%sector_number, "Existing deadline & task have been replaced: new_deadline = {}", deadline);
         }
-        Some((old_deadline, old_abort_handle)) => {
-            tracing::debug!(%sector_number, old_task_id = %old_abort_handle.id(), "Existing deadling is newer than the new one: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
+        Some((old_deadline, _)) => {
+            tracing::debug!(%sector_number, "Existing deadline is newer than the new one: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
         }
         None => {
+            tracing::debug!(%sector_number, "No deadline existing existed, creating it.");
+            let (cancellation_sender, cancellation_receiver) = oneshot::channel();
             let state_for_task = state.clone();
-            let scheduled_pre_commit =
-                schedule_send_pre_commit(state_for_task, tracker, sector_number, when);
-            scheduled_pre_commits.insert(
+            schedule_send_pre_commit(
+                state_for_task,
+                tracker,
                 sector_number,
-                (deadline, scheduled_pre_commit.abort_handle()),
+                when,
+                cancellation_receiver,
             );
+            scheduled_pre_commits.insert(sector_number, (deadline, cancellation_sender));
         }
     }
 }
@@ -196,7 +210,8 @@ fn schedule_send_pre_commit(
     tracker: TaskTracker,
     sector_number: SectorNumber,
     when: Duration,
-) -> JoinHandle<()> {
+    cancellation_receiver: oneshot::Receiver<()>,
+) {
     let span = tracing::info_span!("add_piece");
     tracing::info!(
         // Since the span is moved for the instrument call, we can't span.enter()
@@ -206,9 +221,20 @@ fn schedule_send_pre_commit(
         when.as_secs()
     );
     // We don't care for the returned JoinHandle, but that's ok because the TaskTracker has it!
-    tracker.spawn(
+    let _ = tracker.spawn(
         async move {
-            tokio::time::sleep(when).await;
+            match tokio::time::timeout(when, cancellation_receiver).await {
+                Ok(Ok(())) => {
+                    tracing::debug!(%sector_number, "Received cancellation signal, not sending message.");
+                    return;
+                },
+                Ok(Err(err)) => {
+                    tracing::error!(%sector_number, "Failed to receive message with error (will return): {err}");
+                    return;
+                },
+                Err(_elapsed) => tracing::debug!(%sector_number, "No cancelation signal was received"),
+            }
+
             tracing::info!(%sector_number, "Awoken from sleep, submitting pre-commit task!");
             match state.send_pre_commit(sector_number) {
                 Ok(()) => tracing::info!(%sector_number, "Successfully submitted task!"),
@@ -218,5 +244,5 @@ fn schedule_send_pre_commit(
             }
         }
         .instrument(span),
-    )
+    );
 }

--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -19,9 +19,9 @@ use crate::{
 };
 
 /// Finds a sector to which a piece will fit and adds it to the sector.
-/// This function is *cancellation safe* as if future is dropped,
-/// it can be dropped only when waiting for `spawn_blocking`.
-/// When dropped when waiting, the sector state won't be preserved and adding piece can be retried.
+///
+/// This function is *not* cancellation safe. If cancelled the system state may become inconsistent
+/// and the sector the piece belongs to may never be scheduled for pre-commit.
 #[tracing::instrument(skip(tracker, state, deal, commitment))]
 pub async fn add_piece(
     tracker: TaskTracker,
@@ -61,8 +61,6 @@ pub async fn add_piece(
             fill_percentage,
             fill_threshold,
         );
-        // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
-        // Ideally sector won't be finalized after one piece has been added and the precommit will depend on the start_block?
         return state.send_pre_commit(sector_number);
     }
     tracing::debug!(
@@ -104,7 +102,7 @@ async fn find_or_create_sector_for_piece(
         Ok(unsealed_sector) => {
             let free_space = unsealed_sector.free_space();
             tracing::debug!(sector_number = %unsealed_sector.sector_number, free_space = free_space, "Checking sector...");
-            free_space > deal.piece_size
+            free_space >= deal.piece_size
         },
         // Errors return false since, well, they're not valid sectors
         _ => false,
@@ -160,11 +158,11 @@ async fn schedule_pre_commit(
     sector_number: SectorNumber,
     when: Duration,
 ) {
-    let deadline = Utc::now() + when;
+    let precommit_target_time = Utc::now() + when;
     let mut scheduled_pre_commits = state.scheduled_pre_commits.lock().await;
     match scheduled_pre_commits.get_mut(&sector_number) {
-        Some((old_deadline, old_cancellation_sender)) if deadline < *old_deadline => {
-            tracing::debug!(%sector_number, "Existing deadline is older than the new one, cancelling existing task: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
+        Some((old_deadline, old_cancellation_sender)) if precommit_target_time < *old_deadline => {
+            tracing::debug!(%sector_number, "Existing deadline is older than the new one, cancelling existing task: old_deadline = {}, new_deadline = {}", old_deadline, precommit_target_time);
             let state_for_task = state.clone();
 
             let (cancellation_sender, cancellation_receiver) = oneshot::channel();
@@ -176,20 +174,20 @@ async fn schedule_pre_commit(
                 cancellation_receiver,
             );
 
-            *old_deadline = deadline;
+            *old_deadline = precommit_target_time;
             let old_cancellation_sender =
                 std::mem::replace(old_cancellation_sender, cancellation_sender);
             if old_cancellation_sender.send(()).is_err() {
                 tracing::error!("Failed to send cancellation value");
             }
 
-            tracing::debug!(%sector_number, "Existing deadline & task have been replaced: new_deadline = {}", deadline);
+            tracing::debug!(%sector_number, "Existing deadline & task have been replaced: new_deadline = {}", precommit_target_time);
         }
         Some((old_deadline, _)) => {
-            tracing::debug!(%sector_number, "Existing deadline is newer than the new one: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
+            tracing::debug!(%sector_number, "Existing deadline is newer than the new one: old_deadline = {}, new_deadline = {}", old_deadline, precommit_target_time);
         }
         None => {
-            tracing::debug!(%sector_number, "No deadline existing existed, creating it.");
+            tracing::debug!(%sector_number, "Pre-commit wasn't scheduled, scheduling it to execute at {}.", precommit_target_time);
             let (cancellation_sender, cancellation_receiver) = oneshot::channel();
             let state_for_task = state.clone();
             schedule_send_pre_commit(
@@ -199,7 +197,8 @@ async fn schedule_pre_commit(
                 when,
                 cancellation_receiver,
             );
-            scheduled_pre_commits.insert(sector_number, (deadline, cancellation_sender));
+            scheduled_pre_commits
+                .insert(sector_number, (precommit_target_time, cancellation_sender));
         }
     }
 }

--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -63,7 +63,7 @@ pub async fn add_piece(
         );
         // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
         // Ideally sector won't be finalized after one piece has been added and the precommit will depend on the start_block?
-        return Ok(state.send_pre_commit(sector_number)?);
+        return state.send_pre_commit(sector_number);
     }
     tracing::debug!(
         %sector_number,
@@ -119,12 +119,11 @@ async fn find_or_create_sector_for_piece(
     if let Some(sector) = sector {
         // NOTE(@jmg-duarte,03/02/2025): as per our filter, errors return false, as such an error couldn't be returned
         return sector
-            .map(|sector| {
+            .inspect(|sector| {
                 tracing::debug!(
                     sector_number = %sector.sector_number,
                     "Found sector for piece!",
                 );
-                sector
             })
             .map_err(PipelineError::from);
     }

--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -1,0 +1,222 @@
+//! Module containing the implementation for the add piece phase.
+
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use chrono::Utc;
+use polka_storage_provider_common::sector::UnsealedSector;
+use primitives::{
+    commitment::{CommP, Commitment},
+    sector::SectorNumber,
+};
+use storagext::{types::market::DealProposal, SystemClientExt};
+use tokio::task::JoinHandle;
+use tokio_util::task::TaskTracker;
+use tracing::Instrument;
+
+use crate::{
+    pipeline::{PipelineError, PipelineState},
+    rpc::SECS_PER_BLOCK,
+};
+
+/// Finds a sector to which a piece will fit and adds it to the sector.
+/// This function is *cancellation safe* as if future is dropped,
+/// it can be dropped only when waiting for `spawn_blocking`.
+/// When dropped when waiting, the sector state won't be preserved and adding piece can be retried.
+#[tracing::instrument(skip(tracker, state, deal, commitment))]
+pub async fn add_piece(
+    tracker: TaskTracker,
+    state: Arc<PipelineState>,
+    piece_path: PathBuf,
+    commitment: Commitment<CommP>,
+    deal: DealProposal,
+    deal_id: u64,
+) -> Result<(), PipelineError> {
+    // This guard MUST be scoped to the entire add_piece logic!
+    // Otherwise, depending on the fill percentage it can happen that two tasks try to send
+    // pre_commit messages that would later result in processing issues.
+    // Given a fill_threshold that is low enough, without a lock on this entire method,
+    // if two pieces are added past the fill threshold, two pre commit messages will be sent
+    // which will then race and create issues
+    let _guard = state.add_piece_serializer.lock().await;
+
+    let deal_start_block = deal.start_block;
+
+    tracing::info!("Adding a piece...");
+    let mut sector = find_or_create_sector_for_piece(&state, &deal).await?;
+    sector
+        .add_piece(deal_id, deal, piece_path, commitment)
+        .await?;
+    let sector_number = sector.sector_number;
+    tracing::info!(%sector_number, "Finished adding a piece");
+
+    // Update the database with the latest sector information
+    state.db.insert_unsealed_sector(sector_number, &sector)?;
+
+    let fill_percentage = sector.fill_percentage();
+    let fill_threshold = state.server_info.sealing_configuration.fill_threshold as u64;
+    if fill_percentage >= fill_threshold {
+        tracing::debug!(
+            %sector_number,
+            "Occupation level at {}%, above limit of {}% - pre-committing",
+            fill_percentage,
+            fill_threshold,
+        );
+        // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
+        // Ideally sector won't be finalized after one piece has been added and the precommit will depend on the start_block?
+        return Ok(state.send_pre_commit(sector_number)?);
+    }
+    tracing::debug!(
+        %sector_number,
+        "Occupation at {}; not pre-committing yet",
+        fill_percentage
+    );
+
+    let current_block = state.xt_client.height(true).await?;
+    let duration_to_deal_start =
+        Duration::from_secs((deal_start_block - current_block) * SECS_PER_BLOCK);
+    let when = std::cmp::min(
+        state.server_info.sealing_configuration.wait_deals_delay,
+        duration_to_deal_start,
+    );
+    // We always try to schedule a new pre-commit
+    schedule_pre_commit(state.clone(), tracker, sector_number, when).await;
+
+    Ok(())
+}
+
+/// Finds or creates a sector for the given piece. Returns the [`UnsealedSector`] and a `bool`
+/// indicating if the sector was created or not.
+///
+/// * If no sectors exist, it creates one and returns it.
+/// * If no sectors with enough size to harbor the piece exist, it creates one and returns it.
+/// * If a sector with enough size to harbor the piece exists, it returns it.
+#[tracing::instrument(skip_all)]
+async fn find_or_create_sector_for_piece(
+    state: &Arc<PipelineState>,
+    deal: &DealProposal, // We pass the DealProposal instead of the sector number for better logs
+) -> Result<UnsealedSector, PipelineError> {
+    tracing::debug!(
+        "Searching for sector for piece with size: {}",
+        deal.piece_size
+    );
+    // Find the first sector with enough space for the piece
+    let sector = state.db.iter_unsealed_sectors().find(|res| match res {
+        Ok(unsealed_sector) => {
+            let free_space = unsealed_sector.free_space();
+            tracing::debug!(sector_number = %unsealed_sector.sector_number, free_space = free_space, "Checking sector...");
+            free_space > deal.piece_size
+        },
+        // Errors return false since, well, they're not valid sectors
+        _ => false,
+    });
+
+    // If we found a sector with space, we return it, otherwise, we'll create a new one
+    // NOTE(@jmg-duarte,03/02/2025): we can't keep creating sectors forever just because they dont fit
+    // (or maybe we can) but FC keeps a limit on new sectors, I don't have a solution for this NOW
+    // but we can keep this here while this implementation develops
+    // (possible) SOLUTION: pre-check sector availability when receiving deals and decide there
+    // whether we're taking the deal or not
+    if let Some(sector) = sector {
+        // NOTE(@jmg-duarte,03/02/2025): as per our filter, errors return false, as such an error couldn't be returned
+        return sector
+            .map(|sector| {
+                tracing::debug!(
+                    sector_number = %sector.sector_number,
+                    "Found sector for piece!",
+                );
+                sector
+            })
+            .map_err(PipelineError::from);
+    }
+
+    // NOTE(@jmg-duarte,03/02/2025): comment below no longer applies but im keeping it until
+    // we have a full implementation in place
+    // TODO(@th7nder,30/10/2024): simplification, we're always creating a new sector for storing a piece.
+    // It should not work like that, sectors should be filled with pieces according to *some* algorithm.
+    let sector_number = state
+        .db
+        .next_sector_number()
+        .map_err(|err| PipelineError::CustomError(err.to_string()))?;
+    tracing::debug!(%sector_number, "Could not find a sector for piece, creating a new one...");
+
+    let unsealed_path = state.unsealed_sectors_dir.join(sector_number.to_string());
+    let sector =
+        UnsealedSector::create(state.server_info.seal_proof, sector_number, unsealed_path).await?;
+
+    Ok(sector)
+}
+
+/// Schedule a pre commit.
+///
+/// Calls to this function *MUST NOT* be made while holding a [`MutexGuard`] for `scheduled_pre_commits`.
+///
+/// If no pre-commit task has been previously scheduled, a new one is scheduled.
+/// If an existing pre-commit task is scheduled to be executed *after* the new deadline,
+/// that task will be cancelled and replaced with the new one.
+/// Otherwise, this function is a no-op.
+#[tracing::instrument(skip_all)]
+async fn schedule_pre_commit(
+    state: Arc<PipelineState>,
+    tracker: TaskTracker,
+    sector_number: SectorNumber,
+    when: Duration,
+) {
+    let deadline = Utc::now() + when;
+    let mut scheduled_pre_commits = state.scheduled_pre_commits.lock().await;
+    match scheduled_pre_commits.get_mut(&sector_number) {
+        Some((old_deadline, old_abort_handle)) if deadline < *old_deadline => {
+            tracing::debug!(%sector_number, old_task_id = %old_abort_handle.id(), "Existing deadline is older than the new one, aborting existing task: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
+            old_abort_handle.abort();
+
+            let state_for_task = state.clone();
+            let scheduled_pre_commit =
+                schedule_send_pre_commit(state_for_task, tracker, sector_number, when);
+            *old_deadline = deadline;
+            *old_abort_handle = scheduled_pre_commit.abort_handle();
+            tracing::debug!(%sector_number, "Existing deadline & task have been replaced: new_task_id = {}, new_deadline = {}", scheduled_pre_commit.id(), deadline);
+        }
+        Some((old_deadline, old_abort_handle)) => {
+            tracing::debug!(%sector_number, old_task_id = %old_abort_handle.id(), "Existing deadling is newer than the new one: old_deadline = {}, new_deadline = {}", old_deadline, deadline);
+        }
+        None => {
+            let state_for_task = state.clone();
+            let scheduled_pre_commit =
+                schedule_send_pre_commit(state_for_task, tracker, sector_number, when);
+            scheduled_pre_commits.insert(
+                sector_number,
+                (deadline, scheduled_pre_commit.abort_handle()),
+            );
+        }
+    }
+}
+
+/// *Unconditionally* schedule a pre commit.
+fn schedule_send_pre_commit(
+    state: Arc<PipelineState>,
+    tracker: TaskTracker,
+    sector_number: SectorNumber,
+    when: Duration,
+) -> JoinHandle<()> {
+    let span = tracing::info_span!("add_piece");
+    tracing::info!(
+        // Since the span is moved for the instrument call, we can't span.enter()
+        // doing a span.in_scope(|| ...) is also a bit overkill for a log
+        parent: &span,
+        "Launching task to pre-commit in {} seconds",
+        when.as_secs()
+    );
+    // We don't care for the returned JoinHandle, but that's ok because the TaskTracker has it!
+    tracker.spawn(
+        async move {
+            tokio::time::sleep(when).await;
+            tracing::info!(%sector_number, "Awoken from sleep, submitting pre-commit task!");
+            match state.send_pre_commit(sector_number) {
+                Ok(()) => tracing::info!(%sector_number, "Successfully submitted task!"),
+                // Not sure what we can do if the task fails, maybe try to re-submit?
+                // Not even sure when this can happen asides from an OOM since we're using an unbounded channel
+                Err(err) => tracing::error!(%sector_number, "Failed to submit task: {}", err),
+            }
+        }
+        .instrument(span),
+    )
+}

--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -177,8 +177,9 @@ async fn schedule_pre_commit(
             );
 
             *old_deadline = deadline;
-            let old_abort_handle = std::mem::replace(old_cancellation_sender, cancellation_sender);
-            if old_abort_handle.send(()).is_err() {
+            let old_cancellation_sender =
+                std::mem::replace(old_cancellation_sender, cancellation_sender);
+            if old_cancellation_sender.send(()).is_err() {
                 tracing::error!("Failed to send cancellation value");
             }
 

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -1,7 +1,9 @@
+mod add_piece;
 pub mod types;
 
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
+use chrono::{DateTime, Utc};
 use polka_storage_proofs::{
     porep::PoRepParameters,
     post::{PoStError, PoStParameters},
@@ -9,25 +11,27 @@ use polka_storage_proofs::{
 use polka_storage_provider_common::{
     deadline::Deadline,
     rpc::ServerInfo,
-    sector::{PreCommittedSector, ProvenSector, SectorError, UnsealedSector},
+    sector::{PreCommittedSector, ProvenSector, SectorError},
 };
-use primitives::{
-    commitment::{CommP, Commitment},
-    sector::SectorNumber,
-};
-use storagext::{types::market::DealProposal, StorageProviderClientExt};
-use tokio::sync::{
-    mpsc::{error::SendError, UnboundedReceiver, UnboundedSender},
-    Mutex, Semaphore,
+use primitives::sector::SectorNumber;
+use storagext::StorageProviderClientExt;
+use tokio::{
+    sync::{
+        mpsc::{error::SendError, UnboundedReceiver, UnboundedSender},
+        Mutex, Semaphore,
+    },
+    task::AbortHandle,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::Instrument;
 use types::{
     AddPieceMessage, PipelineMessage, PreCommitMessage, ProveCommitMessage,
     SubmitWindowedPoStMessage,
 };
 
-use crate::db::{DBError, DealDB};
+use crate::{
+    db::{DBError, DealDB},
+    pipeline::add_piece::add_piece,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PipelineError {
@@ -79,6 +83,18 @@ pub struct PipelineState {
     // transactions + get_for_update(exclusive: true)
     // This is not trivial and requires a refactor on the DB side!
     pub add_piece_serializer: Mutex<()>,
+
+    // Store the estimated date of execution of the task and its abort handle for re-scheduling
+    pub scheduled_pre_commits: Mutex<HashMap<SectorNumber, (DateTime<Utc>, AbortHandle)>>,
+}
+
+impl PipelineState {
+    /// Sends a [`PreCommitMessage`](crate::pipeline::types::PreCommitMessage) to the pipeline.
+    fn send_pre_commit(&self, sector_number: SectorNumber) -> Result<(), PipelineError> {
+        Ok(self
+            .pipeline_sender
+            .send(PipelineMessage::pre_commit(sector_number))?)
+    }
 }
 
 #[tracing::instrument(skip_all)]
@@ -265,162 +281,6 @@ fn process(
         }
         PipelineMessage::SchedulePoSts => tracker.schedule_posts(state.clone()),
     }
-}
-
-/// Finds or creates a sector for the given piece. Returns the [`UnsealedSector`] and a `bool`
-/// indicating if the sector was created or not.
-///
-/// * If no sectors exist, it creates one and returns it.
-/// * If no sectors with enough size to harbor the piece exist, it creates one and returns it.
-/// * If a sector with enough size to harbor the piece exists, it returns it.
-#[tracing::instrument(skip_all)]
-async fn find_or_create_sector_for_piece(
-    state: &Arc<PipelineState>,
-    deal: &DealProposal, // We pass the DealProposal instead of the sector number for better logs
-) -> Result<(UnsealedSector, bool), PipelineError> {
-    tracing::debug!(
-        "Searching for sector for piece with size: {}",
-        deal.piece_size
-    );
-    // Find the first sector with enough space for the piece
-    let sector = state.db.iter_unsealed_sectors().find(|res| match res {
-        Ok(unsealed_sector) => {
-            let free_space = unsealed_sector.free_space();
-            tracing::debug!(sector_number = %unsealed_sector.sector_number, free_space = free_space, "Checking sector...");
-            free_space > deal.piece_size
-        },
-        // Errors return false since, well, they're not valid sectors
-        _ => false,
-    });
-
-    // If we found a sector with space, we return it, otherwise, we'll create a new one
-    // NOTE(@jmg-duarte,03/02/2025): we can't keep creating sectors forever just because they dont fit
-    // (or maybe we can) but FC keeps a limit on new sectors, I don't have a solution for this NOW
-    // but we can keep this here while this implementation develops
-    // (possible) SOLUTION: pre-check sector availability when receiving deals and decide there
-    // whether we're taking the deal or not
-    if let Some(sector) = sector {
-        // NOTE(@jmg-duarte,03/02/2025): as per our filter, errors return false, as such an error couldn't be returned
-        return sector
-            .map(|sector| {
-                tracing::debug!(
-                    sector_number = %sector.sector_number,
-                    "Found sector for piece!",
-                );
-                (sector, false)
-            })
-            .map_err(PipelineError::from);
-    }
-
-    // NOTE(@jmg-duarte,03/02/2025): comment below no longer applies but im keeping it until
-    // we have a full implementation in place
-    // TODO(@th7nder,30/10/2024): simplification, we're always creating a new sector for storing a piece.
-    // It should not work like that, sectors should be filled with pieces according to *some* algorithm.
-    let sector_number = state
-        .db
-        .next_sector_number()
-        .map_err(|err| PipelineError::CustomError(err.to_string()))?;
-    tracing::debug!(%sector_number, "Could not find a sector for piece, creating a new one...");
-
-    let unsealed_path = state.unsealed_sectors_dir.join(sector_number.to_string());
-    let sector =
-        UnsealedSector::create(state.server_info.seal_proof, sector_number, unsealed_path).await?;
-
-    Ok((sector, true))
-}
-
-/// Finds a sector to which a piece will fit and adds it to the sector.
-/// This function is *cancellation safe* as if future is dropped,
-/// it can be dropped only when waiting for `spawn_blocking`.
-/// When dropped when waiting, the sector state won't be preserved and adding piece can be retried.
-#[tracing::instrument(skip(state, deal, commitment))]
-async fn add_piece(
-    tracker: TaskTracker,
-    state: Arc<PipelineState>,
-    piece_path: PathBuf,
-    commitment: Commitment<CommP>,
-    deal: DealProposal,
-    deal_id: u64,
-) -> Result<(), PipelineError> {
-    // This guard MUST be scoped to the entire add_piece logic!
-    // Otherwise, depending on the fill percentage it can happen that two tasks try to send
-    // pre_commit messages that would later result in processing issues.
-    // Given a fill_threshold that is low enough, without a lock on this entire method,
-    // if two pieces are added past the fill threshold, two pre commit messages will be sent
-    // which will then race and create issues
-    let _guard = state.add_piece_serializer.lock().await;
-
-    tracing::info!("Adding a piece...");
-    let (mut sector, created) = find_or_create_sector_for_piece(&state, &deal).await?;
-
-    sector
-        .add_piece(deal_id, deal, piece_path, commitment)
-        .await?;
-    tracing::info!("Finished adding a piece");
-
-    // Update the database with the latest sector information
-    state
-        .db
-        .insert_unsealed_sector(sector.sector_number, &sector)?;
-
-    let fill_percentage = sector.fill_percentage();
-    let fill_threshold = state.server_info.sealing_configuration.fill_threshold as u64;
-    if fill_percentage > fill_threshold {
-        tracing::debug!(
-            "Occupation level at {}%, above limit of {}% - pre-committing",
-            fill_percentage,
-            fill_threshold,
-        );
-        // TODO(@th7nder,30/10/2024): simplification, as we're always scheduling a precommit just after adding a piece and creating a new sector.
-        // Ideally sector won't be finalized after one piece has been added and the precommit will depend on the start_block?
-        return Ok(state
-            .pipeline_sender
-            .send(PipelineMessage::PreCommit(PreCommitMessage {
-                sector_number: sector.sector_number,
-            }))?);
-    }
-    tracing::debug!(
-        sector_number = %sector.sector_number,
-        "Occupation at {}; not pre-committing yet",
-        fill_percentage
-    );
-
-    // If the sector is new, we schedule it's pre-commit task submission
-    if created {
-        schedule_pre_commit(state.clone(), tracker, sector);
-    }
-
-    Ok(())
-}
-
-fn schedule_pre_commit(state: Arc<PipelineState>, tracker: TaskTracker, sector: UnsealedSector) {
-    let delay = state.server_info.sealing_configuration.wait_deals_delay;
-    let span = tracing::info_span!("add_piece");
-    tracing::info!(
-        // Since the span is moved for the instrument call, we can't span.enter()
-        // doing a span.in_scope(|| ...) is also a bit overkill for a log
-        parent: &span,
-        "Sector was created, launching task to pre-commit in {} seconds",
-        delay.as_secs()
-    );
-    // We don't care for the returned JoinHandle, but that's ok because the TaskTracker has it!
-    let _ = tracker.spawn(
-        async move {
-            tokio::time::sleep(delay).await;
-            let sector_number = sector.sector_number;
-            tracing::info!(%sector_number, "Awoken from sleep, submitting pre-commit task!");
-            match state
-                .pipeline_sender
-                .send(PipelineMessage::pre_commit(sector_number))
-            {
-                Ok(()) => tracing::info!(%sector_number, "Successfully submitted task!"),
-                // Not sure what we can do if the task fails, maybe try to re-submit?
-                // Not even sure when this can happen asides from an OOM since we're using an unbounded channel
-                Err(err) => tracing::error!(%sector_number, "Failed to submit task: {}", err),
-            }
-        }
-        .instrument(span),
-    );
 }
 
 /// Creates a replica and calls pre-commit on-chain.

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -15,12 +15,9 @@ use polka_storage_provider_common::{
 };
 use primitives::sector::SectorNumber;
 use storagext::StorageProviderClientExt;
-use tokio::{
-    sync::{
-        mpsc::{error::SendError, UnboundedReceiver, UnboundedSender},
-        Mutex, Semaphore,
-    },
-    task::AbortHandle,
+use tokio::sync::{
+    mpsc::{error::SendError, UnboundedReceiver, UnboundedSender},
+    oneshot, Mutex, Semaphore,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use types::{
@@ -85,7 +82,7 @@ pub struct PipelineState {
     pub add_piece_serializer: Mutex<()>,
 
     // Store the estimated date of execution of the task and its abort handle for re-scheduling
-    pub scheduled_pre_commits: Mutex<HashMap<SectorNumber, (DateTime<Utc>, AbortHandle)>>,
+    pub scheduled_pre_commits: Mutex<HashMap<SectorNumber, (DateTime<Utc>, oneshot::Sender<()>)>>,
 }
 
 impl PipelineState {
@@ -295,6 +292,15 @@ async fn precommit(
     sector_number: SectorNumber,
 ) -> Result<(), PipelineError> {
     tracing::info!("Starting pre-commit");
+
+    {
+        // We remove ourselves from the scheduled pre-commits
+        let mut scheduled_pre_commits = state.scheduled_pre_commits.lock().await;
+        if scheduled_pre_commits.remove(&sector_number).is_none() {
+            tracing::warn!(%sector_number, "No task was found!");
+            // Maybe we should do an early return in this case?
+        }
+    }
 
     // This unit of work effectively works as a "block", since `remove_unsealed_sector`
     // blocks the row it removes, meaning that even if two tasks race here,

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -297,8 +297,8 @@ async fn precommit(
         // We remove ourselves from the scheduled pre-commits
         let mut scheduled_pre_commits = state.scheduled_pre_commits.lock().await;
         if scheduled_pre_commits.remove(&sector_number).is_none() {
-            tracing::warn!(%sector_number, "No task was found!");
-            // Maybe we should do an early return in this case?
+            tracing::warn!(%sector_number, "No task was found! Not pre-committing.");
+            return Ok(());
         }
     }
 

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -158,7 +158,7 @@ impl PipelineOperations for TaskTracker {
         let tracker = self.clone();
         self.spawn(async move {
             tokio::select! {
-                // AddPiece is cancellation safe, as it can be retried and the state will be fine.
+                // AddPiece is NOT cancellation safe, cancelling it will make the program state inconsistent.
                 res = add_piece(tracker, state, piece_path, commitment, deal, published_deal_id) => {
                     match res {
                         Ok(_) => tracing::info!("Add Piece for piece {}, deal id {}, finished successfully.", commitment, published_deal_id),
@@ -297,7 +297,7 @@ async fn precommit(
         // We remove ourselves from the scheduled pre-commits
         let mut scheduled_pre_commits = state.scheduled_pre_commits.lock().await;
         if scheduled_pre_commits.remove(&sector_number).is_none() {
-            tracing::warn!(%sector_number, "No task was found! Not pre-committing.");
+            tracing::warn!(%sector_number, "No task was found! Skipping pre-commiting as sector should have been pre-commited before.");
             return Ok(());
         }
     }

--- a/storage-provider/server/src/rpc.rs
+++ b/storage-provider/server/src/rpc.rs
@@ -24,6 +24,8 @@ use crate::{
     pipeline::types::{AddPieceMessage, PipelineMessage},
 };
 
+pub const SECS_PER_BLOCK: u64 = 6;
+
 /// RPC server shared state.
 pub struct RpcServerState {
     pub server_info: ServerInfo,
@@ -57,6 +59,27 @@ impl RpcServerState {
                 format!(
                     "Deal starts in the past: current_block = {}, deal_start_block = {}",
                     current_block, deal.start_block
+                ),
+                None,
+            ));
+        }
+
+        let deal_start_distance = deal.start_block - current_block;
+        let minimum_start_distance = self
+            .server_info
+            .sealing_configuration
+            .pre_commit_submission_slack
+            .as_secs()
+            / SECS_PER_BLOCK;
+        // NOTE(@jmg-duarte,12/02/2025): we could consider the deal size when doing this,
+        // if a deal is going to fill up a single sector, we could let it through as long as
+        // its deal_start_distance > pre_commit_submission_slack
+        if deal_start_distance < minimum_start_distance {
+            return Err(RpcError::invalid_params(
+                format!(
+                    "Deal starts too early: start_block = {}, (current) minimum_start_block = {}",
+                    deal.start_block,
+                    current_block + minimum_start_distance,
                 ),
                 None,
             ));

--- a/storagext/cli/src/cmd/storage_provider.rs
+++ b/storagext/cli/src/cmd/storage_provider.rs
@@ -41,8 +41,7 @@ pub enum StorageProviderCommand {
         /// PeerId in Storage Provider P2P network.
         peer_id: PeerId,
         /// Proof of Space Time type.
-        /// Can only be "2KiB" meaning `RegisteredPoStProof::StackedDRGWindow2KiBV1P1`.
-        #[arg(long, value_parser = parse_post_proof, default_value = "2KiB")]
+        #[arg(long, value_parser = parse_post_proof, default_value = "8MiB")]
         post_proof: RegisteredPoStProof,
     },
 


### PR DESCRIPTION
### Description

Takes into account the start block of a deal when considering the pre-commit.

The implementation is as simple as I could make it given the constant tug-of-war of several requirements, but basically:
* We now always try to schedule a pre-commit for a given sector
* If no pre-commit has been scheduled yet, we schedule it
* If a pre-commit has been scheduled, then we check if the *estimated* target deadline for that task
  * If the deadline for the new task happens *before* the old one, we cancel the old task and replace it in our mapping
  * If the deadline for the new task happens *after* the old one, we don't do anything

The original implementation used abort handles but turns out, they don't work like I expected — I expected that if a task was suspended at an await point and got cancelled, it would be dropped from the runtime and forgotten but no, instead the task will still run and only at the next await point it will be cancelled. 

The new implementation simply suspends waiting for a cancellation value with a timeout (instead of a sleep), then we "race" the cancel versus the timeout, whichever runs first decides whether the pre commit happens or not.

### Checklist

- [x] Make sure that you described what this change does.
- [x] Have you tested this solution?
- [x] Were there any alternative implementations considered?
- [x] Did you document new (or modified) APIs?

Logs for review:
[sp_server.log.2025-02-13.txt](https://github.com/user-attachments/files/18786282/sp_server.log.2025-02-13.txt)


