### PR TITLE
fix: fetch randomness from chain for batch verification

### DIFF
--- a/pallets/market/benchmarks/src/mock.rs
+++ b/pallets/market/benchmarks/src/mock.rs
@@ -176,6 +176,7 @@ impl pallet_storage_provider::Config for Test {
 }
 
 impl pallet_proofs::Config for Test {
+    type Randomness = DummyRandomnessGenerator<Self>;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
 }

--- a/pallets/proofs/Cargo.toml
+++ b/pallets/proofs/Cargo.toml
@@ -29,14 +29,14 @@ num-bigint = { workspace = true }
 pairing = { workspace = true }
 polka-storage-proofs = { workspace = true, features = ["substrate"] }
 primitives = { workspace = true, features = ["serde"] }
-rand = { workspace = true, features = ["alloc"] }
+rand = { workspace = true, default-features = false, features = ["alloc"] }
 rand_chacha = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 sha2 = { workspace = true }
+sp-core = { default-features = false, workspace = true }
 sp-runtime.workspace = true
 sp-std.workspace = true
 
-# Runtime benchmarks
 rand_xorshift = { workspace = true }
 
 [dev-dependencies]
@@ -49,7 +49,6 @@ fr32 = { workspace = true }
 generic-array = { workspace = true }
 hex = { workspace = true }
 rand_xorshift = { workspace = true }
-sp-core = { default-features = true, workspace = true }
 sp-io = { default-features = true, workspace = true }
 storage-proofs-core = { workspace = true }
 storage-proofs-porep = { workspace = true }

--- a/pallets/proofs/src/crypto/groth16.rs
+++ b/pallets/proofs/src/crypto/groth16.rs
@@ -8,6 +8,7 @@ use pairing::{group::Group, MillerLoopResult};
 pub use polka_storage_proofs::{Bls12, PrimeField, Proof, Scalar as Fr, VerifyingKey};
 use polka_storage_proofs::{Curve, MultiMillerLoop, PrimeCurveAffine};
 use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
 use scale_info::TypeInfo;
 
 use crate::Vec;
@@ -107,16 +108,12 @@ pub enum VerificationError {
     InvalidInput,
 }
 
