### PR TITLE
ci: Run CI on all 'ready-to-review' PR commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   check-files:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       skip: ${{ steps.check-files.outputs.skip }}
     steps:
@@ -43,7 +43,7 @@ jobs:
           fi
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Setup mdBook

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,13 @@ name: CI
 
 on:
   pull_request:
-    types: [labeled]
+    types:
+    # These are the default types
+    - opened
+    - synchronize
+    - reopened
+    # This additional type is added to trigger on the 'ready for review' label being added
+    - labeled
   push:
     branches: [develop, main]
   workflow_dispatch: # manual launch
@@ -48,7 +54,7 @@ jobs:
         run: mdbook build docs
 
   toml:
-    if: ${{ needs.check-files.outputs.skip == 'false' && ((github.event.label.name == 'ready for review') || (github.ref_name == 'develop') || (github.ref_name == 'master')) }}
+    if: ${{ needs.check-files.outputs.skip == 'false' && (contains(github.event.pull_request.labels.*.name, 'ready for review') || (github.ref_name == 'develop') || (github.ref_name == 'master')) }}
     runs-on: self-hosted
     needs: check-files
     steps:


### PR DESCRIPTION
### Description

Hopefully this will make merging PRs faster because the workflow will already be running when you reopen the page rather than having to re-tag.

### Important points for reviewers

This will trigger more builds than before, but if it becomes a problem we can revisit this and maybe set a manual approval before building instead of using the tag.

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] See above
- [x] Make sure that you described what this change does.
- [ ] ~~If there are follow-ups, have you created issues for them?~~
  - [ ] ~~If yes, which ones? / List them here~~
- [ ] Have you tested this solution?
  - I don't think I can since the PR doesn't contain code changes, but I'm open to suggestions.
- [ ] Were there any alternative implementations considered?
- [ ] ~~Did you document new (or modified) APIs?~~
