### PR TITLE
fix(sp-server): cancel & stop tasks on failure

### DIFF
--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = { workspace = true }
 subxt = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { workspace = true, features = ["rt"] }
 toml = { workspace = true }
 tower = { workspace = true }

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -16,12 +16,13 @@ use std::{
 };
 
 use clap::Parser;
+use futures::FutureExt;
 use indexer::{
     local_index_directory::rdb::{RocksDBLid, RocksDBStateStoreConfig},
     start_indexer, IndexerMessage, IndexerState,
 };
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
-use p2p::{blockstore::PiecesBlockstore, start_p2p, P2pArgs, P2pError};
+use p2p::{blockstore::PiecesBlockstore, P2pArgs, P2pError};
 use pipeline::types::PipelineMessage;
 use polka_storage_proofs::{
     porep::{self, PoRepParameters},
@@ -41,7 +42,7 @@ use storagext::{
 use subxt::{self, tx::Signer};
 use tokio::{
     sync::{mpsc::UnboundedReceiver, Mutex, Semaphore},
-    task::JoinError,
+    task::{JoinError, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::level_filters::LevelFilter;
@@ -191,30 +192,6 @@ pub enum ServerError {
 
     #[error(transparent)]
     Lid(#[from] crate::indexer::local_index_directory::LidError),
-}
-
-/// Takes an expression that returns a `Result<Result<T, E2>, E1>`.
-/// It tries to inspect and log the first error (`E1`), otherwise,
-/// it inspects the result and tries to inspect the nested error (`E2`).
-///
-/// This macro is *roughly* equivalent to calling:
-/// ```text
-/// res // : Result<Result<T, E2>, E1>
-///     .inspect_err(|e| tracing::error!(%e))
-///     .inspect(|r| r.inspect_err(|e| tracing::error!(%e))
-/// ```
-macro_rules! inspect_and_log_nested_errors {
-    ($($task:expr),+ $(,)?) => {
-        (
-            $(
-                $task
-                    .inspect_err(|err| tracing::error!(%err))
-                    .inspect(|ok| {
-                        let _ = ok.as_ref().inspect_err(|err| tracing::error!(%err));
-                    })
-            ),+
-        )
-    };
 }
 
 /// The server arguments, as passed by the user, unvalidated.
@@ -390,63 +367,77 @@ impl Server {
 
         let cancellation_token = CancellationToken::new();
 
-        let p2p_task = start_p2p(p2p_args, cancellation_token.child_token())?;
-        let rpc_task = tokio::spawn(start_rpc_server(
-            rpc_state,
-            cancellation_token.child_token(),
-        ));
-        let storage_task = tokio::spawn(start_upload_server(
-            Arc::new(storage_state),
-            cancellation_token.child_token(),
-        ));
-        let pipeline_task = tokio::spawn(start_pipeline(
-            Arc::new(pipeline_state),
-            pipeline_rx,
-            cancellation_token.child_token(),
-        ));
-        let indexer_task = tokio::spawn(start_indexer(
-            indexer_state,
-            indexer_rx,
-            cancellation_token.child_token(),
-        ));
-
+        let mut tasks = JoinSet::new();
+        tasks.spawn(
+            start_rpc_server(rpc_state, cancellation_token.child_token())
+                .map(|result| ("RPC", result.map_err(ServerError::from))),
+        );
+        tasks.spawn(
+            p2p::Worker::new(p2p_args)?
+                .run(cancellation_token.child_token())
+                .map(|result| ("P2P", result.map_err(ServerError::from))),
+        );
+        tasks.spawn(
+            start_upload_server(Arc::new(storage_state), cancellation_token.child_token())
+                .map(|result| ("HTTP Storage", result.map_err(ServerError::from))),
+        );
+        tasks.spawn(
+            start_pipeline(
+                Arc::new(pipeline_state),
+                pipeline_rx,
+                cancellation_token.child_token(),
+            )
+            .map(|result| ("Pipeline", result.map_err(ServerError::from))),
+        );
+        tasks.spawn(
+            start_indexer(indexer_state, indexer_rx, cancellation_token.child_token())
+                .map(|result| ("Indexer", result.map_err(ServerError::from))),
+        );
         tracing::info!("Successfully launched all sub-services, ready for work!");
 
-        // Wait for SIGTERM on the main thread and once received "unblock"
-        tokio::signal::ctrl_c()
-            .await
-            .expect("failed to listen for event");
-        tracing::info!("SIGTERM received, shutting down...");
-
-        cancellation_token.cancel();
-        tracing::info!("sent shutdown signal");
-
-        // Wait for the tasks to finish
-        let (upload_result, rpc_task, pipeline_task, p2p_task, indexer_task) = tokio::join!(
-            storage_task,
-            rpc_task,
-            pipeline_task,
-            p2p_task,
-            indexer_task,
-        );
-
-        // Inspect and log errors
-        let (upload_result, rpc_task, pipeline_task, p2p_task, indexer_task) = inspect_and_log_nested_errors!(
-            upload_result,
-            rpc_task,
-            pipeline_task,
-            p2p_task,
-            indexer_task,
-        );
-
-        // Exit with error
-        upload_result??;
-        rpc_task??;
-        pipeline_task??;
-        p2p_task??;
-        indexer_task??;
-
-        Ok(())
+        // Keep the first error around as the "canonical return",
+        // since we can't return multiple values
+        let mut error = None;
+        loop {
+            tokio::select! {
+                result = tasks.join_next() => {
+                    match result {
+                        Some(Ok((task_name, task_result))) => {
+                            match task_result {
+                                Ok(()) => tracing::info!("{task_name} finished successfully!"),
+                                Err(err) => {
+                                    tracing::error!("{task_name} finished with error: {err}");
+                                    tracing::error!("Cancelling remaining tasks...");
+                                    if error.is_none() {
+                                        error = Some(err);
+                                    }
+                                    cancellation_token.cancel();
+                                },
+                            }
+                        }
+                        Some(Err(err)) => {
+                            tracing::error!("Failed to join task with error: {err}");
+                            cancellation_token.cancel();
+                        }
+                        None => {
+                            // This branch should run when all tasks have terminated,
+                            // thus, this is the most appropriate place to return the value
+                            match error {
+                                Some(err) => return Err(err),
+                                None => return Ok(()),
+                            }
+                        },
+                    }
+                }
+                result = tokio::signal::ctrl_c() => {
+                    match result {
+                        Ok(()) => tracing::info!("SIGTERM received, shutting down..."),
+                        Err(err) => tracing::error!("Failed to listen for SIGTERM with error: {err}"),
+                    }
+                    cancellation_token.cancel();
+                }
+            }
+        }
     }
 
     async fn setup(self) -> Result<SetupOutput, ServerError> {

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -2,6 +2,12 @@
 #![warn(unused_crate_dependencies)]
 #![deny(clippy::unwrap_used)]
 
+// Explicit gate because:
+// * We're not testing on non-Unix systems
+// * Signal handling is very explicitly Unix-only
+#[cfg(not(target_family = "unix"))]
+compile_error!("polka-storage-provider-server is only compatible with Unix systems");
+
 mod config;
 mod db;
 mod indexer;
@@ -41,6 +47,7 @@ use storagext::{
 };
 use subxt::{self, tx::Signer};
 use tokio::{
+    signal::unix::{signal, SignalKind},
     sync::{mpsc::UnboundedReceiver, Mutex, Semaphore},
     task::{JoinError, JoinSet},
 };
@@ -395,6 +402,13 @@ impl Server {
         );
         tracing::info!("Successfully launched all sub-services, ready for work!");
 
+        // Infos here:
+        // https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html
+        let mut sigint_listener =
+            signal(SignalKind::interrupt()).expect("should be able to listen for SIGINT");
+        let mut sigterm_listener =
+            signal(SignalKind::terminate()).expect("should be able to listen for SIGTERM");
+
         // Keep the first error around as the "canonical return",
         // since we can't return multiple values
         let mut error = None;
@@ -417,6 +431,9 @@ impl Server {
                         }
                         Some(Err(err)) => {
                             tracing::error!("Failed to join task with error: {err}");
+                            if error.is_none() {
+                                error = Some(ServerError::from(err));
+                            }
                             cancellation_token.cancel();
                         }
                         None => {
@@ -429,11 +446,12 @@ impl Server {
                         },
                     }
                 }
-                result = tokio::signal::ctrl_c() => {
-                    match result {
-                        Ok(()) => tracing::info!("SIGTERM received, shutting down..."),
-                        Err(err) => tracing::error!("Failed to listen for SIGTERM with error: {err}"),
-                    }
+                _ = sigint_listener.recv() => {
+                    tracing::info!("SIGINT received, shutting down...");
+                    cancellation_token.cancel();
+                }
+                _ = sigterm_listener.recv() => {
+                    tracing::info!("SIGTERM received, shutting down...");
                     cancellation_token.cancel();
                 }
             }

--- a/storage-provider/server/src/p2p/mod.rs
+++ b/storage-provider/server/src/p2p/mod.rs
@@ -11,9 +11,9 @@ use libp2p::{
 };
 use primitives::p2p::DEFAULT_REGISTRATION_TTL;
 use swarm::new_swarm;
-use tokio::{select, task::JoinHandle};
+use tokio::select;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 pub mod blockstore;
 mod error;
@@ -32,34 +32,6 @@ const P2P_NAMESPACE: &str = "polka-storage";
 
 /// The protocol version identifier string used by the identify protocol.
 const IDENTIFY_PROTOCOL_VERSION: &str = "polka-storage/1.0.0";
-
-/// Starts a new P2P networking service in a separate tokio task.
-pub fn start_p2p<B>(
-    args: P2pArgs<B>,
-    cancellation_token: CancellationToken,
-) -> Result<JoinHandle<Result<(), P2pError>>, P2pError>
-where
-    B: Blockstore + Send + 'static,
-{
-    // Initialize the p2p worker and move it to the different task
-    let worker = Worker::new(args)?;
-
-    Ok(tokio::spawn(async move {
-        tokio::select! {
-            _ = cancellation_token.cancelled() => {
-                info!("P2P worker received shutdown signal");
-            }
-            result = worker.run() => {
-                match result {
-                    Ok(_) => info!("P2P worker completed"),
-                    Err(err) => error!("P2P failed with error: {}", err),
-                }
-            }
-        }
-
-        Ok(())
-    }))
-}
 
 /// Arguments used to configure the [`P2p`].
 pub struct P2pArgs<B>
@@ -95,7 +67,7 @@ where
 /// 3. Exchange identity information
 /// 4. Register our presence with the rendezvous nodes (repeated periodically)
 /// 5. Handle incoming bitswap requests
-struct Worker<B>
+pub struct Worker<B>
 where
     B: Blockstore + 'static,
 {
@@ -140,7 +112,7 @@ where
         })
     }
 
-    async fn run(mut self) -> Result<(), P2pError> {
+    pub async fn run(mut self, cancellation_token: CancellationToken) -> Result<(), P2pError> {
         let mut register_interval = tokio::time::interval(REGISTRATION_TTL);
 
         loop {
@@ -161,6 +133,10 @@ where
                     request_registration(&mut self.swarm, &self.rendezvous_nodes);
                 }
                 event = self.swarm.select_next_some() => self.on_swarm_event(event),
+                _ = cancellation_token.cancelled() => {
+                    info!("P2P worker received shutdown signal");
+                    return Ok(());
+                }
             }
         }
     }

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -278,14 +278,14 @@ fn process(
 ) {
     match msg {
         PipelineMessage::AddPiece(msg) => {
-            tracker.add_piece(state.clone(), msg, token.clone());
+            tracker.add_piece(state.clone(), msg, token.child_token());
         }
         PipelineMessage::PreCommit(msg) => tracker.precommit(state.clone(), msg),
         PipelineMessage::ProveCommit(msg) => {
-            tracker.prove_commit(state.clone(), msg, token.clone())
+            tracker.prove_commit(state.clone(), msg, token.child_token())
         }
         PipelineMessage::SubmitWindowedPoStMessage(msg) => {
-            tracker.submit_windowed_post(state.clone(), msg, token.clone())
+            tracker.submit_windowed_post(state.clone(), msg, token.child_token())
         }
         PipelineMessage::SchedulePoSts => tracker.schedule_posts(state.clone()),
     }


### PR DESCRIPTION
### Description

Moves away from `join!` to `JoinSet` since the former blocks waiting for *all* tasks to complete, yet we (for now) should shutdown the server on error instead of limping with invalid tasks.

Notes: 
* The example that prompted this (binding to the same port) still "hangs" due to the pipeline having some tasks pending/running, so it takes a while to close everything down.
* I know the `.map(|result| ("RPC", result.map_err(ServerError::from))),` looks kind of weird but it was the way I found to distinguish tasks from each other — open to suggestions.
* I'm also not super pleased with the final error return, if anyone has ideas, please share.