### PR TITLE
feat(mater-cli): add support for stdin input

### DIFF
--- a/mater/cli/Cargo.toml
+++ b/mater/cli/Cargo.toml
@@ -17,7 +17,7 @@ mater.workspace = true
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "io-std", "macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/mater/cli/src/convert.rs
+++ b/mater/cli/src/convert.rs
@@ -9,15 +9,18 @@ pub(crate) async fn convert_file_to_car(
     output_path: &PathBuf,
     overwrite: bool,
 ) -> Result<Cid, Error> {
-    let source_file = File::open(input_path).await?;
     let output_file = if overwrite {
         File::create(output_path).await
     } else {
         File::create_new(output_path).await
     }?;
-    let cid = create_filestore(source_file, output_file, Config::default()).await?;
 
-    Ok(cid)
+    if input_path.as_os_str() == "-" {
+        create_filestore(tokio::io::stdin(), output_file, Config::default()).await
+    } else {
+        let source_file = File::open(input_path).await?;
+        create_filestore(source_file, output_file, Config::default()).await
+    }
 }
 
 /// Tests for file conversion.

--- a/mater/cli/src/extract.rs
+++ b/mater/cli/src/extract.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use mater::{CarExtractor, Error};
-use tokio::fs::File;
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, BufReader},
+};
 
 /// Extracts a file to `output_path` from the CARv2 file at `input_path`
 pub(crate) async fn extract_file_from_car(
@@ -15,10 +18,29 @@ pub(crate) async fn extract_file_from_car(
         File::create_new(&output_path).await?
     };
 
-    CarExtractor::from_path(input_path)
-        .await?
-        .copy_to_writer(output_file)
-        .await
+    if input_path.as_os_str() == "-" {
+        // NOTE(@jmg-duarte,17/02/2025): this approach is bound to be inefficient for large inputs
+        // given that we're forced to load the whole input into memory upfront
+        // a possible alternative could be implementing a Reader that takes an AsyncRead
+        // and makes it AsyncSeek by keeping read contents in memory and forward seeks (where
+        // forward means that said part of the stream hasn't been loaded into memory yet) start
+        // loading file as needed before returning the new position
+
+        // Arbitrary value, it's just so the buffer doesn't constantly resize
+        // while loading the first bytes
+        let mut buffer = Vec::with_capacity(16 * 1024);
+        let mut buffered_stdin = BufReader::new(tokio::io::stdin());
+        buffered_stdin.read_to_end(&mut buffer).await?;
+        CarExtractor::from_vec(buffer)
+            .await?
+            .copy_to_writer(output_file)
+            .await
+    } else {
+        CarExtractor::from_path(input_path)
+            .await?
+            .copy_to_writer(output_file)
+            .await
+    }
 }
 
 /// Tests for file extraction.

--- a/mater/cli/src/extract.rs
+++ b/mater/cli/src/extract.rs
@@ -6,6 +6,9 @@ use tokio::{
     io::{AsyncReadExt, BufReader},
 };
 
+/// Arbitrary value, it's just so the buffer doesn't constantly resize while loading the first bytes
+const STDIN_BUFFER_START_CAPACITY: usize = 16 * 1024;
+
 /// Extracts a file to `output_path` from the CARv2 file at `input_path`
 pub(crate) async fn extract_file_from_car(
     input_path: &PathBuf,
@@ -26,9 +29,7 @@ pub(crate) async fn extract_file_from_car(
         // forward means that said part of the stream hasn't been loaded into memory yet) start
         // loading file as needed before returning the new position
 
-        // Arbitrary value, it's just so the buffer doesn't constantly resize
-        // while loading the first bytes
-        let mut buffer = Vec::with_capacity(16 * 1024);
+        let mut buffer = Vec::with_capacity(STDIN_BUFFER_START_CAPACITY);
         let mut buffered_stdin = BufReader::new(tokio::io::stdin());
         buffered_stdin.read_to_end(&mut buffer).await?;
         CarExtractor::from_vec(buffer)

--- a/mater/cli/src/main.rs
+++ b/mater/cli/src/main.rs
@@ -83,16 +83,24 @@ async fn main() -> Result<(), Error> {
             overwrite,
         } => {
             let output_path = output_path.unwrap_or_else(|| {
-                // If we let the output become `-.car` it isn't only weird
+                // If we let the output become `-` it isn't only weird
                 // terminals are annoying with it
                 if input_path.as_os_str() == "-" {
-                    let file_name = "stdin.car";
+                    let file_name = "stdin";
                     let mut path = PathBuf::with_capacity(file_name.len());
                     path.set_file_name(file_name);
                     path
                 } else {
                     let mut new_path = input_path.clone();
-                    new_path.set_extension("car");
+                    if let Some(_) = new_path.extension() {
+                        // We don't check if the ext is `.car` because we don't care about the ext
+                        // being "right", we only care about the bytes, however, we remove the ext
+                        // if there is one
+                        new_path.set_extension("");
+                    } else {
+                        // If no extension existed, we must add one or we risk overwriting the file
+                        new_path.set_extension("out");
+                    }
                     new_path
                 }
             });

--- a/mater/cli/src/main.rs
+++ b/mater/cli/src/main.rs
@@ -52,9 +52,18 @@ async fn main() -> Result<(), Error> {
             overwrite,
         } => {
             let output_path = output_path.unwrap_or_else(|| {
-                let mut new_path = input_path.clone();
-                new_path.set_extension("car");
-                new_path
+                // If we let the output become `-.car` it isn't only weird
+                // terminals are annoying with it
+                if input_path.as_os_str() == "-" {
+                    let file_name = "stdin.car";
+                    let mut path = PathBuf::with_capacity(file_name.len());
+                    path.set_file_name(file_name);
+                    path
+                } else {
+                    let mut new_path = input_path.clone();
+                    new_path.set_extension("car");
+                    new_path
+                }
             });
             let cid = convert_file_to_car(&input_path, &output_path, overwrite).await?;
 
@@ -74,9 +83,18 @@ async fn main() -> Result<(), Error> {
             overwrite,
         } => {
             let output_path = output_path.unwrap_or_else(|| {
-                let mut new_path = input_path.clone();
-                new_path.set_extension("");
-                new_path
+                // If we let the output become `-.car` it isn't only weird
+                // terminals are annoying with it
+                if input_path.as_os_str() == "-" {
+                    let file_name = "stdin.car";
+                    let mut path = PathBuf::with_capacity(file_name.len());
+                    path.set_file_name(file_name);
+                    path
+                } else {
+                    let mut new_path = input_path.clone();
+                    new_path.set_extension("car");
+                    new_path
+                }
             });
             extract_file_from_car(&input_path, &output_path, overwrite).await?;
 

--- a/mater/lib/src/lib.rs
+++ b/mater/lib/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 #![deny(unsafe_code)]
-#![deny(clippy::unwrap_used)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 mod async_varint;
 mod cid;


### PR DESCRIPTION
### Description

Partial fix for #757, will need fetch to stream the file to stdout.
Also "brings to light" the issue that is if the file needs to be fully loaded into memory.

Test it with 
```
# extract
cat mater/lib/tests/fixtures/car_v2/spaceglenda_wrapped.car | cargo r -r -p mater-cli -- extract -
# convert
cat mater/lib/tests/fixtures/original/spaceglenda.jpg | cargo r -r -p mater-cli -- convert --overwrite -
```