### PR TITLE
fix(primitives): custom Commitment Debug implementation

### DIFF
--- a/primitives/src/commitment/mod.rs
+++ b/primitives/src/commitment/mod.rs
@@ -2,6 +2,8 @@ pub mod commd;
 pub mod piece;
 mod zero;
 
+extern crate alloc;
+
 use core::{fmt::Display, marker::PhantomData};
 
 use cid::{multihash::Multihash, Cid};
@@ -108,7 +110,7 @@ impl core::fmt::Debug for CommitmentError {
 }
 
 #[cfg_attr(feature = "serde", derive(::serde::Deserialize, ::serde::Serialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Commitment<Kind>
 where
     Kind: CommitmentKind,
@@ -162,6 +164,27 @@ where
         let hash = Multihash::wrap(multihash, &self.raw)
             .expect("multihash is large enough so it can wrap the commitment");
         Cid::new_v1(multicodec, hash)
+    }
+}
+
+impl<Kind> core::fmt::Debug for Commitment<Kind>
+where
+    Kind: CommitmentKind,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use alloc::{format, string::String};
+
+        let mut hex = String::with_capacity(2 + &self.raw.len() * 2);
+        hex.push_str("0x");
+        f.debug_struct(&format!("Commitment<{}>", core::any::type_name::<Kind>()))
+            .field(
+                "raw",
+                &self.raw.iter().fold(hex, |mut acc, b| {
+                    acc.push_str(&format!("{:0x}", b));
+                    acc
+                }),
+            )
+            .finish()
     }
 }
 


### PR DESCRIPTION
### Description
* No more byte arrays/vecs as a long list of numbers, have an hex string instead
* No more PhantomData, have the proper type name instead

```
Commitment { raw: [76, 190, 175, 201, 171, 20, 233, 200, 221, 225, 89, 132, 224, 7, 125, 90, 167, 11, 69, 23, 103, 202, 161, 213, 232, 65, 138, 246, 233, 216, 70, 38], kind: PhantomData<primitives::commitment::CommP> }
```
Becomes:
```
Commitment<primitives::commitment::CommP> { raw: "0x4cbeafc9ab14e9c8dde15984e077d5aa7b451767caa1d5e8418af6e9d84626" } 
```
