### PR TITLE
feat(fetch): add support for multiple providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14094,6 +14094,7 @@ dependencies = [
  "libp2p-swarm 0.45.1",
  "mater",
  "multihash-codetable",
+ "rand",
  "thiserror 2.0.8",
  "tokio",
  "tracing",

--- a/storage-retrieval/cli/src/main.rs
+++ b/storage-retrieval/cli/src/main.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::{
 struct Cli {
     /// Provider used for data download
     #[arg(long)]
-    provider: Multiaddr,
+    provider: Vec<Multiaddr>,
 
     /// The output file to write to.
     #[arg(long)]
@@ -46,7 +46,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let arguments = Cli::parse();
 
     let settings = ClientSettings::new(arguments.output, arguments.extract, arguments.overwrite);
-    let client = Client::new(vec![arguments.provider], arguments.payload_cid, settings).await?;
+    let client = Client::new(arguments.provider, arguments.payload_cid, settings).await?;
 
     let download_result = match arguments.timeout {
         Some(duration) => timeout(duration, client.download()).await,

--- a/storage-retrieval/lib/Cargo.toml
+++ b/storage-retrieval/lib/Cargo.toml
@@ -28,5 +28,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 multihash-codetable = { workspace = true, features = ["sha2"] }
+rand = { workspace = true, default-features = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/storage-retrieval/lib/examples/chaos_server.rs
+++ b/storage-retrieval/lib/examples/chaos_server.rs
@@ -2,15 +2,77 @@
 //! blockstore. Because the server is simple it is used for manual testing of
 //! the retrieval client.
 
-use std::{env::args, sync::Arc};
+use std::{any::type_name, env::args, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
+use blockstore::Blockstore;
 use libp2p::Multiaddr;
 use mater::blockstore::ReadOnlyBlockstore;
 use polka_storage_retrieval::server::Server;
-use tokio::fs::File;
+use rand::prelude::*;
+use tokio::{
+    fs::File,
+    io::{AsyncRead, AsyncSeek},
+};
 
 const DEFAULT_PORT: u16 = 8989;
+
+/// Adds random delays on the `get` calls.
+struct ChaosReadOnlyStore<R>(ReadOnlyBlockstore<R>);
+
+impl<R> Blockstore for ChaosReadOnlyStore<R>
+where
+    R: AsyncRead + AsyncSeek + Unpin + blockstore::cond_send::CondSync,
+{
+    fn get<const S: usize>(
+        &self,
+        cid: &cid::CidGeneric<S>,
+    ) -> impl futures::Future<Output = blockstore::Result<Option<Vec<u8>>>>
+           + blockstore::cond_send::CondSend {
+        async {
+            if rand::thread_rng().gen_bool(0.5) {
+                let dur = Duration::from_millis(thread_rng().gen_range(250..=1000));
+                tracing::info!("sleeping for {}", dur.as_millis());
+                tokio::time::sleep(dur).await;
+            }
+            self.0.get(cid).await
+        }
+    }
+
+    fn put_keyed<const S: usize>(
+        &self,
+        _: &cid::CidGeneric<S>,
+        _: &[u8],
+    ) -> impl futures::Future<Output = blockstore::Result<()>> + blockstore::cond_send::CondSend
+    {
+        async {
+            Err(blockstore::Error::FatalDatabaseError(format!(
+                "{} is read-only",
+                type_name::<Self>()
+            )))
+        }
+    }
+
+    fn remove<const S: usize>(
+        &self,
+        _: &cid::CidGeneric<S>,
+    ) -> impl futures::Future<Output = blockstore::Result<()>> + blockstore::cond_send::CondSend
+    {
+        async {
+            Err(blockstore::Error::FatalDatabaseError(format!(
+                "{} is read-only",
+                type_name::<Self>()
+            )))
+        }
+    }
+
+    fn close(
+        self,
+    ) -> impl futures::Future<Output = blockstore::Result<()>> + blockstore::cond_send::CondSend
+    {
+        async { Ok(()) }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -35,7 +97,7 @@ async fn main() -> Result<()> {
     };
 
     // Example blockstore providing only a single file.
-    let blockstore = Arc::new((ReadOnlyBlockstore::new(file).await?));
+    let blockstore = Arc::new(ChaosReadOnlyStore(ReadOnlyBlockstore::new(file).await?));
 
     let roots = blockstore.write().await.roots().await?;
     tracing::info!("available roots: {:?}", roots);

--- a/storage-retrieval/lib/src/client.rs
+++ b/storage-retrieval/lib/src/client.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use beetswap::{Event, QueryId};
 use blockstore::Blockstore;
@@ -74,8 +78,8 @@ pub struct Client {
     blockstore: ReadWriteBlockstore<File>,
     /// Content roots being downloaded.
     root: Cid,
-
-    structure: HashMap<Cid, Cid>,
+    /// CAR block DAG mapping children to parents. (The A in DAG isn't checked!)
+    dag: HashMap<Cid, Cid>,
 }
 
 impl Client {
@@ -112,7 +116,7 @@ impl Client {
             queries: HashMap::new(),
             blockstore,
             root,
-            structure: HashMap::new(),
+            dag: HashMap::new(),
         })
     }
 
@@ -152,12 +156,11 @@ impl Client {
         let inner = self.blockstore.into_inner();
         let mut file = inner
             .finish_with_roots(
-                self.structure
+                self.dag
                     .values()
                     .copied()
-                    // We're expecting a single one, so this should be ok
-                    // if any issues arise, we can use an HashSet
-                    .filter(|cid| self.structure.contains_key(cid)),
+                    .filter(|cid| !self.dag.contains_key(cid))
+                    .collect::<HashSet<_>>(),
             )
             .await?;
 
@@ -251,7 +254,7 @@ impl Client {
 
                         node.links.iter().map(|link| link.cid).for_each(|l_cid| {
                             tracing::debug!("inserting {}: {}", l_cid, cid);
-                            self.structure.insert(l_cid, cid);
+                            self.dag.insert(l_cid, cid);
                             self.request_block(l_cid);
                         });
                     }


### PR DESCRIPTION
### Description

Adds support for multiple providers, I also added a "chaos" server example to fake network delays (and I definitely didn't snuck in a fix because I fucked up the graph retrieval).

Partially addresses #743 (it's not delia but now we should have an example)