### PR TITLE
feat(mater): replace the Reader/Writer structs with traits

### DIFF
--- a/mater/lib/src/file_reader.rs
+++ b/mater/lib/src/file_reader.rs
@@ -13,23 +13,31 @@ use tokio::{
     io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWriteExt},
 };
 
-use crate::{multicodec, v1::BlockMetadata, v2, Error};
+use crate::{
+    multicodec,
+    v1::{BlockMetadata, CarReader, CarReaderExt},
+    v2::CarReader as _,
+    Error,
+};
 
 /// Extracts the raw data from a CARv2 file.
 /// It expects the CAR file to have only 1 root.
 pub struct CarExtractor<R> {
-    reader: v2::Reader<R>,
+    reader: R,
     index: HashMap<Cid, BlockMetadata>,
 }
 
-impl<R> CarExtractor<R> {
+impl<R> CarExtractor<R>
+where
+    R: AsyncRead + AsyncSeek + Unpin,
+{
     /// Creates a new [`CarExtractor`] from the given reader.
     pub async fn new(reader: R) -> Result<Self, Error>
     where
         R: AsyncRead + AsyncSeek + Unpin,
     {
         let mut self_ = Self {
-            reader: v2::Reader::new(reader),
+            reader,
             index: HashMap::with_capacity(1),
         };
         self_.naive_build_index().await?;
@@ -63,11 +71,11 @@ where
     /// Always returns a non-empty vector, if there are no roots the error
     /// `Error::WrongNumberOfRoots` is returned.
     pub async fn roots(&mut self) -> Result<Vec<Cid>, Error> {
-        self.reader.get_inner_mut().rewind().await?;
+        self.reader.rewind().await?;
         self.reader.read_pragma().await?;
-        self.reader.read_header().await?;
+        self.reader.read_v2_header().await?;
 
-        let roots = self.reader.read_v1_header().await?.roots;
+        let roots = self.reader.read_header().await?.roots;
         if roots.is_empty() {
             return Err(Error::WrongNumberOfRoots);
         }
@@ -81,15 +89,15 @@ where
     /// (Cid, data start offset and data length) without loading the blocks into memory.
     async fn naive_build_index(&mut self) -> Result<(), Error> {
         // Indexing must always be made from the start
-        self.reader.get_inner_mut().rewind().await?;
+        self.reader.rewind().await?;
         let _ = self.reader.read_pragma().await?;
-        let v2_header = self.reader.read_header().await?;
-        let _ = self.reader.read_v1_header().await?;
+        let v2_header = self.reader.read_v2_header().await?;
+        let _ = self.reader.read_header().await?;
 
         let data_end = v2_header.data_offset + v2_header.data_size;
 
         loop {
-            let position = self.reader.get_inner_mut().stream_position().await?;
+            let position = self.reader.stream_position().await?;
             if position >= data_end {
                 break;
             }
@@ -115,7 +123,6 @@ where
                 match block_metadata.cid.codec() {
                     multicodec::RAW_CODE => {
                         self.reader
-                            .get_inner_mut()
                             .seek(std::io::SeekFrom::Start(block_metadata.block_offset))
                             .await?;
                         let block = self.reader.read_block().await?;
@@ -123,7 +130,6 @@ where
                     }
                     multicodec::DAG_PB_CODE => {
                         self.reader
-                            .get_inner_mut()
                             .seek(std::io::SeekFrom::Start(block_metadata.block_offset))
                             .await?;
                         let (_, block) = self.reader.read_block().await?;
@@ -184,7 +190,7 @@ pub(crate) mod blockstore {
         sync::RwLock,
     };
 
-    use crate::{stores::to_blockstore_cid, CarExtractor, CidExt, Error};
+    use crate::{stores::to_blockstore_cid, v1::CarReader, CarExtractor, CidExt, Error};
 
     // Methods in here are marked as unused in the "main" `impl` because they're only used here.
     impl<R> CarExtractor<R>
@@ -208,7 +214,6 @@ pub(crate) mod blockstore {
                 Some(metadata) => {
                     // We could seek directly to the data and not read the Cid, but this is "canonical"
                     self.reader
-                        .get_inner_mut()
                         .seek(std::io::SeekFrom::Start(metadata.block_offset))
                         .await?;
                     let (_, block) = self.reader.read_block().await?;

--- a/mater/lib/src/file_reader.rs
+++ b/mater/lib/src/file_reader.rs
@@ -75,7 +75,7 @@ where
         self.reader.read_pragma().await?;
         self.reader.read_v2_header().await?;
 
-        let roots = self.reader.read_header().await?.roots;
+        let roots = self.reader.read_v1_header().await?.roots;
         if roots.is_empty() {
             return Err(Error::WrongNumberOfRoots);
         }
@@ -92,7 +92,7 @@ where
         self.reader.rewind().await?;
         let _ = self.reader.read_pragma().await?;
         let v2_header = self.reader.read_v2_header().await?;
-        let _ = self.reader.read_header().await?;
+        let _ = self.reader.read_v1_header().await?;
 
         let data_end = v2_header.data_offset + v2_header.data_size;
 

--- a/mater/lib/src/ipld.rs
+++ b/mater/lib/src/ipld.rs
@@ -3,80 +3,63 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::{async_varint::read_varint, IDENTITY_CODE};
 
-/// Extension trait for [`Cid`](ipld_core::cid::Cid)
-pub trait CidExt {
-    /// Reads the bytes from a byte stream.
-    fn read_bytes_async<R>(r: R) -> impl std::future::Future<Output = Result<(Self, usize), Error>>
-    where
-        Self: Sized,
-        R: AsyncRead + Unpin;
+/// Ipld-related extensions.
+pub trait IpldExt {
+    /// Reads the bytes from a byte stream, returns the read [`CidGeneric`] & number of bytes read.
+    fn read_cid<const S: usize>(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<(CidGeneric<S>, usize), Error>>;
 
-    /// Returns Some(data) if the CID is an identity. If not, None is returned.
-    fn get_identity_data(&self) -> Option<&[u8]>;
+    /// Reads the bytes from a byte stream, returns the read [`Multihash`] & number of bytes read.
+    fn read_multihash<const S: usize>(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<(Multihash<S>, usize), Error>>;
 }
 
-/// Extension trait for [`Multihash`](ipld_core::cid::multihash::Multihash)
-pub trait MultihashExt {
-    /// Reads the bytes from a byte stream.
-    fn read_async<R>(r: R) -> impl std::future::Future<Output = Result<(Self, usize), Error>>
-    where
-        Self: Sized,
-        R: AsyncRead + Unpin;
-}
-
-impl<const S: usize> CidExt for CidGeneric<S> {
-    fn get_identity_data(&self) -> Option<&[u8]> {
-        (self.hash().code() == IDENTITY_CODE).then(|| self.hash().digest())
-    }
-
+impl<R> IpldExt for R
+where
+    R: AsyncRead + Unpin,
+{
     /// Async implementation of
     /// <https://github.com/multiformats/rust-cid/blob/eb03f566e9bfb19bad79b2691dbcb2541627c0b3/src/cid.rs#L143C12-L143C22>
-    async fn read_bytes_async<R>(mut r: R) -> Result<(Self, usize), Error>
-    where
-        R: AsyncRead + Unpin,
-    {
-        let (version, version_bytes_read): (u64, usize) = read_varint(&mut r).await?;
-        let (codec, codec_bytes_read): (u64, usize) = read_varint(&mut r).await?;
+    async fn read_cid<const S: usize>(&mut self) -> Result<(CidGeneric<S>, usize), Error> {
+        let (version, version_bytes_read): (u64, usize) = read_varint(self).await?;
+        let (codec, codec_bytes_read): (u64, usize) = read_varint(self).await?;
 
         // CIDv0 has the fixed `0x12 0x20` prefix
         if [version, codec] == [0x12, 0x20] {
             const DIGEST_SIZE: usize = 32;
             let mut digest = [0u8; DIGEST_SIZE];
-            r.read_exact(&mut digest).await?;
+            self.read_exact(&mut digest).await?;
             let mh = Multihash::wrap(version, &digest).expect("Digest is always 32 bytes.");
 
             let bytes_read = version_bytes_read + codec_bytes_read + DIGEST_SIZE;
-            return Ok((Self::new_v0(mh)?, bytes_read));
+            return Ok((CidGeneric::new_v0(mh)?, bytes_read));
         }
 
         let version = Version::try_from(version)?;
         match version {
             Version::V0 => Err(Error::InvalidExplicitCidV0),
             Version::V1 => {
-                let (mh, multihash_bytes_read) = Multihash::read_async(r).await?;
+                let (mh, multihash_bytes_read) = self.read_multihash().await?;
                 let bytes_read = version_bytes_read + codec_bytes_read + multihash_bytes_read;
-                Ok((Self::new(version, codec, mh)?, bytes_read))
+                Ok((CidGeneric::new(version, codec, mh)?, bytes_read))
             }
         }
     }
-}
 
-impl<const S: usize> MultihashExt for Multihash<S> {
     /// Async implementation of
     /// <https://github.com/multiformats/rust-multihash/blob/90a6c19ec71ced09469eec164a3586aafeddfbbd/src/multihash.rs#L271>
-    async fn read_async<R>(mut r: R) -> Result<(Self, usize), Error>
-    where
-        R: AsyncRead + Unpin,
-    {
-        let (code, code_bytes_read): (u64, usize) = read_varint(&mut r).await?;
-        let (size, size_bytes_read): (u64, usize) = read_varint(&mut r).await?;
+    async fn read_multihash<const S: usize>(&mut self) -> Result<(Multihash<S>, usize), Error> {
+        let (code, code_bytes_read): (u64, usize) = read_varint(self).await?;
+        let (size, size_bytes_read): (u64, usize) = read_varint(self).await?;
 
         if size > S as u64 || size > u8::MAX as u64 {
             return Err(Error::ParsingError);
         }
 
         let mut digest = [0; S];
-        r.read_exact(&mut digest[..size as usize])
+        self.read_exact(&mut digest[..size as usize])
             .await
             .map_err(|_| Error::ParsingError)?;
 
@@ -90,25 +73,33 @@ impl<const S: usize> MultihashExt for Multihash<S> {
     }
 }
 
+/// Extension trait for [`Cid`](ipld_core::cid::Cid)
+pub trait CidExt {
+    /// Returns Some(data) if the CID is an identity. If not, None is returned.
+    fn get_identity_data(&self) -> Option<&[u8]>;
+}
+
+impl<const S: usize> CidExt for CidGeneric<S> {
+    fn get_identity_data(&self) -> Option<&[u8]> {
+        (self.hash().code() == IDENTITY_CODE).then(|| self.hash().digest())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{io::Cursor, str::FromStr};
 
     use ipld_core::cid::{multihash::Multihash, Cid};
 
-    use crate::{
-        cid::{CidExt, MultihashExt},
-        multicodec::SHA_256_CODE,
-        RAW_CODE,
-    };
+    use crate::{ipld::IpldExt, multicodec::SHA_256_CODE, RAW_CODE};
 
     #[tokio::test]
     async fn cid_v0_read_bytes_async() {
         let mh = Multihash::<64>::wrap(SHA_256_CODE, &[0u8; 32]).unwrap();
         let original_cid = Cid::new_v0(mh).unwrap();
 
-        let cid_bytes = Cursor::new(original_cid.to_bytes());
-        let (cid, bytes_read) = Cid::read_bytes_async(cid_bytes).await.unwrap();
+        let mut cid_bytes = Cursor::new(original_cid.to_bytes());
+        let (cid, bytes_read) = cid_bytes.read_cid().await.unwrap();
 
         assert_eq!(original_cid, cid);
         // In case of CIDv0. Multihash has an explicit size and codec. Because
@@ -122,8 +113,8 @@ mod tests {
         let original_cid =
             Cid::from_str("bafkreiczsrdrvoybcevpzqmblh3my5fu6ui3tgag3jm3hsxvvhaxhswpyu").unwrap();
 
-        let cid_bytes = Cursor::new(original_cid.to_bytes());
-        let (cid, bytes_read) = Cid::read_bytes_async(cid_bytes).await.unwrap();
+        let mut cid_bytes = Cursor::new(original_cid.to_bytes());
+        let (cid, bytes_read) = cid_bytes.read_cid().await.unwrap();
 
         assert_eq!(original_cid, cid);
         // 36 = cid_version(1) + cid_codec(1) + mh_code(1) + mh_size(1) + multihash_digest_size(32)
@@ -134,8 +125,8 @@ mod tests {
     async fn multihash_read_async() {
         let original_mh = Multihash::<64>::wrap(RAW_CODE, b"Hello World!").unwrap();
 
-        let mh_bytes = Cursor::new(original_mh.to_bytes());
-        let (mh, bytes_read) = Multihash::<64>::read_async(mh_bytes).await.unwrap();
+        let mut mh_bytes = Cursor::new(original_mh.to_bytes());
+        let (mh, bytes_read) = mh_bytes.read_multihash::<64>().await.unwrap();
 
         assert_eq!(original_mh, mh);
         // 10 = mh_code(1) + mh_size(1) + multihash_digest_size(12)
@@ -146,7 +137,7 @@ mod tests {
     async fn multihash_read_async_digest_size_error() {
         let original_mh = Multihash::<64>::wrap(RAW_CODE, b"Hello World!").unwrap();
 
-        let mh_bytes = Cursor::new(original_mh.to_bytes());
-        assert!(Multihash::<5>::read_async(mh_bytes).await.is_err());
+        let mut mh_bytes = Cursor::new(original_mh.to_bytes());
+        assert!(mh_bytes.read_multihash::<5>().await.is_err());
     }
 }

--- a/mater/lib/src/lib.rs
+++ b/mater/lib/src/lib.rs
@@ -10,8 +10,8 @@
 
 mod async_varint;
 mod chunker;
-mod cid;
 mod file_reader;
+mod ipld;
 mod multicodec;
 mod stores;
 mod unixfs;
@@ -19,15 +19,19 @@ mod v1;
 mod v2;
 
 // We need to re-expose this because `read_block` returns `(Cid, Vec<u8>)`.
-pub use cid::{CidExt, MultihashExt};
 pub use file_reader::CarExtractor;
+pub use ipld::CidExt;
 pub use ipld_core::cid::Cid;
 pub use multicodec::{DAG_PB_CODE, IDENTITY_CODE, RAW_CODE};
 pub use stores::{Blockwriter, Config, FileBlockstore};
-pub use v1::{BlockMetadata, Header as CarV1Header, Reader as CarV1Reader, Writer as CarV1Writer};
+pub use v1::{
+    BlockMetadata, CarReader as CarV1Reader, CarReaderExt as CarV1ReaderExt,
+    CarWriter as CarV1Writer, Header as CarV1Header,
+};
 pub use v2::{
-    verify_cid, Characteristics, Header as CarV2Header, Index, IndexEntry, IndexSorted,
-    MultihashIndexSorted, Reader as CarV2Reader, SingleWidthIndex, Writer as CarV2Writer,
+    CarReader as CarV2Reader, CarReaderExt as CarV2ReaderExt, CarWriter as CarV2Writer,
+    Characteristics, Header as CarV2Header, Index, IndexEntry, IndexSorted, MultihashIndexSorted,
+    SingleWidthIndex,
 };
 
 /// [`blockstore`] abstractions over CAR files.

--- a/mater/lib/src/stores/blockstore.rs
+++ b/mater/lib/src/stores/blockstore.rs
@@ -5,17 +5,21 @@ use std::{
 
 use futures::stream::StreamExt;
 use ipld_core::cid::Cid;
-use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
     unixfs::stream_balanced_tree,
-    v1::{self},
-    v2, BlockMetadata, Config, Error, Index, IndexEntry, IndexSorted, SingleWidthIndex,
+    v1::{
+        CarWriter, {self},
+    },
+    v2,
+    v2::CarWriter as _,
+    BlockMetadata, Config, Error, Index, IndexEntry, IndexSorted, SingleWidthIndex,
 };
 
 /// CAR file writer.
 pub struct Blockwriter<W> {
-    writer: v2::Writer<W>,
+    writer: W,
     index: HashMap<Cid, BlockMetadata>,
     roots: Vec<Cid>,
     started: bool,
@@ -26,7 +30,7 @@ impl<W> Blockwriter<W> {
     /// Creates a new [`Blockwriter`] with the given `writer`.
     pub fn new(writer: W) -> Self {
         Self {
-            writer: v2::Writer::new(writer),
+            writer,
             index: HashMap::new(),
             roots: Vec::with_capacity(1),
             started: false,
@@ -63,7 +67,7 @@ impl Blockwriter<Cursor<Vec<u8>>> {
     /// Creates an in-memory [`Blockwriter`].
     pub fn in_memory() -> Self {
         Self {
-            writer: v2::Writer::new(Cursor::new(vec![])),
+            writer: Cursor::new(vec![]),
             index: HashMap::new(),
             roots: Vec::with_capacity(1),
             started: false,
@@ -95,12 +99,12 @@ where
         S: AsyncRead + Unpin,
     {
         if !self.started {
+            self.writer.write_v2_header(&Default::default()).await?;
             self.writer.write_header(&Default::default()).await?;
-            self.writer.write_v1_header(&Default::default()).await?;
             self.started = true;
         }
 
-        let mut current_position = self.writer.get_inner_mut().stream_position().await?;
+        let mut current_position = self.writer.stream_position().await?;
 
         let nodes = match self.config {
             Config::Balanced {
@@ -147,16 +151,15 @@ where
 
     /// Writes the final header as well as the indexes, flushes the inner writer and returns it.
     pub async fn finish(mut self) -> Result<W, Error> {
-        self.writer.get_inner_mut().rewind().await?;
+        self.writer.rewind().await?;
 
         let v1_header = self.header_v1();
         let v2_header = self.header_v2(&v1_header);
 
-        self.writer.write_header(&v2_header).await?;
-        self.writer.write_v1_header(&v1_header).await?;
+        self.writer.write_v2_header(&v2_header).await?;
+        self.writer.write_header(&v1_header).await?;
 
         self.writer
-            .get_inner_mut()
             .seek(std::io::SeekFrom::Start(v2_header.index_offset))
             .await?;
 
@@ -199,7 +202,8 @@ where
         );
         self.writer.write_index(&index).await?;
 
-        self.writer.finish().await
+        self.writer.flush().await?;
+        Ok(self.writer)
     }
 }
 
@@ -222,7 +226,6 @@ mod tests {
         let mut store = Blockwriter::in_memory();
         store.write_from(file).await.unwrap();
         let output = store.finish().await.unwrap().into_inner();
-
         assert_buffer_eq!(&output, &reference);
     }
 

--- a/mater/lib/src/stores/file.rs
+++ b/mater/lib/src/stores/file.rs
@@ -96,7 +96,7 @@ impl FileBlockstore {
         // Read the headers
         reader.read_pragma().await?;
         let v2_header = reader.read_v2_header().await?;
-        let v1_header = reader.read_header().await?;
+        let v1_header = reader.read_v1_header().await?;
 
         // This blockstore expects index to be used
         if v2_header.index_offset == 0 {
@@ -356,7 +356,7 @@ mod tests {
         let mut file = File::open(path).await.unwrap();
         file.read_pragma().await.unwrap();
         let header = file.read_v2_header().await?;
-        let v1_header = file.read_header().await?;
+        let v1_header = file.read_v1_header().await?;
 
         let (guard, blockstore_file, blockstore) = init_blockstore(v1_header.roots).await?;
 

--- a/mater/lib/src/stores/file.rs
+++ b/mater/lib/src/stores/file.rs
@@ -10,10 +10,10 @@ use tokio::{
 };
 
 use crate::{
-    cid::CidExt,
+    ipld::CidExt,
     multicodec::SHA_256_CODE,
-    v1::{self, read_block, write_block},
-    v2::{self},
+    v1::{self, write_block, CarReader as _},
+    v2::{self, CarReader},
     CarV1Header, CarV2Header, Characteristics, Error, Index, IndexEntry, MultihashIndexSorted,
     SingleWidthIndex,
 };
@@ -91,13 +91,12 @@ impl FileBlockstore {
     where
         P: AsRef<Path>,
     {
-        let file = File::open(&path).await?;
-        let mut reader = v2::Reader::new(file);
+        let mut reader = File::open(&path).await?;
 
         // Read the headers
         reader.read_pragma().await?;
-        let v2_header = reader.read_header().await?;
-        let v1_header = reader.read_v1_header().await?;
+        let v2_header = reader.read_v2_header().await?;
+        let v1_header = reader.read_header().await?;
 
         // This blockstore expects index to be used
         if v2_header.index_offset == 0 {
@@ -105,8 +104,7 @@ impl FileBlockstore {
         }
 
         // Read the index
-        let inner = reader.get_inner_mut();
-        inner.seek(SeekFrom::Start(v2_header.index_offset)).await?;
+        reader.seek(SeekFrom::Start(v2_header.index_offset)).await?;
 
         let mut index_map = IndexMap::new();
         match reader.read_index().await? {
@@ -173,7 +171,7 @@ impl FileBlockstore {
             .await?;
 
         // Read the lock
-        let (block_cid, block_data) = read_block(&mut inner.store).await?;
+        let (block_cid, block_data) = inner.store.read_block().await?;
         debug_assert_eq!(block_cid, cid);
 
         // Move cursor back to the position where we'll continue writing next blocks.
@@ -334,7 +332,9 @@ mod tests {
     use crate::{
         multicodec::{generate_multihash, IDENTITY_CODE, RAW_CODE},
         test_utils::assert_buffer_eq,
-        CarV2Reader, Error, FileBlockstore,
+        v1::CarReader,
+        v2::CarReader as V2CarReader,
+        Error, FileBlockstore,
     };
 
     /// Initialize a new blockstore
@@ -353,16 +353,15 @@ mod tests {
     where
         P: AsRef<Path>,
     {
-        let file = File::open(path).await.unwrap();
-        let mut reader = CarV2Reader::new(file);
-        reader.read_pragma().await.unwrap();
-        let header = reader.read_header().await?;
-        let v1_header = reader.read_v1_header().await?;
+        let mut file = File::open(path).await.unwrap();
+        file.read_pragma().await.unwrap();
+        let header = file.read_v2_header().await?;
+        let v1_header = file.read_header().await?;
 
         let (guard, blockstore_file, blockstore) = init_blockstore(v1_header.roots).await?;
 
         loop {
-            match reader.read_block().await {
+            match file.read_block().await {
                 Ok((cid, data)) => {
                     // Add block to the store
                     blockstore.put_keyed(&cid, &data).await.unwrap();
@@ -375,7 +374,7 @@ mod tests {
                     assert_eq!(block, data);
 
                     // Kinda hacky, but better than doing a seek later on
-                    let position = reader.get_inner_mut().stream_position().await.unwrap();
+                    let position = file.stream_position().await.unwrap();
                     let data_end = header.data_offset + header.data_size;
                     if position >= data_end {
                         break;

--- a/mater/lib/src/v1/mod.rs
+++ b/mater/lib/src/v1/mod.rs
@@ -6,10 +6,10 @@ use ipld_core::cid::{multihash::Multihash, Cid};
 use serde::{Deserialize, Serialize};
 
 use crate::multicodec::{RAW_CODE, SHA_256_CODE};
-pub use crate::v1::{reader::Reader, writer::Writer};
-pub(crate) use crate::v1::{
-    reader::{read_block, read_block_metadata, read_header},
-    writer::{write_block, write_header},
+pub(crate) use crate::v1::writer::{write_block, write_header};
+pub use crate::v1::{
+    reader::{CarReader, CarReaderExt},
+    writer::CarWriter,
 };
 
 /// The SHA256 hash over a 32-byte array filled with zeroes.
@@ -157,20 +157,13 @@ mod tests {
 
     use ipld_core::cid::Cid;
     use sha2::Sha256;
-    use tokio::io::BufWriter;
+    use tokio::io::{AsyncWriteExt, BufWriter};
 
     use crate::{
         multicodec::{generate_multihash, RAW_CODE},
-        v1::{Header, Reader, Writer},
+        v1::{writer::CarWriter, Header},
+        CarV1Reader,
     };
-
-    impl Writer<BufWriter<Vec<u8>>> {
-        pub fn test_writer() -> Self {
-            let buffer = Vec::new();
-            let buf_writer = BufWriter::new(buffer);
-            Writer::new(buf_writer)
-        }
-    }
 
     #[tokio::test]
     async fn roundtrip_lorem() {
@@ -181,19 +174,20 @@ mod tests {
         let root_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
         let written_header = Header::new(vec![root_cid]);
-        let mut writer = crate::v1::Writer::test_writer();
+        let buffer = Vec::new();
+        let mut writer = BufWriter::new(buffer);
         writer.write_header(&written_header).await.unwrap();
 
         // There's only one block
         writer.write_block(&root_cid, &file_contents).await.unwrap();
-        let buf_writer = writer.finish().await.unwrap();
+        writer.flush().await.unwrap();
         let expected_header = tokio::fs::read("tests/fixtures/car_v1/lorem.car")
             .await
             .unwrap();
-        assert_eq!(&expected_header, buf_writer.get_ref());
+        assert_eq!(&expected_header, writer.get_ref());
 
-        let buffer = buf_writer.into_inner();
-        let mut reader = Reader::new(Cursor::new(buffer));
+        let buffer = writer.into_inner();
+        let mut reader = Cursor::new(buffer);
         let read_header = reader.read_header().await.unwrap();
         assert_eq!(read_header, written_header);
 

--- a/mater/lib/src/v1/mod.rs
+++ b/mater/lib/src/v1/mod.rs
@@ -188,7 +188,7 @@ mod tests {
 
         let buffer = writer.into_inner();
         let mut reader = Cursor::new(buffer);
-        let read_header = reader.read_header().await.unwrap();
+        let read_header = reader.read_v1_header().await.unwrap();
         assert_eq!(read_header, written_header);
 
         let (read_cid, read_block) = reader.read_block().await.unwrap();

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -5,8 +5,7 @@ use serde_ipld_dagcbor::codec::DagCborCodec;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 
 use super::BlockMetadata;
-use crate::ipld::IpldExt;
-use crate::{async_varint::read_varint, v1::Header, v2::PRAGMA, Error};
+use crate::{async_varint::read_varint, ipld::IpldExt, v1::Header, v2::PRAGMA, Error};
 
 /// Low-level, reading functions for the CAR format.
 pub trait CarReader {

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -5,100 +5,11 @@ use serde_ipld_dagcbor::codec::DagCborCodec;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 
 use super::BlockMetadata;
-use crate::{async_varint::read_varint, cid::CidExt, v1::Header, v2::PRAGMA, Error};
+use crate::ipld::IpldExt;
+use crate::{async_varint::read_varint, v1::Header, v2::PRAGMA, Error};
 
-pub(crate) async fn read_header<R>(mut reader: R) -> Result<Header, Error>
-where
-    R: AsyncRead + Unpin,
-{
-    let header_length: usize = read_varint(&mut reader).await?.0;
-    let mut header_buffer = vec![0; header_length];
-    reader.read_exact(&mut header_buffer).await?;
-
-    // From the V2 specification:
-    // > This 11 byte string remains fixed and may be matched using a
-    // > simple byte comparison and does not require a varint or CBOR
-    // > decode since it does not vary for the CARv2 format.
-    // We're skipping the first byte because we already read the length
-    if header_buffer.starts_with(&PRAGMA[1..]) {
-        return Err(Error::VersionMismatchError {
-            expected: 1,
-            received: 2,
-        });
-    }
-
-    let header: Header = DagCborCodec::decode_from_slice(&header_buffer)?;
-    // NOTE(@jmg-duarte,23/05/2024): implementing a custom Deserialize for Header
-    // would make this shorter and overall handling more reliable
-    if header.version != 1 {
-        return Err(Error::VersionMismatchError {
-            expected: 1,
-            received: header.version,
-        });
-    }
-    if header.roots.is_empty() {
-        return Err(Error::EmptyRootsError);
-    }
-    Ok(header)
-}
-
-pub(crate) async fn read_block<R>(mut reader: R) -> Result<(Cid, Vec<u8>), Error>
-where
-    R: AsyncRead + Unpin,
-{
-    let (full_block_length, _): (u64, _) = read_varint(&mut reader).await?;
-    let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
-
-    let data_size = full_block_length as usize - cid_bytes_read;
-    let mut data_buffer = vec![0; data_size];
-    reader.read_exact(&mut data_buffer).await?;
-
-    Ok((cid, data_buffer))
-}
-
-pub(crate) async fn read_block_metadata<R>(mut reader: R) -> Result<BlockMetadata, Error>
-where
-    R: AsyncRead + AsyncSeek + Unpin,
-{
-    let block_offset = reader.stream_position().await?;
-
-    // Length of the block. This length contains the length of the cid and data.
-    let (full_block_length, varint_bytes_read): (u64, _) = read_varint(&mut reader).await?;
-
-    // Cid of the block
-    let (cid, cid_bytes_read) = Cid::read_bytes_async(&mut reader).await?;
-
-    // Data section position and size
-    let data_offset_source = block_offset + (varint_bytes_read as u64) + (cid_bytes_read as u64);
-    let data_size = full_block_length - cid_bytes_read as u64;
-
-    // Skip block data section
-    reader.seek(SeekFrom::Current(data_size as i64)).await?;
-
-    Ok(BlockMetadata {
-        block_offset,
-        cid,
-        data_offset_source,
-        data_size,
-    })
-}
-
-/// Low-level CARv1 reader.
-pub struct Reader<R> {
-    reader: R,
-}
-
-impl<R> Reader<R> {
-    /// Constructs a new [`Reader`].
-    pub fn new(reader: R) -> Self {
-        Self { reader }
-    }
-}
-
-impl<R> Reader<R>
-where
-    R: AsyncRead + Unpin,
-{
+/// Low-level, reading functions for the CAR format.
+pub trait CarReader {
     /// Read a [`Header`].
     ///
     /// As defined in the [specification constraints](https://ipld.io/specs/transport/car/carv1/#constraints),
@@ -107,9 +18,7 @@ where
     /// * The read header does not have roots.
     ///
     /// For more information, check the [header specification](https://ipld.io/specs/transport/car/carv1/#header).
-    pub async fn read_header(&mut self) -> Result<Header, Error> {
-        read_header(&mut self.reader).await
-    }
+    fn read_header(&mut self) -> impl std::future::Future<Output = Result<Header, Error>>;
 
     /// Reads a [`Cid`] and a data block.
     ///
@@ -122,20 +31,94 @@ where
     /// *The data block is returned AS IS, callers should use the codec field of the [`Cid`] to parse it.*
     ///
     /// For more information, check the [block specification](https://ipld.io/specs/transport/car/carv1/#data).
-    pub async fn read_block(&mut self) -> Result<(Cid, Vec<u8>), Error> {
-        read_block(&mut self.reader).await
+    fn read_block(&mut self) -> impl std::future::Future<Output = Result<(Cid, Vec<u8>), Error>>;
+}
+
+impl<R> CarReader for R
+where
+    R: AsyncRead + Unpin,
+{
+    async fn read_header(&mut self) -> Result<Header, Error> {
+        let header_length: usize = read_varint(self).await?.0;
+        let mut header_buffer = vec![0; header_length];
+        self.read_exact(&mut header_buffer).await?;
+
+        // From the V2 specification:
+        // > This 11 byte string remains fixed and may be matched using a
+        // > simple byte comparison and does not require a varint or CBOR
+        // > decode since it does not vary for the CARv2 format.
+        // We're skipping the first byte because we already read the length
+        if header_buffer.starts_with(&PRAGMA[1..]) {
+            return Err(Error::VersionMismatchError {
+                expected: 1,
+                received: 2,
+            });
+        }
+
+        let header: Header = DagCborCodec::decode_from_slice(&header_buffer)?;
+        // NOTE(@jmg-duarte,23/05/2024): implementing a custom Deserialize for Header
+        // would make this shorter and overall handling more reliable
+        if header.version != 1 {
+            return Err(Error::VersionMismatchError {
+                expected: 1,
+                received: header.version,
+            });
+        }
+        if header.roots.is_empty() {
+            return Err(Error::EmptyRootsError);
+        }
+        Ok(header)
+    }
+
+    async fn read_block(&mut self) -> Result<(Cid, Vec<u8>), Error> {
+        let (full_block_length, _): (u64, _) = read_varint(self).await?;
+        let (cid, cid_bytes_read) = self.read_cid().await?;
+
+        let data_size = full_block_length as usize - cid_bytes_read;
+        let mut data_buffer = vec![0; data_size];
+        self.read_exact(&mut data_buffer).await?;
+
+        Ok((cid, data_buffer))
     }
 }
 
-impl<R> Reader<R>
-where
-    R: AsyncRead + AsyncSeek + Unpin,
-{
+/// Extensions to the core functions in [`CarReader`].
+pub trait CarReaderExt: CarReader {
     /// Skips the next block and only returns a [`BlockMetadata`]. This is
     /// useful in cases when we only need the block's metadata and don't care
     /// about the content.
-    pub async fn read_block_metadata(&mut self) -> Result<BlockMetadata, Error> {
-        read_block_metadata(&mut self.reader).await
+    fn read_block_metadata(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<BlockMetadata, Error>>;
+}
+
+impl<R> CarReaderExt for R
+where
+    R: AsyncRead + AsyncSeek + Unpin,
+{
+    async fn read_block_metadata(&mut self) -> Result<BlockMetadata, Error> {
+        let block_offset = self.stream_position().await?;
+
+        // Length of the block. This length contains the length of the cid and data.
+        let (full_block_length, varint_bytes_read): (u64, _) = read_varint(self).await?;
+
+        // Cid of the block
+        let (cid, cid_bytes_read) = self.read_cid().await?;
+
+        // Data section position and size
+        let data_offset_source =
+            block_offset + (varint_bytes_read as u64) + (cid_bytes_read as u64);
+        let data_size = full_block_length - cid_bytes_read as u64;
+
+        // Skip block data section
+        self.seek(SeekFrom::Current(data_size as i64)).await?;
+
+        Ok(BlockMetadata {
+            block_offset,
+            cid,
+            data_offset_source,
+            data_size,
+        })
     }
 }
 
@@ -147,7 +130,7 @@ mod tests {
 
     use crate::{
         multicodec::{generate_multihash, RAW_CODE},
-        v1::reader::Reader,
+        v1::reader::{CarReader, CarReaderExt},
         Error,
     };
 
@@ -162,8 +145,7 @@ mod tests {
         let file = File::open("tests/fixtures/car_v1/lorem_header.car")
             .await
             .unwrap();
-        let reader = BufReader::new(file);
-        let mut reader = Reader::new(reader);
+        let mut reader = BufReader::new(file);
         let header = reader.read_header().await.unwrap();
 
         assert_eq!(header.version, 1);
@@ -180,8 +162,7 @@ mod tests {
         let contents_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
         let file = File::open("tests/fixtures/car_v1/lorem.car").await.unwrap();
-        let reader = BufReader::new(file);
-        let mut reader = Reader::new(reader);
+        let mut reader = BufReader::new(file);
         let header = reader.read_header().await.unwrap();
 
         assert_eq!(header.version, 1);
@@ -202,8 +183,7 @@ mod tests {
         let contents_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
         let file = File::open("tests/fixtures/car_v1/lorem.car").await.unwrap();
-        let reader = BufReader::new(file);
-        let mut reader = Reader::new(reader);
+        let mut reader = BufReader::new(file);
         let header = reader.read_header().await.unwrap();
 
         assert_eq!(header.version, 1);
@@ -218,9 +198,8 @@ mod tests {
 
     #[tokio::test]
     async fn v2_header() {
-        let file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let mut reader = Reader::new(file);
-        let header = reader.read_header().await;
+        let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
+        let header = file.read_header().await;
         println!("{:?}", header);
         assert!(matches!(
             header,

--- a/mater/lib/src/v1/reader.rs
+++ b/mater/lib/src/v1/reader.rs
@@ -18,7 +18,7 @@ pub trait CarReader {
     /// * The read header does not have roots.
     ///
     /// For more information, check the [header specification](https://ipld.io/specs/transport/car/carv1/#header).
-    fn read_header(&mut self) -> impl std::future::Future<Output = Result<Header, Error>>;
+    fn read_v1_header(&mut self) -> impl std::future::Future<Output = Result<Header, Error>>;
 
     /// Reads a [`Cid`] and a data block.
     ///
@@ -38,7 +38,7 @@ impl<R> CarReader for R
 where
     R: AsyncRead + Unpin,
 {
-    async fn read_header(&mut self) -> Result<Header, Error> {
+    async fn read_v1_header(&mut self) -> Result<Header, Error> {
         let header_length: usize = read_varint(self).await?.0;
         let mut header_buffer = vec![0; header_length];
         self.read_exact(&mut header_buffer).await?;
@@ -146,7 +146,7 @@ mod tests {
             .await
             .unwrap();
         let mut reader = BufReader::new(file);
-        let header = reader.read_header().await.unwrap();
+        let header = reader.read_v1_header().await.unwrap();
 
         assert_eq!(header.version, 1);
         assert_eq!(header.roots.len(), 1);
@@ -163,7 +163,7 @@ mod tests {
 
         let file = File::open("tests/fixtures/car_v1/lorem.car").await.unwrap();
         let mut reader = BufReader::new(file);
-        let header = reader.read_header().await.unwrap();
+        let header = reader.read_v1_header().await.unwrap();
 
         assert_eq!(header.version, 1);
         assert_eq!(header.roots.len(), 1);
@@ -184,7 +184,7 @@ mod tests {
 
         let file = File::open("tests/fixtures/car_v1/lorem.car").await.unwrap();
         let mut reader = BufReader::new(file);
-        let header = reader.read_header().await.unwrap();
+        let header = reader.read_v1_header().await.unwrap();
 
         assert_eq!(header.version, 1);
         assert_eq!(header.roots.len(), 1);
@@ -199,7 +199,7 @@ mod tests {
     #[tokio::test]
     async fn v2_header() {
         let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let header = file.read_header().await;
+        let header = file.read_v1_header().await;
         println!("{:?}", header);
         assert!(matches!(
             header,

--- a/mater/lib/src/v1/writer.rs
+++ b/mater/lib/src/v1/writer.rs
@@ -38,41 +38,37 @@ where
     Ok(varint_len + cid.encoded_len() + block.as_ref().len())
 }
 
-/// Low-level CARv1 writer.
-pub struct Writer<W> {
-    writer: W,
+/// Low-level, writing functions for the CAR format.
+pub trait CarWriter {
+    /// Write a [`crate::v1::Header`].
+    fn write_header(
+        &mut self,
+        header: &Header,
+    ) -> impl std::future::Future<Output = Result<usize, Error>>;
+
+    /// Write a [`Cid`] and the respective data block.
+    fn write_block<D>(
+        &mut self,
+        cid: &Cid,
+        data: &D,
+    ) -> impl std::future::Future<Output = Result<usize, Error>>
+    where
+        D: AsRef<[u8]>;
 }
 
-impl<W> Writer<W> {
-    /// Construct a new [`crate::v1::Writer`].
-    ///
-    /// Takes a writer into which the data will be written.
-    pub fn new(writer: W) -> Self {
-        Self { writer }
-    }
-}
-
-impl<W> Writer<W>
+impl<W> CarWriter for W
 where
     W: AsyncWrite + Unpin,
 {
-    /// Write a [`crate::v1::Header`].
-    pub async fn write_header(&mut self, header: &Header) -> Result<usize, Error> {
-        write_header(&mut self.writer, header).await
+    async fn write_header(&mut self, header: &Header) -> Result<usize, Error> {
+        write_header(self, header).await
     }
 
-    /// Write a [`Cid`] and the respective data block.
-    pub async fn write_block<D>(&mut self, cid: &Cid, data: &D) -> Result<usize, Error>
+    async fn write_block<D>(&mut self, cid: &Cid, data: &D) -> Result<usize, Error>
     where
         D: AsRef<[u8]>,
     {
-        write_block(&mut self.writer, cid, data).await
-    }
-
-    /// Flushes and returns the inner writer.
-    pub async fn finish(mut self) -> Result<W, Error> {
-        self.writer.flush().await?;
-        Ok(self.writer)
+        write_block(self, cid, data).await
     }
 }
 
@@ -80,8 +76,9 @@ where
 mod tests {
     use ipld_core::cid::Cid;
     use sha2::Sha256;
+    use tokio::io::{AsyncWriteExt, BufWriter};
 
-    use super::Writer;
+    use super::CarWriter;
     use crate::{
         multicodec::{generate_multihash, RAW_CODE},
         v1::Header,
@@ -95,18 +92,19 @@ mod tests {
         let contents_multihash = generate_multihash::<Sha256, _>(&file_contents);
         let root_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
-        let mut writer = Writer::test_writer();
+        let buffer = Vec::new();
+        let mut writer = BufWriter::new(buffer);
         writer
             .write_header(&Header::new(vec![root_cid]))
             .await
             .unwrap();
-        let buf_writer = writer.finish().await.unwrap();
+        writer.flush().await.unwrap();
 
         let expected_header = tokio::fs::read("tests/fixtures/car_v1/lorem_header.car")
             .await
             .unwrap();
 
-        assert_eq!(&expected_header, buf_writer.get_ref());
+        assert_eq!(&expected_header, writer.get_ref());
     }
 
     #[tokio::test]
@@ -117,18 +115,19 @@ mod tests {
         let contents_multihash = generate_multihash::<Sha256, _>(&file_contents);
         let root_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
-        let mut writer = Writer::test_writer();
+        let buffer = Vec::new();
+        let mut writer = BufWriter::new(buffer);
         writer
             .write_header(&Header::new(vec![root_cid]))
             .await
             .unwrap();
         // There's only one block
         writer.write_block(&root_cid, &file_contents).await.unwrap();
-        let buf_writer = writer.finish().await.unwrap();
+        writer.flush().await.unwrap();
 
         let expected_header = tokio::fs::read("tests/fixtures/car_v1/lorem.car")
             .await
             .unwrap();
-        assert_eq!(&expected_header, buf_writer.get_ref());
+        assert_eq!(&expected_header, writer.get_ref());
     }
 }

--- a/mater/lib/src/v2/index.rs
+++ b/mater/lib/src/v2/index.rs
@@ -415,13 +415,13 @@ mod tests {
 
     use crate::{
         multicodec::{generate_multihash, MultihashCode, DAG_PB_CODE, RAW_CODE, SHA_256_CODE},
-        v1::read_block,
         v2::index::{
             read_index, read_index_entry, read_index_sorted, read_multihash_index_sorted,
             read_single_width_index, write_index, write_index_entry, write_index_sorted,
             write_multihash_index_sorted, write_single_width_index, Index, IndexEntry, IndexSorted,
             MultihashIndexSorted, SingleWidthIndex,
         },
+        CarV1Reader,
     };
 
     fn generate_single_width_index<H>(count: u64) -> SingleWidthIndex
@@ -496,7 +496,7 @@ mod tests {
             .await
             .unwrap();
 
-            let (cid, block) = read_block(&mut file).await.unwrap();
+            let (cid, block) = file.read_block().await.unwrap();
             assert_eq!(cid.hash().code(), SHA_256_CODE);
 
             // Sorting at this level is made byte-wise, so there's no short way

--- a/mater/lib/src/v2/mod.rs
+++ b/mater/lib/src/v2/mod.rs
@@ -6,8 +6,8 @@ use bitflags::bitflags;
 pub use index::{
     write_index, Index, IndexEntry, IndexSorted, MultihashIndexSorted, SingleWidthIndex,
 };
-pub use reader::{verify_cid, Reader};
-pub use writer::{write_header, Writer};
+pub use reader::{CarReader, CarReaderExt};
+pub use writer::{write_header, CarWriter};
 
 /// The pragma for a CARv2. This is also a valid CARv1 header, with version 2 and no root CIDs.
 ///
@@ -112,22 +112,24 @@ mod tests {
 
     use ipld_core::cid::Cid;
     use sha2::Sha256;
-    use tokio::io::{AsyncSeekExt, BufWriter};
+    use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter};
 
     use crate::{
         multicodec::{generate_multihash, MultihashCode, RAW_CODE},
         test_utils::assert_buffer_eq,
+        v1::CarWriter,
         v2::{
             index::{Index, IndexEntry, IndexSorted},
-            Header, Reader, Writer,
+            writer::CarWriter as _,
+            Header,
         },
+        CarV1Reader, CarV2Reader,
     };
 
     #[tokio::test]
     async fn roundtrip_lorem() {
         let cursor = Cursor::new(vec![]);
-        let buf_writer = BufWriter::new(cursor);
-        let mut writer = Writer::new(buf_writer);
+        let mut writer = BufWriter::new(cursor);
 
         let file_contents = tokio::fs::read("tests/fixtures/original/lorem.txt")
             .await
@@ -137,30 +139,21 @@ mod tests {
 
         let written_header = Header::new(false, 51, 7661, 7712);
         // To simplify testing, the values were extracted using `car inspect`
-        writer.write_header(&written_header).await.unwrap();
+        writer.write_v2_header(&written_header).await.unwrap();
 
         // We start writing the CARv1 here and keep the stream positions
         // so that we can properly index the blocks later
-        let start_car_v1 = {
-            let inner = writer.get_inner_mut();
-            inner.stream_position().await.unwrap()
-        };
+        let start_car_v1 = writer.stream_position().await.unwrap();
 
         let written_header_v1 = crate::v1::Header::new(vec![root_cid]);
-        writer.write_v1_header(&written_header_v1).await.unwrap();
+        writer.write_header(&written_header_v1).await.unwrap();
 
-        let start_car_v1_data = {
-            let inner = writer.get_inner_mut();
-            inner.stream_position().await.unwrap()
-        };
+        let start_car_v1_data = writer.stream_position().await.unwrap();
 
         // There's only one block
         writer.write_block(&root_cid, &file_contents).await.unwrap();
 
-        let written = {
-            let inner = writer.get_inner_mut();
-            inner.stream_position().await.unwrap()
-        };
+        let written = writer.stream_position().await.unwrap();
         assert_eq!(written, 7712);
 
         let mut mapping = BTreeMap::new();
@@ -179,24 +172,24 @@ mod tests {
         let written_index = Index::multihash(mapping);
         writer.write_index(&written_index).await.unwrap();
 
-        let mut buffer = writer.finish().await.unwrap().into_inner();
-        buffer.rewind().await.unwrap();
+        writer.flush().await.unwrap();
+        writer.rewind().await.unwrap();
+
         let expected_header = tokio::fs::read("tests/fixtures/car_v2/lorem.car")
             .await
             .unwrap();
 
-        assert_buffer_eq!(&expected_header, buffer.get_ref());
+        assert_buffer_eq!(&expected_header, writer.get_ref().get_ref());
 
-        let mut reader = Reader::new(buffer);
-        reader.read_pragma().await.unwrap();
-        let read_header = reader.read_header().await.unwrap();
+        writer.read_pragma().await.unwrap();
+        let read_header = writer.read_v2_header().await.unwrap();
         assert_eq!(read_header, written_header);
-        let read_header_v1 = reader.read_v1_header().await.unwrap();
+        let read_header_v1 = writer.read_header().await.unwrap();
         assert_eq!(read_header_v1, written_header_v1);
-        let (read_cid, read_block) = reader.read_block().await.unwrap();
+        let (read_cid, read_block) = writer.read_block().await.unwrap();
         assert_eq!(read_cid, root_cid);
         assert_eq!(read_block, file_contents);
-        let read_index = reader.read_index().await.unwrap();
+        let read_index = writer.read_index().await.unwrap();
         assert_eq!(read_index, written_index);
     }
 }

--- a/mater/lib/src/v2/mod.rs
+++ b/mater/lib/src/v2/mod.rs
@@ -184,7 +184,7 @@ mod tests {
         writer.read_pragma().await.unwrap();
         let read_header = writer.read_v2_header().await.unwrap();
         assert_eq!(read_header, written_header);
-        let read_header_v1 = writer.read_header().await.unwrap();
+        let read_header_v1 = writer.read_v1_header().await.unwrap();
         assert_eq!(read_header_v1, written_header_v1);
         let (read_cid, read_block) = writer.read_block().await.unwrap();
         assert_eq!(read_cid, root_cid);

--- a/mater/lib/src/v2/reader.rs
+++ b/mater/lib/src/v2/reader.rs
@@ -2,9 +2,10 @@ use ipld_core::cid::Cid;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::index::read_index;
-use crate::v1::CarReader as _;
 use crate::{
-    v1::{self},
+    v1::{
+        CarReader as _, {self},
+    },
     v2::{index::Index, Characteristics, Header, PRAGMA},
     Error,
 };

--- a/mater/lib/src/v2/reader.rs
+++ b/mater/lib/src/v2/reader.rs
@@ -87,14 +87,14 @@ where
     async fn is_car_file(&mut self) -> Result<(), Error> {
         let _pragma = self.read_pragma().await?;
         let _header = self.read_v2_header().await?;
-        let _v1_header = self.read_header().await?;
+        let _v1_header = self.read_v1_header().await?;
         Ok(())
     }
 
     async fn verify_cid(&mut self, contents_cid: Cid) -> Result<(), Error> {
         let _pragma = self.read_pragma().await?;
         let _header = self.read_v2_header().await?;
-        let v1_header = self.read_header().await?;
+        let v1_header = self.read_v1_header().await?;
 
         if [contents_cid] != *v1_header.roots {
             return Err(Error::InvalidCid);
@@ -223,7 +223,7 @@ mod tests {
             .await
             .unwrap();
 
-        let v1_header = v1::CarReader::read_header(&mut file).await.unwrap();
+        let v1_header = v1::CarReader::read_v1_header(&mut file).await.unwrap();
         assert_eq!(v1_header.roots, vec![contents_cid]);
 
         loop {
@@ -287,7 +287,7 @@ mod tests {
         assert_eq!(header.data_size, 7661);
         assert_eq!(header.index_offset, 7712);
 
-        let v1_header = v1::CarReader::read_header(&mut file).await.unwrap();
+        let v1_header = v1::CarReader::read_v1_header(&mut file).await.unwrap();
         assert_eq!(v1_header.roots, vec![contents_cid]);
 
         loop {
@@ -337,7 +337,7 @@ mod tests {
         assert_eq!(header.data_size, 654402);
         assert_eq!(header.index_offset, 654453);
 
-        let v1_header = v1::CarReader::read_header(&mut file).await.unwrap();
+        let v1_header = v1::CarReader::read_v1_header(&mut file).await.unwrap();
         assert_eq!(v1_header.roots.len(), 1);
         assert_eq!(
             v1_header.roots[0]

--- a/mater/lib/src/v2/reader.rs
+++ b/mater/lib/src/v2/reader.rs
@@ -1,34 +1,100 @@
 use ipld_core::cid::Cid;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::index::read_index;
+use crate::v1::CarReader as _;
 use crate::{
-    v1::BlockMetadata,
+    v1::{self},
     v2::{index::Index, Characteristics, Header, PRAGMA},
     Error,
 };
 
-/// Low-level CARv2 reader.
-pub struct Reader<R> {
-    reader: R,
+/// CAR v2 specific reading functions.
+pub trait CarReader {
+    /// Read the CARv2 pragma.
+    ///
+    /// This function fails if the pragma does not match the one defined in the
+    /// [specification](https://ipld.io/specs/transport/car/carv2/#pragma).
+    fn read_pragma(&mut self) -> impl std::future::Future<Output = Result<(), Error>>;
+
+    /// Read the [`Header`].
+    ///
+    /// This function fails if there are set bits that are not covered in the
+    /// [characteristics specification](https://ipld.io/specs/transport/car/carv2/#characteristics).
+    ///
+    /// For more information check the [header specification](https://ipld.io/specs/transport/car/carv2/#header).
+    fn read_v2_header(&mut self) -> impl std::future::Future<Output = Result<Header, Error>>;
+
+    /// Read an [`Index`].
+    fn read_index(&mut self) -> impl std::future::Future<Output = Result<Index, Error>>;
 }
 
-impl<R> Reader<R> {
-    /// Constructs a new [`Reader`].
-    pub fn new(reader: R) -> Self {
-        Self { reader }
-    }
-}
-
-impl<R> Reader<R>
+impl<R> CarReader for R
 where
     R: AsyncRead + Unpin,
 {
+    async fn read_pragma(&mut self) -> Result<(), Error> {
+        let mut pragma_buffer = vec![0; PRAGMA.len()];
+        self.read_exact(&mut pragma_buffer).await?;
+        if pragma_buffer != PRAGMA {
+            return Err(Error::InvalidPragmaError(pragma_buffer));
+        }
+        // Since we validate the pragma, there's no point in returning it.
+        Ok(())
+    }
+
+    async fn read_v2_header(&mut self) -> Result<Header, Error> {
+        // Even though the standard doesn't explicitly state endianness, go-car does
+        // https://github.com/ipld/go-car/blob/45b81c1cc5117b3340dfdb025afeca90bfbe8d86/v2/car.go#L51-L69
+        let characteristics_bitfield = self.read_u128_le().await?;
+
+        let characteristics = Characteristics::from_bits(characteristics_bitfield)
+            .ok_or(Error::UnknownCharacteristicsError(characteristics_bitfield))?;
+
+        let data_offset = self.read_u64_le().await?;
+        let data_size = self.read_u64_le().await?;
+        let index_offset = self.read_u64_le().await?;
+
+        Ok(Header {
+            characteristics,
+            data_offset,
+            data_size,
+            index_offset,
+        })
+    }
+
+    async fn read_index(&mut self) -> Result<Index, Error> {
+        read_index(self).await
+    }
+}
+
+/// Extensions to [`CarReader`].
+pub trait CarReaderExt: CarReader + v1::CarReader {
+    /// Checks if the contents of the reader is a CARv2 file.
+    fn is_car_file(&mut self) -> impl std::future::Future<Output = Result<(), Error>>;
+
     /// Takes in a CID and checks that the contents in the reader matches this CID
-    pub async fn verify_cid(&mut self, contents_cid: Cid) -> Result<(), Error> {
+    fn verify_cid(
+        &mut self,
+        contents_cid: Cid,
+    ) -> impl std::future::Future<Output = Result<(), Error>>;
+}
+
+impl<R> CarReaderExt for R
+where
+    R: AsyncRead + Unpin,
+{
+    async fn is_car_file(&mut self) -> Result<(), Error> {
         let _pragma = self.read_pragma().await?;
-        let _header = self.read_header().await?;
-        let v1_header = self.read_v1_header().await?;
+        let _header = self.read_v2_header().await?;
+        let _v1_header = self.read_header().await?;
+        Ok(())
+    }
+
+    async fn verify_cid(&mut self, contents_cid: Cid) -> Result<(), Error> {
+        let _pragma = self.read_pragma().await?;
+        let _header = self.read_v2_header().await?;
+        let v1_header = self.read_header().await?;
 
         if [contents_cid] != *v1_header.roots {
             return Err(Error::InvalidCid);
@@ -46,100 +112,6 @@ where
             Err(Error::InvalidCid)
         }
     }
-
-    /// Checks if the contents of the reader is a CARv2 file.
-    pub async fn is_car_file(&mut self) -> Result<(), Error> {
-        let _pragma = self.read_pragma().await?;
-        let _header = self.read_header().await?;
-        let _v1_header = self.read_v1_header().await?;
-        Ok(())
-    }
-
-    /// Read the CARv2 pragma.
-    ///
-    /// This function fails if the pragma does not match the one defined in the
-    /// [specification](https://ipld.io/specs/transport/car/carv2/#pragma).
-    pub async fn read_pragma(&mut self) -> Result<(), Error> {
-        let mut pragma_buffer = vec![0; PRAGMA.len()];
-        self.reader.read_exact(&mut pragma_buffer).await?;
-        if pragma_buffer != PRAGMA {
-            return Err(Error::InvalidPragmaError(pragma_buffer));
-        }
-        // Since we validate the pragma, there's no point in returning it.
-        Ok(())
-    }
-
-    /// Read the [`Header`].
-    ///
-    /// This function fails if there are set bits that are not covered in the
-    /// [characteristics specification](https://ipld.io/specs/transport/car/carv2/#characteristics).
-    ///
-    /// For more information check the [header specification](https://ipld.io/specs/transport/car/carv2/#header).
-    pub async fn read_header(&mut self) -> Result<Header, Error> {
-        // Even though the standard doesn't explicitly state endianness, go-car does
-        // https://github.com/ipld/go-car/blob/45b81c1cc5117b3340dfdb025afeca90bfbe8d86/v2/car.go#L51-L69
-        let characteristics_bitfield = self.reader.read_u128_le().await?;
-
-        let characteristics = Characteristics::from_bits(characteristics_bitfield)
-            .ok_or(Error::UnknownCharacteristicsError(characteristics_bitfield))?;
-
-        let data_offset = self.reader.read_u64_le().await?;
-        let data_size = self.reader.read_u64_le().await?;
-        let index_offset = self.reader.read_u64_le().await?;
-
-        Ok(Header {
-            characteristics,
-            data_offset,
-            data_size,
-            index_offset,
-        })
-    }
-
-    /// Read the [`Header`].
-    ///
-    /// See [`crate::v1::Reader`] for more information.
-    pub async fn read_v1_header(&mut self) -> Result<crate::v1::Header, Error> {
-        crate::v1::read_header(&mut self.reader).await
-    }
-
-    /// Read a [`Cid`] and data block.
-    ///
-    /// See [`crate::v1::Reader`] for more information.
-    pub async fn read_block(&mut self) -> Result<(Cid, Vec<u8>), Error> {
-        crate::v1::read_block(&mut self.reader).await
-    }
-
-    /// Read an [`Index`].
-    pub async fn read_index(&mut self) -> Result<Index, Error> {
-        read_index(&mut self.reader).await
-    }
-
-    /// Get a mutable reference to the inner reader.
-    ///
-    /// This is useful to skip padding or perform other operations the
-    /// [`Reader`] does not natively support.
-    pub fn get_inner_mut(&mut self) -> &mut R {
-        &mut self.reader
-    }
-}
-
-impl<R> Reader<R>
-where
-    R: AsyncRead + AsyncSeek + Unpin,
-{
-    /// Skips the next block and only returns a [`BlockMetadata`]. This is
-    /// useful in cases when we only need the block's metadata and don't care
-    /// about the content.
-    pub async fn read_block_metadata(&mut self) -> Result<BlockMetadata, Error> {
-        crate::v1::read_block_metadata(&mut self.reader).await
-    }
-}
-
-/// Function verifies that a given CID matches the CID for the CAR file in the given reader
-pub async fn verify_cid<R: AsyncRead + Unpin>(reader: R, contents_cid: Cid) -> Result<(), Error> {
-    let mut reader = Reader::new(BufReader::new(reader));
-
-    reader.verify_cid(contents_cid).await
 }
 
 #[cfg(test)]
@@ -152,19 +124,22 @@ mod tests {
 
     use crate::{
         multicodec::{generate_multihash, RAW_CODE, SHA_256_CODE},
-        v2::{index::Index, reader::Reader},
-        verify_cid, Error,
+        v1,
+        v2::{
+            index::Index,
+            reader::{CarReader, CarReaderExt},
+        },
+        Error,
     };
 
     #[tokio::test]
     async fn failure_verifying_cid() {
         let path = PathBuf::from("tests/fixtures/car_v2/spaceglenda.car");
-        let file = File::open(&path).await.unwrap();
+        let mut file = File::open(&path).await.unwrap();
 
         let wrong_cid =
             Cid::from_str("bafkreidnmi5roys6exf5urwrplejyjvt3nrviryb4lafsjrggig357krlm").unwrap();
-
-        let result = verify_cid(file, wrong_cid).await;
+        let result = file.verify_cid(wrong_cid).await;
 
         assert!(result.is_err());
     }
@@ -172,38 +147,40 @@ mod tests {
     #[tokio::test]
     async fn test_verify_cid_empty() {
         let path = PathBuf::from("tests/fixtures/car_v2/empty.car");
-        let file = File::open(&path).await.unwrap();
+        let mut file = File::open(&path).await.unwrap();
         // Taken from `car inspect tests/fixtures/car_v2/spaceglenda.car`
         let contents_cid =
             Cid::from_str("bafybeib37argqu7zjibjqwiekvvjtv6lby76ruft4dkysyfqdhvk4o3gvy").unwrap();
-        assert!(verify_cid(file, contents_cid).await.is_ok());
+        let result = file.verify_cid(contents_cid).await;
+        assert!(matches!(result, Ok(())));
     }
 
     #[tokio::test]
     async fn test_verify_cid_spaceglenda() {
         let path = PathBuf::from("tests/fixtures/car_v2/spaceglenda.car");
-        let file = File::open(&path).await.unwrap();
+        let mut file = File::open(&path).await.unwrap();
         // Taken from `car inspect tests/fixtures/car_v2/spaceglenda.car`
         let contents_cid =
             Cid::from_str("bafybeiefli7iugocosgirzpny4t6yxw5zehy6khtao3d252pbf352xzx5q").unwrap();
-        assert!(verify_cid(file, contents_cid).await.is_ok());
+        let result = file.verify_cid(contents_cid).await;
+        assert!(matches!(result, Ok(())));
     }
 
     #[tokio::test]
     async fn test_verify_cid_lorem() {
         let path = PathBuf::from("tests/fixtures/car_v2/lorem.car");
-        let file = File::open(&path).await.unwrap();
+        let mut file = File::open(&path).await.unwrap();
         // Taken from `car inspect tests/fixtures/car_v2/lorem.car`
         let contents_cid =
             Cid::from_str("bafkreidnmi5roys6exf5urwrplejyjvt3nrviryb4lafsjrggig357krlm").unwrap();
-        assert!(verify_cid(file, contents_cid).await.is_ok());
+        let result = file.verify_cid(contents_cid).await;
+        assert!(matches!(result, Ok(())));
     }
 
     #[tokio::test]
     async fn pragma() {
-        let file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let mut reader = Reader::new(file);
-        let pragma = reader.read_pragma().await;
+        let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
+        let pragma = file.read_pragma().await;
         assert!(matches!(pragma, Ok(())));
     }
 
@@ -211,17 +188,16 @@ mod tests {
     async fn bad_pragma() {
         let mut bad_pragma = vec![0u8; 11];
         bad_pragma.fill_with(rand::random);
-        let mut reader = Reader::new(Cursor::new(bad_pragma));
+        let mut reader = Cursor::new(bad_pragma);
         let pragma = reader.read_pragma().await;
         assert!(matches!(pragma, Err(Error::InvalidPragmaError(_))));
     }
 
     #[tokio::test]
     async fn header() {
-        let file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let mut reader = Reader::new(file);
-        let _ = reader.read_pragma().await.unwrap();
-        let header = reader.read_header().await.unwrap();
+        let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
+        let _ = file.read_pragma().await.unwrap();
+        let header = file.read_v2_header().await.unwrap();
 
         // `car inspect tests/fixtures/car_v2/lorem.car` to get the values
         assert_eq!(header.characteristics.bits(), 0);
@@ -239,22 +215,19 @@ mod tests {
         let contents_multihash = generate_multihash::<Sha256, _>(&file_contents);
         let contents_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
-        let file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let mut reader = Reader::new(file);
-        let _ = reader.read_pragma().await.unwrap();
-        let header = reader.read_header().await.unwrap();
+        let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
+        let _ = file.read_pragma().await.unwrap();
+        let header = file.read_v2_header().await.unwrap();
 
-        let inner = reader.get_inner_mut();
-        inner
-            .seek(std::io::SeekFrom::Start(header.data_offset))
+        file.seek(std::io::SeekFrom::Start(header.data_offset))
             .await
             .unwrap();
 
-        let v1_header = reader.read_v1_header().await.unwrap();
+        let v1_header = v1::CarReader::read_header(&mut file).await.unwrap();
         assert_eq!(v1_header.roots, vec![contents_cid]);
 
         loop {
-            match reader.read_block().await {
+            match v1::CarReader::read_block(&mut file).await {
                 Ok((cid, _)) => println!("{:?}", cid),
                 else_ => {
                     assert!(matches!(else_, Err(Error::IoError(_))));
@@ -272,18 +245,15 @@ mod tests {
             .unwrap();
         let contents_multihash = generate_multihash::<Sha256, _>(&file_contents);
 
-        let file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let mut reader = Reader::new(file);
-        let _ = reader.read_pragma().await.unwrap();
-        let header = reader.read_header().await.unwrap();
+        let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
+        let _ = file.read_pragma().await.unwrap();
+        let header = file.read_v2_header().await.unwrap();
 
-        let inner = reader.get_inner_mut();
-        inner
-            .seek(std::io::SeekFrom::Start(header.index_offset))
+        file.seek(std::io::SeekFrom::Start(header.index_offset))
             .await
             .unwrap();
 
-        let index = reader.read_index().await.unwrap();
+        let index = file.read_index().await.unwrap();
         assert!(matches!(index, Index::MultihashIndexSorted(_)));
         if let Index::MultihashIndexSorted(mh) = index {
             assert_eq!(mh.len(), 1);
@@ -307,25 +277,24 @@ mod tests {
         let contents_multihash = generate_multihash::<Sha256, _>(&file_contents);
         let contents_cid = Cid::new_v1(RAW_CODE, contents_multihash);
 
-        let file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
-        let mut reader = Reader::new(file);
-        reader.read_pragma().await.unwrap();
+        let mut file = File::open("tests/fixtures/car_v2/lorem.car").await.unwrap();
+        file.read_pragma().await.unwrap();
 
-        let header = reader.read_header().await.unwrap();
+        let header = file.read_v2_header().await.unwrap();
         // `car inspect tests/fixtures/car_v2/lorem.car` to get the values
         assert_eq!(header.characteristics.bits(), 0);
         assert_eq!(header.data_offset, 51);
         assert_eq!(header.data_size, 7661);
         assert_eq!(header.index_offset, 7712);
 
-        let v1_header = reader.read_v1_header().await.unwrap();
+        let v1_header = v1::CarReader::read_header(&mut file).await.unwrap();
         assert_eq!(v1_header.roots, vec![contents_cid]);
 
         loop {
-            match reader.read_block().await {
+            match v1::CarReader::read_block(&mut file).await {
                 Ok((cid, _)) => {
                     // Kinda hacky, but better than doing a seek later on
-                    let position = reader.get_inner_mut().stream_position().await.unwrap();
+                    let position = file.stream_position().await.unwrap();
                     let data_end = header.data_offset + header.data_size;
                     if position >= data_end {
                         break;
@@ -339,7 +308,7 @@ mod tests {
             }
         }
 
-        let index = reader.read_index().await.unwrap();
+        let index = file.read_index().await.unwrap();
         assert!(matches!(index, Index::MultihashIndexSorted(_)));
         if let Index::MultihashIndexSorted(mh) = index {
             assert_eq!(mh.len(), 1);
@@ -356,20 +325,19 @@ mod tests {
 
     #[tokio::test]
     async fn full_file_glenda() {
-        let file = File::open("tests/fixtures/car_v2/spaceglenda.car")
+        let mut file = File::open("tests/fixtures/car_v2/spaceglenda.car")
             .await
             .unwrap();
-        let mut reader = Reader::new(file);
-        reader.read_pragma().await.unwrap();
+        file.read_pragma().await.unwrap();
 
-        let header = reader.read_header().await.unwrap();
+        let header = file.read_v2_header().await.unwrap();
         // `car inspect tests/fixtures/car_v2/lorem.car` to get the values
         assert_eq!(header.characteristics.bits(), 0);
         assert_eq!(header.data_offset, 51);
         assert_eq!(header.data_size, 654402);
         assert_eq!(header.index_offset, 654453);
 
-        let v1_header = reader.read_v1_header().await.unwrap();
+        let v1_header = v1::CarReader::read_header(&mut file).await.unwrap();
         assert_eq!(v1_header.roots.len(), 1);
         assert_eq!(
             v1_header.roots[0]
@@ -381,10 +349,10 @@ mod tests {
 
         loop {
             // NOTE(@jmg-duarte,22/05/2024): review this
-            match reader.read_block().await {
+            match v1::CarReader::read_block(&mut file).await {
                 Ok((_, _)) => {
                     // Kinda hacky, but better than doing a seek later on
-                    let position = reader.get_inner_mut().stream_position().await.unwrap();
+                    let position = file.stream_position().await.unwrap();
                     let data_end = header.data_offset + header.data_size;
                     if position >= data_end {
                         break;
@@ -398,7 +366,7 @@ mod tests {
             }
         }
 
-        let index = reader.read_index().await.unwrap();
+        let index = file.read_index().await.unwrap();
         assert!(matches!(index, Index::MultihashIndexSorted(_)));
         if let Index::MultihashIndexSorted(mh) = index {
             assert_eq!(mh.len(), 1);

--- a/mater/lib/src/v2/writer.rs
+++ b/mater/lib/src/v2/writer.rs
@@ -1,78 +1,62 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use ipld_core::cid::Cid;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use super::{Header, PRAGMA};
 use crate::{v2::index::Index, Error};
 
-/// Low-level CARv2 writer.
-pub struct Writer<W> {
-    writer: W,
-}
-
-impl<W> Writer<W> {
-    /// Construct a new [`Writer`].
+/// Low-level, V2-specific writing functions for the CAR format.
+pub trait CarWriter {
+    /// Write a [`Header`].
     ///
-    /// Takes a write into which the data will be written.
-    pub fn new(writer: W) -> Self {
-        Self { writer }
-    }
+    /// Returns the number of bytes written.
+    fn write_v2_header(
+        &mut self,
+        header: &Header,
+    ) -> impl std::future::Future<Output = Result<usize, Error>>;
 
-    /// Get a mutable reference to the inner writer.
-    pub fn get_inner_mut(&mut self) -> &mut W {
-        &mut self.writer
-    }
+    /// Write an [`Index`].
+    ///
+    /// Returns the number of bytes written.
+    fn write_index(
+        &mut self,
+        index: &Index,
+    ) -> impl std::future::Future<Output = Result<usize, Error>>;
+
+    /// Write padding (`0x0` bytes).
+    ///
+    /// Returns the number of bytes written.
+    fn write_padding(
+        &mut self,
+        length: usize,
+    ) -> impl std::future::Future<Output = Result<usize, Error>>;
 }
 
-impl<W> Writer<W>
+impl<W> CarWriter for W
 where
     W: AsyncWrite + Unpin,
 {
     /// Write a [`Header`].
     ///
     /// Returns the number of bytes written.
-    pub async fn write_header(&mut self, header: &Header) -> Result<usize, Error> {
-        write_header(&mut self.writer, header).await
-    }
-
-    /// Write a [`crate::v1::Header`].
-    ///
-    /// Returns the number of bytes written.
-    pub async fn write_v1_header(&mut self, v1_header: &crate::v1::Header) -> Result<usize, Error> {
-        crate::v1::write_header(&mut self.writer, v1_header).await
-    }
-
-    /// Write a [`Cid`] and the respective data block.
-    ///
-    /// Returns the number of bytes written.
-    pub async fn write_block<Block>(&mut self, cid: &Cid, block: &Block) -> Result<usize, Error>
-    where
-        Block: AsRef<[u8]>,
-    {
-        crate::v1::write_block(&mut self.writer, cid, block).await
+    async fn write_v2_header(&mut self, header: &Header) -> Result<usize, Error> {
+        write_header(self, header).await
     }
 
     /// Write an [`Index`].
     ///
     /// Returns the number of bytes written.
-    pub async fn write_index(&mut self, index: &Index) -> Result<usize, Error> {
-        crate::v2::index::write_index(&mut self.writer, index).await
+    async fn write_index(&mut self, index: &Index) -> Result<usize, Error> {
+        crate::v2::index::write_index(self, index).await
     }
 
     /// Write padding (`0x0` bytes).
     ///
     /// Returns the number of bytes written.
-    pub async fn write_padding(&mut self, length: usize) -> Result<usize, Error> {
+    async fn write_padding(&mut self, length: usize) -> Result<usize, Error> {
         for _ in 0..length {
-            self.writer.write_u8(0).await?;
+            self.write_u8(0).await?;
         }
         Ok(length)
-    }
-
-    /// Flushes and returns the inner writer.
-    pub async fn finish(mut self) -> Result<W, Error> {
-        self.writer.flush().await?;
-        Ok(self.writer)
     }
 }
 
@@ -105,7 +89,7 @@ mod tests {
     use sha2::Sha256;
     use tokio::{
         fs::File,
-        io::{AsyncSeekExt, BufWriter},
+        io::{AsyncSeekExt, AsyncWriteExt, BufWriter},
     };
 
     use crate::{
@@ -113,19 +97,13 @@ mod tests {
         multicodec::{generate_multihash, MultihashCode, RAW_CODE},
         test_utils::assert_buffer_eq,
         unixfs::stream_balanced_tree,
+        v1::CarWriter,
         v2::{
             index::{IndexEntry, IndexSorted, SingleWidthIndex},
-            Header, Writer,
+            writer::CarWriter as _,
+            Header,
         },
     };
-
-    impl Writer<BufWriter<Vec<u8>>> {
-        fn test_writer() -> Self {
-            let buffer = Vec::new();
-            let buf_writer = BufWriter::new(buffer);
-            Writer::new(buf_writer)
-        }
-    }
 
     #[tokio::test]
     async fn header_lorem() {
@@ -133,14 +111,16 @@ mod tests {
             .await
             .unwrap();
 
-        let mut writer = Writer::test_writer();
+        let buffer = Vec::new();
+        let mut writer = BufWriter::new(buffer);
         // To simplify testing, the values were extracted using `car inspect`
         writer
-            .write_header(&Header::new(false, 51, 7661, 7712))
+            .write_v2_header(&Header::new(false, 51, 7661, 7712))
             .await
             .unwrap();
 
-        let inner = writer.finish().await.unwrap().into_inner();
+        writer.flush().await.unwrap();
+        let inner = writer.into_inner();
         assert_eq!(inner.len(), 51);
         assert_eq!(inner, file_contents[..51]);
     }
@@ -151,14 +131,16 @@ mod tests {
             .await
             .unwrap();
 
-        let mut writer = Writer::test_writer();
+        let buffer = Vec::new();
+        let mut writer = BufWriter::new(buffer);
         // To simplify testing, the values were extracted using `car inspect`
         writer
-            .write_header(&Header::new(false, 51, 654402, 654453))
+            .write_v2_header(&Header::new(false, 51, 654402, 654453))
             .await
             .unwrap();
 
-        let inner = writer.finish().await.unwrap().into_inner();
+        writer.flush().await.unwrap();
+        let inner = writer.into_inner();
         assert_eq!(inner.len(), 51);
         assert_eq!(inner, file_contents[..51]);
     }
@@ -167,8 +149,7 @@ mod tests {
     #[tokio::test]
     async fn full_lorem() {
         let cursor = Cursor::new(vec![]);
-        let buf_writer = BufWriter::new(cursor);
-        let mut writer = Writer::new(buf_writer);
+        let mut writer = BufWriter::new(cursor);
 
         let file_contents = tokio::fs::read("tests/fixtures/original/lorem.txt")
             .await
@@ -178,32 +159,25 @@ mod tests {
 
         // To simplify testing, the values were extracted using `car inspect`
         writer
-            .write_header(&Header::new(false, 51, 7661, 7712))
+            .write_v2_header(&Header::new(false, 51, 7661, 7712))
             .await
             .unwrap();
 
         // We start writing the CARv1 here and keep the stream positions
         // so that we can properly index the blocks later
-        let start_car_v1 = {
-            let inner = writer.get_inner_mut();
-            inner.stream_position().await.unwrap()
-        };
+        let start_car_v1 = writer.stream_position().await.unwrap();
 
         writer
-            .write_v1_header(&crate::v1::Header::new(vec![root_cid]))
+            .write_header(&crate::v1::Header::new(vec![root_cid]))
             .await
             .unwrap();
 
-        let start_car_v1_data = {
-            let inner = writer.get_inner_mut();
-            inner.stream_position().await.unwrap()
-        };
+        let start_car_v1_data = writer.stream_position().await.unwrap();
 
         // There's only one block
         writer.write_block(&root_cid, &file_contents).await.unwrap();
 
-        let inner = writer.get_inner_mut();
-        let written = inner.stream_position().await.unwrap();
+        let written = writer.stream_position().await.unwrap();
         assert_eq!(written, 7712);
 
         let mut mapping = BTreeMap::new();
@@ -222,14 +196,14 @@ mod tests {
         let index = crate::v2::index::Index::multihash(mapping);
         writer.write_index(&index).await.unwrap();
 
-        let mut buf_writer = writer.finish().await.unwrap();
-        buf_writer.rewind().await.unwrap();
+        writer.flush().await.unwrap();
+        writer.rewind().await.unwrap();
 
         let expected_header = tokio::fs::read("tests/fixtures/car_v2/lorem.car")
             .await
             .unwrap();
 
-        assert_buffer_eq!(&expected_header, buf_writer.get_ref().get_ref())
+        assert_buffer_eq!(&expected_header, writer.get_ref().get_ref())
     }
 
     // Byte to byte comparison to the spaceglenda.car file
@@ -237,8 +211,7 @@ mod tests {
     #[tokio::test]
     async fn full_spaceglenda() {
         let cursor = Cursor::new(vec![]);
-        let buf_writer = BufWriter::new(cursor);
-        let mut writer = Writer::new(buf_writer);
+        let mut writer = BufWriter::new(cursor);
 
         let file = File::open("tests/fixtures/original/spaceglenda.jpg")
             .await
@@ -252,34 +225,27 @@ mod tests {
 
         // To simplify testing, the values were extracted using `car inspect`
         writer
-            .write_header(&Header::new(false, 51, 654402, 654453))
+            .write_v2_header(&Header::new(false, 51, 654402, 654453))
             .await
             .unwrap();
 
         // We start writing the CARv1 here and keep the stream positions
         // so that we can properly index the blocks later
-        let start_car_v1 = {
-            let inner = writer.get_inner_mut();
-            inner.stream_position().await.unwrap()
-        };
+        let start_car_v1 = writer.stream_position().await.unwrap();
 
         writer
-            .write_v1_header(&crate::v1::Header::new(vec![nodes.last().unwrap().0]))
+            .write_header(&crate::v1::Header::new(vec![nodes.last().unwrap().0]))
             .await
             .unwrap();
 
         let mut offsets = vec![];
         for (cid, block) in &nodes {
             // write the blocks, saving their positions for the index
-            offsets.push({
-                let inner = writer.get_inner_mut();
-                inner.stream_position().await.unwrap() - start_car_v1
-            });
+            offsets.push(writer.stream_position().await.unwrap() - start_car_v1);
             writer.write_block(cid, block).await.unwrap();
         }
 
-        let inner = writer.get_inner_mut();
-        let written = inner.stream_position().await.unwrap();
+        let written = writer.stream_position().await.unwrap();
         assert_eq!(written, 654453);
 
         let mut mapping = BTreeMap::new();
@@ -302,13 +268,13 @@ mod tests {
         let index = crate::v2::index::Index::multihash(mapping);
         writer.write_index(&index).await.unwrap();
 
-        let mut buf_writer = writer.finish().await.unwrap();
-        buf_writer.rewind().await.unwrap();
+        writer.flush().await.unwrap();
+        writer.rewind().await.unwrap();
 
         let expected_header = tokio::fs::read("tests/fixtures/car_v2/spaceglenda.car")
             .await
             .unwrap();
 
-        assert_buffer_eq!(&expected_header, buf_writer.get_ref().get_ref());
+        assert_buffer_eq!(&expected_header, writer.get_ref().get_ref());
     }
 }

--- a/storage-provider/client/src/commands/proofs.rs
+++ b/storage-provider/client/src/commands/proofs.rs
@@ -1,7 +1,7 @@
 use std::{io::Write, path::PathBuf, str::FromStr};
 
 use codec::Encode;
-use mater::CarV2Reader;
+use mater::CarV2ReaderExt;
 use polka_storage_proofs::{
     match_post_proof, match_seal_proof,
     porep::{
@@ -149,8 +149,7 @@ impl ProofsCommand {
             ProofsCommand::CalculatePieceCommitment { input_path } => {
                 // Check if the file is a CARv2 file. If it is, we can't calculate the piece commitment.
                 let mut source_file = tokio::fs::File::open(&input_path).await?;
-                let mut car_v2_reader = CarV2Reader::new(&mut source_file);
-                car_v2_reader
+                source_file
                     .is_car_file()
                     .await
                     .map_err(|e| UtilsCommandError::InvalidCARv2(input_path.clone(), e))?;
@@ -260,8 +259,7 @@ impl ProofsCommand {
                 )?;
 
                 let mut source_file = tokio::fs::File::open(&input_path).await?;
-                let mut car_v2_reader = CarV2Reader::new(&mut source_file);
-                car_v2_reader
+                source_file
                     .is_car_file()
                     .await
                     .map_err(|e| UtilsCommandError::InvalidCARv2(input_path.clone(), e))?;

--- a/storage-provider/server/src/indexer/mod.rs
+++ b/storage-provider/server/src/indexer/mod.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, path::Path, sync::Arc};
 
 use local_index_directory::{IndexRecord, OffsetSize, Service};
-use mater::CarV2Reader;
+use mater::{CarV1Reader, CarV1ReaderExt, CarV2Reader};
 use polka_storage_provider_common::sector::ProvenSector;
 use primitives::commitment::{CommP, Commitment};
 use tokio::{fs::File, io::BufReader, sync::mpsc::UnboundedReceiver, task::spawn_blocking};
@@ -109,12 +109,11 @@ where
     P: AsRef<Path>,
 {
     let file = File::open(location).await?;
-    let reader = BufReader::new(file);
-    let mut reader = CarV2Reader::new(reader);
+    let mut reader = BufReader::new(file);
 
     reader.read_pragma().await?;
-    let header = reader.read_header().await?;
-    let _v1_header = reader.read_v1_header().await?;
+    let header = reader.read_v2_header().await?;
+    let _v1_header = reader.read_header().await?;
     let data_end = header.data_offset + header.data_size;
 
     let mut records = vec![];
@@ -146,7 +145,7 @@ pub mod tests {
         sync::Arc,
     };
 
-    use mater::CarV2Reader;
+    use mater::{CarV1Reader, CarV1ReaderExt, CarV2Reader};
     use primitives::commitment::{CommP, Commitment};
     use tempfile::tempdir;
     use tokio::{fs::File, io::BufReader};
@@ -195,12 +194,11 @@ pub mod tests {
 
         // Check indexed blocks
         let file = File::open(piece_path).await.unwrap();
-        let reader = BufReader::new(file);
-        let mut reader = CarV2Reader::new(reader);
+        let mut reader = BufReader::new(file);
 
         reader.read_pragma().await.unwrap();
-        let header = reader.read_header().await.unwrap();
-        let _v1_header = reader.read_v1_header().await.unwrap();
+        let header = reader.read_v2_header().await.unwrap();
+        let _v1_header = reader.read_header().await.unwrap();
         let data_end = header.data_offset + header.data_size;
 
         let mut records = vec![];

--- a/storage-provider/server/src/indexer/mod.rs
+++ b/storage-provider/server/src/indexer/mod.rs
@@ -113,7 +113,7 @@ where
 
     reader.read_pragma().await?;
     let header = reader.read_v2_header().await?;
-    let _v1_header = reader.read_header().await?;
+    let _v1_header = reader.read_v1_header().await?;
     let data_end = header.data_offset + header.data_size;
 
     let mut records = vec![];
@@ -198,7 +198,7 @@ pub mod tests {
 
         reader.read_pragma().await.unwrap();
         let header = reader.read_v2_header().await.unwrap();
-        let _v1_header = reader.read_header().await.unwrap();
+        let _v1_header = reader.read_v1_header().await.unwrap();
         let data_end = header.data_offset + header.data_size;
 
         let mut records = vec![];

--- a/storage-provider/server/src/retrieval/blockstore.rs
+++ b/storage-provider/server/src/retrieval/blockstore.rs
@@ -201,7 +201,7 @@ mod tests {
 
         reader.read_pragma().await.unwrap();
         let header = reader.read_v2_header().await.unwrap();
-        let _v1_header = reader.read_header().await.unwrap();
+        let _v1_header = reader.read_v1_header().await.unwrap();
         let data_end = header.data_offset + header.data_size;
 
         loop {

--- a/storage-provider/server/src/retrieval/blockstore.rs
+++ b/storage-provider/server/src/retrieval/blockstore.rs
@@ -134,7 +134,7 @@ mod tests {
 
     use blockstore::Blockstore;
     use cid::{multihash::Multihash, Cid};
-    use mater::{CarV2Reader, IDENTITY_CODE, RAW_CODE};
+    use mater::{CarV1Reader, CarV1ReaderExt, CarV2Reader, IDENTITY_CODE, RAW_CODE};
     use primitives::commitment::{CommP, Commitment};
     use tempfile::{tempdir, TempDir};
     use tokio::{fs::File, io::BufReader};
@@ -197,12 +197,11 @@ mod tests {
 
         // Check if blocks are provided by the blockstore
         let file = File::open(piece_path).await.unwrap();
-        let reader = BufReader::new(file);
-        let mut reader = CarV2Reader::new(reader);
+        let mut reader = BufReader::new(file);
 
         reader.read_pragma().await.unwrap();
-        let header = reader.read_header().await.unwrap();
-        let _v1_header = reader.read_v1_header().await.unwrap();
+        let header = reader.read_v2_header().await.unwrap();
+        let _v1_header = reader.read_header().await.unwrap();
         let data_end = header.data_offset + header.data_size;
 
         loop {


### PR DESCRIPTION
### Description

This is a "big" change with a simple core: replace the struct (which implemented a trait-like pattern) with (proper) traits.

This addresses a fundamental limitation of the crate that is: you either write *or* read.
One symptom of this was @cernicc (rightful) usage of "internal-er" free functions instead of using the reader/writer.
