### PR TITLE
fix: set mainnet values for 1GiB sectors

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -327,8 +327,8 @@ parameter_types! {
 
     // Fault declaration/recovery functionality has been postponed, this won't make a difference until #592 is done.
     pub const FaultMaxAge: BlockNumber = 1 * DAYS;
-    /// WPoStChallengeLookBack + a tiny margin.
-    pub const FaultDeclarationCutoff: BlockNumber = WPoStChallengeLookBack + (1 * MINUTES);
+    pub const FaultDeclarationCutoffSlack: BlockNumber = 1 * MINUTES;
+    pub const FaultDeclarationCutoff: BlockNumber = WPoStChallengeLookBack + FaultDeclarationCutoffSlack;
     // <https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/runtime/src/runtime/policy.rs#L299>
     pub const AddressedSectorsMax: u64 = 25_000;
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -322,7 +322,8 @@ parameter_types! {
     // The chain can verify 1 proof per block (of 25 sectors per partitions) currently.
     // It means deadline time (blocks) == max theoretical number of the partitions per deadline.
     // There is no global limit, so currently 1 Storage Provider could overload the entire chain.
-    pub const MaxPartitionsPerDeadline: u64 = WpostChallengeWindow;
+    // 1 deadline = 30 minutes, 30 * 10 blocks = 300.
+    pub const MaxPartitionsPerDeadline: u64 = 300;
 
     // Fault declaration/recovery functionality has been postponed, this won't make a difference until #592 is done.
     pub const FaultMaxAge: BlockNumber = 1 * DAYS;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -309,32 +309,34 @@ impl pallet_collator_selection::Config for Runtime {
 parameter_types! {
     // Storage Provider Pallet
     pub const WpostProvingPeriod: BlockNumber = DAYS;
-    // Half an hour (=48 per day)
-    // 30 * 60 = 30 minutes
-    // SLOT_DURATION is in milliseconds thats why we / 1000
-    pub const WpostChallengeWindow: BlockNumber = 30 * 60 / (SLOT_DURATION as BlockNumber / 1000);
-    pub const WPoStChallengeLookBack: BlockNumber = 10 * MINUTES;
-    pub const MinSectorExpiration: BlockNumber = 180 * DAYS;
-    pub const MaxSectorExpiration: BlockNumber = 1278 * DAYS;
-    pub const SectorMaximumLifetime: BlockNumber = (365 * DAYS) * 5; // 5 years
-    pub const MaxProveCommitDuration: BlockNumber =  (30 * DAYS) + 150;
+    // There are 48 deadlines in a day, so a deadline is 30 minutes.
     pub const WPoStPeriodDeadlines: u64 = 48;
-    pub const MaxPartitionsPerDeadline: u64 = 3000;
-    pub const DeclarationsMax: u64 = 3000;
-    pub const FaultMaxAge: BlockNumber = DAYS * 42;
-    /// Copied from FileCoin and adapted to substrate block time. WPoStChallengeLookBack + 125 blocks
-    /// <https://github.com/filecoin-project/builtin-actors/blob/6906288334746318385cfd53edd7ea33ef03919f/runtime/src/runtime/policy.rs#L327>
-    pub const FaultDeclarationCutoff: BlockNumber = (10 * MINUTES) + 125;
-    /// <https://github.com/filecoin-project/builtin-actors/blob/a45fb87910bca74d62215b0d58ed90cf78b6c8ff/runtime/src/runtime/policy.rs#L306>
-    pub const PreCommitChallengeDelay: BlockNumber = 75 * MINUTES;
+    pub const WpostChallengeWindow: BlockNumber = 30 * MINUTES;
+    // PoSt for a single partition is ~20sec, it's a huge margin to start generating the proofs before deadline starts.
+    pub const WPoStChallengeLookBack: BlockNumber = 10 * MINUTES; 
+
+    // Finality in polkadot is 12-60 seconds, gives us a finalized randomness to base the challenge on.
+    pub const PreCommitChallengeDelay: BlockNumber = 1 * MINUTES;
+    // With 1GiB sector size and max security params it takes ~22 minutes to create a replica and zk-SNARK on top of it.
+    pub const MaxProveCommitDuration: BlockNumber =  30 * MINUTES;
+    // The chain can verify 1 proof per block (of 25 sectors per partitions) currently.
+    // It means deadline time (blocks) == max theoretical number of the partitions per deadline.
+    // There is no global limit, so currently 1 Storage Provider could overload the entire chain.
+    pub const MaxPartitionsPerDeadline: u64 = WpostChallengeWindow;
+
+    // Fault declaration/recovery functionality has been postponed, this won't make a difference until #592 is done.
+    pub const FaultMaxAge: BlockNumber = 1 * DAYS;
+    /// WPoStChallengeLookBack + a tiny margin.
+    pub const FaultDeclarationCutoff: BlockNumber = (10 * MINUTES) + (1 * MINUTES);
     // <https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/runtime/src/runtime/policy.rs#L299>
     pub const AddressedSectorsMax: u64 = 25_000;
 
+    pub const MinSectorExpiration: BlockNumber = 1 * DAYS;
+    pub const MaxSectorExpiration: BlockNumber = 365 * DAYS;
+    pub const SectorMaximumLifetime: BlockNumber = 365 * DAYS;
     // Market Pallet
-    /// Deal duration values copied from FileCoin.
-    /// <https://github.com/filecoin-project/builtin-actors/blob/c32c97229931636e3097d92cf4c43ac36a7b4b47/actors/market/src/policy.rs#L28>
-    pub const MinDealDuration: u64 = 20 * DAYS;
-    pub const MaxDealDuration: u64 = 1278 * DAYS;
+    pub const MinDealDuration: u64 = 1 * DAYS;
+    pub const MaxDealDuration: u64 = 365 * DAYS;
 
 }
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -308,10 +308,10 @@ impl pallet_collator_selection::Config for Runtime {
 #[cfg(not(feature = "testnet"))]
 parameter_types! {
     // Storage Provider Pallet
-    pub const WpostProvingPeriod: BlockNumber = DAYS;
+    pub const WPoStProvingPeriod: BlockNumber = DAYS;
     // There are 48 deadlines in a day, so a deadline is 30 minutes.
     pub const WPoStPeriodDeadlines: u64 = 48;
-    pub const WpostChallengeWindow: BlockNumber = 30 * MINUTES;
+    pub const WPoStChallengeWindow: BlockNumber = 30 * MINUTES;
     // PoSt for a single partition is ~20sec, it's a huge margin to start generating the proofs before deadline starts.
     pub const WPoStChallengeLookBack: BlockNumber = 10 * MINUTES;
 
@@ -328,12 +328,13 @@ parameter_types! {
     // Fault declaration/recovery functionality has been postponed, this won't make a difference until #592 is done.
     pub const FaultMaxAge: BlockNumber = 1 * DAYS;
     /// WPoStChallengeLookBack + a tiny margin.
-    pub const FaultDeclarationCutoff: BlockNumber = (10 * MINUTES) + (1 * MINUTES);
+    pub const FaultDeclarationCutoff: BlockNumber = WPoStChallengeLookBack + (1 * MINUTES);
     // <https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/runtime/src/runtime/policy.rs#L299>
     pub const AddressedSectorsMax: u64 = 25_000;
 
     pub const MinSectorExpiration: BlockNumber = 1 * DAYS;
-    pub const MaxSectorExpiration: BlockNumber = 365 * DAYS;
+    pub const MaxSectorExpirationSlack: BlockNumber = 30 * DAYS;
+    pub const MaxSectorExpiration: BlockNumber = 365 * DAYS + MaxSectorExpirationSlack;
     pub const SectorMaximumLifetime: BlockNumber = 365 * DAYS;
     // Market Pallet
     pub const MinDealDuration: u64 = 1 * DAYS;
@@ -344,9 +345,9 @@ parameter_types! {
 #[cfg(feature = "testnet")]
 parameter_types! {
     // Storage Provider Pallet
-    pub const WpostProvingPeriod: BlockNumber = 6 * MINUTES;
+    pub const WPoStProvingPeriod: BlockNumber = 6 * MINUTES;
     pub const WPoStPeriodDeadlines: u64 = 3;
-    pub const WpostChallengeWindow: BlockNumber = 2 * MINUTES;
+    pub const WPoStChallengeWindow: BlockNumber = 2 * MINUTES;
     pub const WPoStChallengeLookBack: BlockNumber = MINUTES;
     pub const MinSectorExpiration: BlockNumber = 5 * MINUTES;
     pub const MaxSectorExpiration: BlockNumber = 60 * MINUTES;
@@ -439,8 +440,8 @@ impl pallet_storage_provider::Config for Runtime {
     #[cfg(feature = "runtime-benchmarks")]
     type ProofVerification = primitives::testing::DummyProofsVerification;
 
-    type WPoStProvingPeriod = WpostProvingPeriod;
-    type WPoStChallengeWindow = WpostChallengeWindow;
+    type WPoStProvingPeriod = WPoStProvingPeriod;
+    type WPoStChallengeWindow = WPoStChallengeWindow;
     type WPoStChallengeLookBack = WPoStChallengeLookBack;
     type MinSectorExpiration = MinSectorExpiration;
     type MaxSectorExpiration = MaxSectorExpiration;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -313,7 +313,7 @@ parameter_types! {
     pub const WPoStPeriodDeadlines: u64 = 48;
     pub const WpostChallengeWindow: BlockNumber = 30 * MINUTES;
     // PoSt for a single partition is ~20sec, it's a huge margin to start generating the proofs before deadline starts.
-    pub const WPoStChallengeLookBack: BlockNumber = 10 * MINUTES; 
+    pub const WPoStChallengeLookBack: BlockNumber = 10 * MINUTES;
 
     // Finality in polkadot is 12-60 seconds, gives us a finalized randomness to base the challenge on.
     pub const PreCommitChallengeDelay: BlockNumber = 1 * MINUTES;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -328,13 +328,14 @@ parameter_types! {
     // Fault declaration/recovery functionality has been postponed, this won't make a difference until #592 is done.
     pub const FaultMaxAge: BlockNumber = 1 * DAYS;
     pub const FaultDeclarationCutoffSlack: BlockNumber = 1 * MINUTES;
-    pub const FaultDeclarationCutoff: BlockNumber = WPoStChallengeLookBack + FaultDeclarationCutoffSlack;
+    // WPoStChallengeLookBack + a bit of slack.
+    pub const FaultDeclarationCutoff: BlockNumber = (10 * MINUTES) + (1 * MINUTES);
     // <https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/runtime/src/runtime/policy.rs#L299>
     pub const AddressedSectorsMax: u64 = 25_000;
 
     pub const MinSectorExpiration: BlockNumber = 1 * DAYS;
-    pub const MaxSectorExpirationSlack: BlockNumber = 30 * DAYS;
-    pub const MaxSectorExpiration: BlockNumber = 365 * DAYS + MaxSectorExpirationSlack;
+    // MinDealDuration + a bit of slack.
+    pub const MaxSectorExpiration: BlockNumber = 365 * DAYS + 30 * DAYS;
     pub const SectorMaximumLifetime: BlockNumber = 365 * DAYS;
     // Market Pallet
     pub const MinDealDuration: u64 = 1 * DAYS;


### PR DESCRIPTION
### Description

It sets expected values for the 'testnet' launch in P3.
Some of those are just my guesses, feel free to challenge them.

Closes #755.
