### PR TITLE
fix(pipeline): precommit scheduling

### DIFF
--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -61,7 +61,11 @@ pub async fn add_piece(
             fill_percentage,
             fill_threshold,
         );
-        return state.send_pre_commit(sector_number);
+
+        // Schedule a new precommit to be executed immediately
+        let when = Duration::from_secs(0);
+        schedule_pre_commit(state.clone(), tracker, sector_number, when).await;
+        return Ok(());
     }
     tracing::debug!(
         %sector_number,
@@ -76,6 +80,7 @@ pub async fn add_piece(
         state.server_info.sealing_configuration.wait_deals_delay,
         duration_to_deal_start,
     );
+
     // We always try to schedule a new pre-commit
     schedule_pre_commit(state.clone(), tracker, sector_number, when).await;
 

--- a/storage-provider/server/src/pipeline/add_piece.rs
+++ b/storage-provider/server/src/pipeline/add_piece.rs
@@ -63,8 +63,7 @@ pub async fn add_piece(
         );
 
         // Schedule a new precommit to be executed immediately
-        let when = Duration::from_secs(0);
-        schedule_pre_commit(state.clone(), tracker, sector_number, when).await;
+        schedule_pre_commit(state.clone(), tracker, sector_number, Duration::ZERO).await;
         return Ok(());
     }
     tracing::debug!(


### PR DESCRIPTION
### Description

If the sector was immediately full, we started the precommit process by sending a message directly. The bug was that in this case we didn't have the scheduled task saved. So later we early returned [here](https://github.com/eigerco/polka-storage/blob/c6c7dea84d2ff41fff70f218839e210a4e784b93/storage-provider/server/src/pipeline/mod.rs#L312).

I've fixed the bug by scheduling a precommit immediately if the sector is full.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?