-pub(crate) fn le_bytes_to_u64s(le_bytes: &[u8]) -> Vec<u64> {
-    assert_eq!(
-        le_bytes.len() % 8,
-        0,
-        "length must be divisible by u64 byte length (8-bytes)"
-    );
-    le_bytes
-        .chunks(8)
-        .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
-        .collect()
+fn seeded_rng(seed_bytes: &[u8; 32]) -> XorShiftRng {
+    let mut xored = [0u8; 16];
+    for i in 0..16 {
+        xored[i] = seed_bytes[i] ^ seed_bytes[i + 16];
+    }
+    XorShiftRng::from_seed(xored)
 }
 
 /// Verifies multiple proofs using randomized batch verification.
@@ -130,14 +127,13 @@ pub(crate) fn le_bytes_to_u64s(le_bytes: &[u8]) -> Vec<u64> {
 /// * https://github.com/filecoin-project/bellperson/blob/95fd3fc10e740547b53ce8e86a04c49509af6a41/src/groth16/verifier.rs#L109
 pub fn verify_proofs_batch<E>(
     pvk: &PreparedVerifyingKey<E>,
-    // rng: &mut R,
+    seed: &[u8; 32],
     proofs: &[Proof<E>],
     public_inputs: &[Vec<E::Fr>],
 ) -> Result<bool, VerificationError>
 where
     E: MultiMillerLoop,
     <E::Fr as PrimeField>::Repr: Sync + Copy,
-    // R: rand::RngCore,
 {
     debug_assert_eq!(proofs.len(), public_inputs.len());
 
@@ -161,31 +157,9 @@ where
     let mut rand_z: Vec<_> = Vec::with_capacity(proof_num);
     let mut accum_y = E::Fr::ZERO;
 
-    // TODO(@th7nder,#810, 18/03/2025): this is unsafe! randomness must be fetched from the chain.
-    use rand::Rng;
-    use rand_xorshift::XorShiftRng;
-    let rng = &mut XorShiftRng::from_seed([
-        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0xd, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
-        0xe5,
-    ]);
-
+    let mut rng = seeded_rng(seed);
     for _ in 0..proof_num {
-        let t: u128 = rng.gen();
-
-        let mut repr = E::Fr::ZERO.to_repr();
-        let mut repr_u64s = le_bytes_to_u64s(repr.as_ref());
-        assert!(repr_u64s.len() > 1);
-
-        repr_u64s[0] = (t & (-1i64 as u128) >> 64) as u64;
-        repr_u64s[1] = (t >> 64) as u64;
-
-        for (i, limb) in repr_u64s.iter().enumerate() {
-            let start = i * 8;
-            let stop = start + 8;
-            repr.as_mut()[start..stop].copy_from_slice(&limb.to_le_bytes());
-        }
-
-        let fr = E::Fr::from_repr(repr).unwrap();
+        let fr = E::Fr::random(&mut rng);
         let repr = fr.to_repr();
 
         accum_y.add_assign(&fr);

--- a/pallets/proofs/src/lib.rs
+++ b/pallets/proofs/src/lib.rs
@@ -29,7 +29,9 @@ pub mod pallet {
     pub const LOG_TARGET: &'static str = "runtime::proofs";
 
     use frame_support::{
-        pallet_prelude::*, sp_runtime::BoundedBTreeMap, traits::BuildGenesisConfig,
+        pallet_prelude::*,
+        sp_runtime::BoundedBTreeMap,
+        traits::{BuildGenesisConfig, Randomness},
     };
     use frame_system::pallet_prelude::*;
     use polka_storage_proofs::{VerifyingKey, POREP_VERIFYINGKEY_MAX_BYTES};
@@ -50,6 +52,8 @@ pub mod pallet {
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
+        /// Randomness generator
+        type Randomness: Randomness<Self::Hash, BlockNumberFor<Self>>;
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         type WeightInfo: WeightInfo;
     }
@@ -120,6 +124,7 @@ pub mod pallet {
         InvalidVerifyingKey,
         /// Returned in case of failed conversion, i.e. in `bytes_into_fr()`.
         Conversion,
+        MissingRandomness,
     }
 
     #[pallet::call]
@@ -208,6 +213,7 @@ pub mod pallet {
 
                 parsed_proofs.try_push(proof).expect("internal (porep::ProofScheme) and external (ProofVerification) apis have the same limits on number of proofs");
             }
+            let (randomness, _) = T::Randomness::random(&comm_r);
             let proof_scheme = porep::ProofScheme::setup(seal_proof);
 
             let vkey = PoRepVerifyingKeys::<T>::get(seal_proof)
@@ -220,6 +226,10 @@ pub mod pallet {
                 sector,
                 &ticket,
                 &seed,
+                &randomness
+                    .as_ref()
+                    .try_into()
+                    .expect("pallet system hash to be configured with 32 bytes"),
                 vkey,
                 parsed_proofs,
             );
@@ -268,8 +278,20 @@ pub mod pallet {
             let vkey = PoStVerifyingKeys::<T>::get(post_type)
                 .ok_or(Error::<T>::MissingPoStVerifyingKey)?;
 
+            // As personalization parameter we use randomness used for the given partition.
+            let (groth_randomness, _) = T::Randomness::random(&randomness);
+
             log::info!(target: LOG_TARGET, "Verifying {} PoSt proofs for replicas {}...", parsed_proofs.len(), replicas.len());
-            let result = proof_scheme.verify(randomness, replicas.clone(), vkey, parsed_proofs);
+            let result = proof_scheme.verify(
+                randomness,
+                replicas.clone(),
+                groth_randomness
+                    .as_ref()
+                    .try_into()
+                    .expect("pallet system hash to be configured with 32 bytes"),
+                vkey,
+                parsed_proofs,
+            );
             log::info!(target: LOG_TARGET, "Verified PoSt proofs for replicas {}.", replicas.len());
 
             result.map_err(|e| {

--- a/pallets/proofs/src/mock.rs
+++ b/pallets/proofs/src/mock.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fs};
 use bls12_381::Bls12;
 use codec::Decode;
 use frame_support::derive_impl;
-use frame_system::mocking::MockBlock;
+use frame_system::{mocking::MockBlock, pallet_prelude::BlockNumberFor};
 use polka_storage_proofs::VerifyingKey;
 use sp_runtime::BuildStorage;
 
@@ -37,6 +37,7 @@ impl frame_system::Config for Test {
 }
 
 impl crate::Config for Test {
+    type Randomness = DummyRandomnessGenerator<Self>;
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
 }
@@ -63,4 +64,22 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 fn load_key(path: &'static str) -> VerifyingKey<Bls12> {
     let vkey_bytes = fs::read(path).expect("key file at the location to be available");
     Decode::decode(&mut vkey_bytes.as_slice()).unwrap()
+}
+
+/// Randomness generator used by tests.
+pub struct DummyRandomnessGenerator<C>(core::marker::PhantomData<C>)
+where
+    C: frame_system::Config;
+
+impl<C> frame_support::traits::Randomness<C::Hash, BlockNumberFor<C>>
+    for DummyRandomnessGenerator<C>
+where
+    C: frame_system::Config,
+{
+    fn random(_subject: &[u8]) -> (C::Hash, BlockNumberFor<C>) {
+        (
+            Default::default(),
+            <frame_system::Pallet<C>>::block_number(),
+        )
+    }
 }

--- a/pallets/proofs/src/porep/mod.rs
+++ b/pallets/proofs/src/porep/mod.rs
@@ -154,6 +154,7 @@ impl ProofScheme {
         sector: SectorNumber,
         ticket: &Ticket,
         seed: &Ticket,
+        groth_randomness: &Ticket,
         vk: VerifyingKey<Bls12>,
         proofs: BoundedVec<Proof<Bls12>, ConstU32<MAX_PROOFS_PER_BLOCK>>,
     ) -> Result<(), ProofError> {
@@ -186,7 +187,7 @@ impl ProofScheme {
             agg_inputs.push(inputs);
         }
 
-        if verify_proofs_batch(&pvk, &proofs[..], agg_inputs.as_slice())? {
+        if verify_proofs_batch(&pvk, groth_randomness, &proofs[..], agg_inputs.as_slice())? {
             Ok(())
         } else {
             Err(ProofError::InvalidProof)

--- a/pallets/proofs/src/post/mod.rs
+++ b/pallets/proofs/src/post/mod.rs
@@ -48,6 +48,7 @@ impl ProofScheme {
             PublicReplicaInfo,
             ConstU32<MAX_REPLICAS_PER_BLOCK>,
         >,
+        groth_randomness: Ticket,
         vk: VerifyingKey<Bls12>,
         proofs: BoundedVec<Proof<Bls12>, ConstU32<MAX_PROOFS_PER_BLOCK>>,
     ) -> Result<(), ProofError> {
@@ -94,7 +95,7 @@ impl ProofScheme {
         }
 
         log::debug!(target: LOG_TARGET, "generated public inputs, verifying...");
-        if verify_proofs_batch(&pvk, &proofs[..], agg_inputs.as_slice())? {
+        if verify_proofs_batch(&pvk, &groth_randomness, &proofs[..], agg_inputs.as_slice())? {
             Ok(())
         } else {
             Err(ProofError::InvalidProof)

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -476,6 +476,12 @@ impl pallet_market::Config for Runtime {
 }
 
 impl pallet_proofs::Config for Runtime {
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type Randomness = crate::Randomness;
+
+    #[cfg(feature = "runtime-benchmarks")]
+    type Randomness = dummy::DummyRandomnessGenerator<Self>;
+
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = pallet_proofs::weights::Weights<Runtime>;
 }


### PR DESCRIPTION
### Description

Now the randomness if fetch via the randomness pallet and used to seed the rng to generate random numbers for Groth16 batch verification.

Closes #810.

### Checklist

- [X] Make sure that you described what this change does.
- [X] Have you tested this solution?