### PR TITLE
fix(primitives-p2p): split off p2p module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13928,6 +13928,7 @@ dependencies = [
  "multihash-codetable",
  "polka-storage-provider-common",
  "primitives",
+ "primitives-p2p",
  "serde",
  "storagext",
  "thiserror 2.0.8",
@@ -13968,6 +13969,7 @@ dependencies = [
  "polkadot-cli",
  "polkadot-primitives 7.0.0",
  "primitives",
+ "primitives-p2p",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-cli",
@@ -14048,6 +14050,7 @@ dependencies = [
  "polka-storage-proofs",
  "polka-storage-provider-common",
  "primitives",
+ "primitives-p2p",
  "sc-cli",
  "serde",
  "serde_json",
@@ -14111,6 +14114,7 @@ dependencies = [
  "polka-storage-proofs",
  "polka-storage-provider-common",
  "primitives",
+ "primitives-p2p",
  "rand",
  "rocksdb",
  "sc-cli",
@@ -16211,7 +16215,6 @@ dependencies = [
  "ed25519-dalek",
  "filecoin-proofs",
  "hex",
- "libp2p 0.54.1",
  "parity-scale-codec",
  "rand",
  "scale-decode 0.14.0",
@@ -16226,6 +16229,17 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412)",
  "thiserror 2.0.8",
+]
+
+[[package]]
+name = "primitives-p2p"
+version = "0.1.0"
+dependencies = [
+ "cid 0.11.1",
+ "ed25519-dalek",
+ "hex",
+ "libp2p 0.54.1",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "pallets/storage-provider",
   "pallets/storage-provider/benchmarks",
   "primitives",
+  "primitives-p2p",
   "runtime",
   "storage-fetch",
   "storage-provider/client",
@@ -154,6 +155,7 @@ polka-storage-proofs = { path = "lib/polka-storage-proofs", default-features = f
 polka-storage-provider-common = { path = "storage-provider/common" }
 polka-storage-runtime = { path = "runtime" }
 primitives = { path = "primitives", default-features = false }
+primitives-p2p = { path = "primitives-p2p" }
 storagext = { path = "storagext/lib" }
 
 # FileCoin proofs

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,7 @@ libp2p-length-prefix-codec = { workspace = true }
 polka-storage-proofs = { workspace = true, features = ["substrate"] }
 polka-storage-runtime.workspace = true
 primitives = { workspace = true, features = ["serde", "std"] }
+primitives-p2p = { workspace = true, features = ["serde"] }
 
 async-trait = { workspace = true }
 cbor4ii = { workspace = true }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use libp2p::{identity::Keypair, Multiaddr};
-use primitives::p2p::{keypair_value_parser, validate_tcp_multiaddr, validate_ws_multiaddr};
+use primitives_p2p::{keypair_value_parser, validate_tcp_multiaddr, validate_ws_multiaddr};
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, clap::Subcommand)]

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -17,7 +17,7 @@ use libp2p::{
 };
 use libp2p_length_prefix_codec::LpCbor;
 use log::{debug, error, info, warn};
-use primitives::p2p::{
+use primitives_p2p::{
     PeerIdRequest, PeerInfo, PeerInfoResponse, BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL,
     DEFAULT_REGISTRATION_TTL, GOSSIP_TOPIC, IDENTIFY_PROTOCOL_VERSION,
 };

--- a/primitives-p2p/Cargo.toml
+++ b/primitives-p2p/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+name = "primitives-p2p"
+repository.workspace = true
+version = "0.1.0"
+
+[features]
+serde = ["dep:serde"]
+
+[dependencies]
+cid = { workspace = true, default-features = false, features = ["alloc"] }
+ed25519-dalek = { workspace = true, features = ["pem"] }
+hex = { workspace = true }
+libp2p = { workspace = true }
+
+# Optional dependencies
+serde = { workspace = true, optional = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/primitives-p2p/src/lib.rs
+++ b/primitives-p2p/src/lib.rs
@@ -1,19 +1,27 @@
+mod request_response;
+
 use std::{path::PathBuf, str::FromStr};
 
-use cid::Cid;
 use ed25519_dalek::{pkcs8::DecodePrivateKey, SigningKey};
-use libp2p::{identity::Keypair, Multiaddr, PeerId};
-use serde::{de, Deserialize, Serialize, Serializer};
+use libp2p::{identity::Keypair, Multiaddr};
+
+// These are exports and I don't want them mixed up with normal imports.
+#[rustfmt::skip]
+pub use request_response::{
+    bootstrap::{PeerIdRequest, PeerInfo, PeerInfoResponse, BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL},
+    storage_provider::{
+        PieceInfo, PieceInfoRequest, PieceInfoResponse, SP_REQUEST_RESPONSE_PROTOCOL,
+    },
+};
 
 pub const GOSSIP_TOPIC: &str = "registrar";
 pub const IDENTIFY_PROTOCOL_VERSION: &str = "polka-storage/1.0.0";
-pub const BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL: &str = "/polka-storage-bootstrap-req-resp/1.0.0";
-pub const SP_REQUEST_RESPONSE_PROTOCOL: &str = "/polka-storage-provider-req-resp/1.0.0";
 pub const DEFAULT_REGISTRATION_TTL: u64 = 86400;
 
 pub fn validate_tcp_multiaddr(s: &str) -> Result<Multiaddr, String> {
     const IP4_TCP: [&str; 2] = ["ip4", "tcp"];
     const IP6_TCP: [&str; 2] = ["ip6", "tcp"];
+
     let multiaddress = Multiaddr::from_str(s).map_err(|err| err.to_string())?;
     let protocols = multiaddress.protocol_stack().collect::<Vec<_>>();
     if protocols.is_empty() {
@@ -58,73 +66,4 @@ pub fn keypair_value_parser(src: &str) -> Result<Keypair, String> {
         SigningKey::try_from(hex_key.as_slice()).map_err(|e| e.to_string())?
     };
     Keypair::ed25519_from_bytes(key.to_bytes()).map_err(|e| e.to_string())
-}
-
-/// Struct holds peer information.
-/// - PeerId: Registered Peer ID.
-/// - multiaddrs: Vec of multiaddresses the peer has registered.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PeerInfo {
-    #[serde(serialize_with = "serialize_peer_id")]
-    #[serde(deserialize_with = "deserialize_peer_id")]
-    pub peer_id: PeerId,
-    pub multiaddrs: Vec<Multiaddr>,
-}
-
-/// This enum is used in the request response P2P protocol.
-/// PeerInfoResponse::NotFound is returned when the requested peer ID was not found.
-/// PeerInfoResponse::Found(..) is returned when the requested peer ID was found.
-/// The latter holds the relevant [`PeerInfo`] inside.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum PeerInfoResponse {
-    Found(PeerInfo),
-    NotFound(PeerIdRequest),
-}
-
-/// The request type used for the request response P2P protocol.
-/// We cannot use PeerId directly because it does not implement
-/// Serialize and Deserialize.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PeerIdRequest(
-    #[serde(serialize_with = "serialize_peer_id")]
-    #[serde(deserialize_with = "deserialize_peer_id")]
-    PeerId,
-);
-
-impl From<PeerId> for PeerIdRequest {
-    fn from(value: PeerId) -> Self {
-        Self(value)
-    }
-}
-
-impl Into<PeerId> for PeerIdRequest {
-    fn into(self) -> PeerId {
-        self.0
-    }
-}
-
-fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(d: D) -> Result<PeerId, D::Error> {
-    let s: String = de::Deserialize::deserialize(d)?;
-    PeerId::from_str(&s).map_err(de::Error::custom)
-}
-
-fn serialize_peer_id<S: Serializer>(id: &PeerId, serializer: S) -> Result<S::Ok, S::Error> {
-    let id = id.to_string();
-    serializer.collect_str(&id)
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PieceInfoRequest {
-    pub piece_cid: Cid,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum PieceInfoResponse {
-    Found(PieceInfo),
-    NotFound(Cid),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PieceInfo {
-    pub roots: Vec<Cid>,
 }

--- a/primitives-p2p/src/request_response/bootstrap.rs
+++ b/primitives-p2p/src/request_response/bootstrap.rs
@@ -1,0 +1,85 @@
+use libp2p::{Multiaddr, PeerId};
+
+pub const BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL: &str = "/polka-storage-bootstrap-req-resp/1.0.0";
+
+/// Struct holds peer information.
+/// - PeerId: Registered Peer ID.
+/// - multiaddrs: Vec of multiaddresses the peer has registered.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub struct PeerInfo {
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "serialize_peer_id",
+            deserialize_with = "deserialize_peer_id"
+        )
+    )]
+    pub peer_id: PeerId,
+    pub multiaddrs: Vec<Multiaddr>,
+}
+
+/// This enum is used in the request response P2P protocol.
+/// PeerInfoResponse::NotFound is returned when the requested peer ID was not found.
+/// PeerInfoResponse::Found(..) is returned when the requested peer ID was found.
+/// The latter holds the relevant [`PeerInfo`] inside.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub enum PeerInfoResponse {
+    Found(PeerInfo),
+    NotFound(PeerIdRequest),
+}
+
+/// The request type used for the request response P2P protocol.
+/// We cannot use PeerId directly because it does not implement
+/// Serialize and Deserialize.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub struct PeerIdRequest(
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "serialize_peer_id",
+            deserialize_with = "deserialize_peer_id"
+        )
+    )]
+    PeerId,
+);
+
+impl From<PeerId> for PeerIdRequest {
+    fn from(value: PeerId) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<PeerId> for PeerIdRequest {
+    fn into(self) -> PeerId {
+        self.0
+    }
+}
+
+#[cfg(feature = "serde")]
+use _serde::{deserialize_peer_id, serialize_peer_id};
+
+#[cfg(feature = "serde")]
+mod _serde {
+    use std::str::FromStr;
+
+    use libp2p::PeerId;
+    use serde::{de, Serializer};
+
+    pub(super) fn deserialize_peer_id<'de, D: de::Deserializer<'de>>(
+        d: D,
+    ) -> Result<PeerId, D::Error> {
+        let s: String = de::Deserialize::deserialize(d)?;
+        PeerId::from_str(&s).map_err(de::Error::custom)
+    }
+
+    pub(super) fn serialize_peer_id<S: Serializer>(
+        id: &PeerId,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let id = id.to_string();
+        serializer.collect_str(&id)
+    }
+}

--- a/primitives-p2p/src/request_response/mod.rs
+++ b/primitives-p2p/src/request_response/mod.rs
@@ -1,0 +1,2 @@
+pub mod bootstrap;
+pub mod storage_provider;

--- a/primitives-p2p/src/request_response/storage_provider.rs
+++ b/primitives-p2p/src/request_response/storage_provider.rs
@@ -1,0 +1,22 @@
+use cid::Cid;
+
+pub const SP_REQUEST_RESPONSE_PROTOCOL: &str = "/polka-storage-provider-req-resp/1.0.0";
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub struct PieceInfoRequest {
+    pub piece_cid: Cid,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub enum PieceInfoResponse {
+    Found(PieceInfo),
+    NotFound(Cid),
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+pub struct PieceInfo {
+    pub roots: Vec<Cid>,
+}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -14,7 +14,6 @@ codec = { workspace = true, features = ["derive"] }
 ed25519-dalek = { workspace = true, optional = true, features = ["pem"] }
 filecoin-proofs = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
-libp2p = { workspace = true, optional = true }
 scale-decode = { workspace = true, features = ["derive"] }
 scale-encode = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
@@ -47,7 +46,6 @@ std = [
   "dep:ed25519-dalek",
   "dep:filecoin-proofs",
   "dep:hex",
-  "dep:libp2p",
   "scale-info/std",
   "serde/std",
   "sha2/std",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -6,9 +6,6 @@ pub mod proofs;
 pub mod randomness;
 pub mod sector;
 
-#[cfg(feature = "std")]
-pub mod p2p;
-
 #[cfg(feature = "testing")]
 pub mod testing {
     // NOTE(@jmg-duarte,22/01/2025): Since there's only one thing, star import for now.

--- a/storage-fetch/Cargo.toml
+++ b/storage-fetch/Cargo.toml
@@ -25,6 +25,7 @@ mater = { workspace = true, features = ["blockstore"] }
 multihash-codetable = { workspace = true, features = ["sha2"] }
 polka-storage-provider-common = { workspace = true }
 primitives = { workspace = true }
+primitives-p2p = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 storagext = { workspace = true }
 thiserror = { workspace = true }

--- a/storage-fetch/src/p2p/resolvers.rs
+++ b/storage-fetch/src/p2p/resolvers.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use cid::Cid;
 use libp2p::{Multiaddr, PeerId};
-use primitives::p2p::{
+use primitives_p2p::{
     PeerIdRequest, PeerInfoResponse, PieceInfo, PieceInfoRequest, PieceInfoResponse,
     BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL, SP_REQUEST_RESPONSE_PROTOCOL,
 };

--- a/storage-provider/client/Cargo.toml
+++ b/storage-provider/client/Cargo.toml
@@ -37,6 +37,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 libp2p = { workspace = true, features = ["cbor", "macros", "noise", "request-response", "tcp", "tokio", "yamux"] }
+primitives-p2p = { workspace = true, features = ["serde"] }
 
 [lints]
 workspace = true

--- a/storage-provider/client/examples/peer-resolver.rs
+++ b/storage-provider/client/examples/peer-resolver.rs
@@ -16,7 +16,7 @@ use libp2p::{
     swarm::SwarmEvent,
     tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
-use primitives::p2p::{PeerIdRequest, PeerInfoResponse, BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL};
+use primitives_p2p::{PeerIdRequest, PeerInfoResponse, BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL};
 use tracing_subscriber::EnvFilter;
 
 /// Create a discovery swarm

--- a/storage-provider/client/src/main.rs
+++ b/storage-provider/client/src/main.rs
@@ -2,6 +2,10 @@
 #![warn(unused_crate_dependencies)]
 #![deny(clippy::unwrap_used)]
 
+// Rust thinks that primitives_p2p is unused even though it's in dev_dependencies & used in examples
+#[cfg(test)]
+use primitives_p2p as _;
+
 pub(crate) mod commands;
 mod rpc_client;
 

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -18,6 +18,7 @@ mater = { workspace = true }
 polka-storage-proofs = { workspace = true, default-features = false }
 polka-storage-provider-common = { workspace = true, features = ["clap"] }
 primitives = { workspace = true, features = ["clap", "serde", "std"] }
+primitives-p2p = { workspace = true, features = ["serde"] }
 storagext = { workspace = true, features = ["clap"] }
 
 async-trait = { workspace = true }

--- a/storage-provider/server/src/config.rs
+++ b/storage-provider/server/src/config.rs
@@ -8,10 +8,8 @@ use std::{
 use clap::Args;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use polka_storage_provider_common::config::sealing::SealingConfiguration;
-use primitives::{
-    p2p::{keypair_value_parser, validate_tcp_multiaddr, validate_ws_multiaddr},
-    proofs::{RegisteredPoStProof, RegisteredSealProof},
-};
+use primitives::proofs::{RegisteredPoStProof, RegisteredSealProof};
+use primitives_p2p::{keypair_value_parser, validate_tcp_multiaddr, validate_ws_multiaddr};
 use serde::{de::Error, Deserialize, Deserializer};
 use url::Url;
 

--- a/storage-provider/server/src/p2p/mod.rs
+++ b/storage-provider/server/src/p2p/mod.rs
@@ -11,7 +11,7 @@ use libp2p::{
     Multiaddr, PeerId, StreamProtocol, Swarm,
 };
 use libp2p_length_prefix_codec::LpCbor;
-use primitives::p2p::{
+use primitives_p2p::{
     PieceInfo, PieceInfoRequest, PieceInfoResponse, DEFAULT_REGISTRATION_TTL,
     IDENTIFY_PROTOCOL_VERSION, SP_REQUEST_RESPONSE_PROTOCOL,
 };


### PR DESCRIPTION
### Description

Splits off the `p2p` module as it makes it really hard (nigh impossible) to keep the `primitives` crate as `no-std`.

This also opens the door to simplify the protocol handling in the server and node by extracting some of the builders.