### PR TITLE
bump: beetswap 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "beetswap"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f2cf2244bd65e9f00adb06c6b5e951bab980fdacdd572ff035bf610628be99"
+checksum = "e4227c5fc06b7fd8a26daf3fa79861233116d0708ee7fae4c4109b7154298fbd"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "blockstore",
@@ -1403,7 +1403,6 @@ dependencies = [
  "time",
  "tracing",
  "unsigned-varint 0.8.0",
- "void",
  "web-time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.80"
 axum = "0.7.5"
 base64 = "0.22.1"
-beetswap = "0.4.0"
+beetswap = "0.4.1"
 bincode = "1.3.3"
 bitflags = "2.5.0"
 blake2b_simd = { version = "1.0.2", default-features = false }


### PR DESCRIPTION
### Description

Update beetswap dependency. The lastest version has a change we need, so that the content retrieval works from the browser.
