### PR TITLE
docs(book): book auto formatting & update cli commands docs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,5 +10,7 @@
         "ryanluker.vscode-coverage-gutters",
         // direnv, to use tool binaries from `nix` profile and set environment variables automatically
         "mkhl.direnv",
+        // Used for markdown formating
+        "esbenp.prettier-vscode"
     ]
 }

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -15,6 +15,9 @@
   // Rust-analyzer doesn't need to build the wasm binary
   "rust-analyzer.cargo.extraEnv": {
     "SKIP_WASM_BUILD": "true"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
   // Recommended when developing benchmarks
   /*

--- a/docs/src/architecture/index.md
+++ b/docs/src/architecture/index.md
@@ -22,7 +22,7 @@ We do provide an implementation of the storage provider, you can read more about
 
 ![](../images/architecture/pallets_overview.png)
 
-We've been focusing on implementing the core functionality by developing the market, storage provider, proofs and randomness pallets.
+We've been focusing on implementing the core functionality by developing the market, storage provider, proofs, randomness and faucet pallets.
 
 The market pallet handles all things related to deal payments and slashing,
 being informed by the storage provider when deals haven't been proven and applying slashing in those cases.
@@ -35,11 +35,12 @@ For a deeper dive on the pallets, you can read the [Pallets chapter](./pallets/i
 ## Resources on Parachains
 
 Reading:
-* [Parachains' Protocol Overview](https://wiki.polkadot.network/docs/learn-parachains-protocol)
-* [The Path of a Parachain Block](https://polkadot.com/blog/the-path-of-a-parachain-block)
+
+- [Parachains' Protocol Overview](https://wiki.polkadot.network/docs/learn-parachains-protocol)
+- [The Path of a Parachain Block](https://polkadot.com/blog/the-path-of-a-parachain-block)
 
 Videos:
-* [Introduction to Polkadot, Parachains, and Substrate](https://www.youtube.com/live/gT-9r1bcVHY?si=dmCJyWB5w2NY1bnu&t=1670)
-* [The Path of a Parachain Block - Joe Petrowski](https://www.youtube.com/watch?v=vRsBlVELQEo)
-* [The Path of a Parachain Block on Polkadot and Kusama Network](https://www.youtube.com/watch?v=m0vxqWwFfDs)
 
+- [Introduction to Polkadot, Parachains, and Substrate](https://www.youtube.com/live/gT-9r1bcVHY?si=dmCJyWB5w2NY1bnu&t=1670)
+- [The Path of a Parachain Block - Joe Petrowski](https://www.youtube.com/watch?v=vRsBlVELQEo)
+- [The Path of a Parachain Block on Polkadot and Kusama Network](https://www.youtube.com/watch?v=m0vxqWwFfDs)

--- a/docs/src/architecture/pallets/index.md
+++ b/docs/src/architecture/pallets/index.md
@@ -4,6 +4,7 @@
 - [`market`](market.md) - A pallet that handles the storage market operations.
 - [`proofs`](proofs.md) - A pallet responsible for verifying [PoRep](../../glossary.md#porep) and [PoSt](../../glossary.md#post).
 - [`randomness`](randomness.md) - A pallet providing randomness source for blocks, mainly used by Proofs.
+- [`faucet`](faucet.md) - A pallet that provides a means to distribute tokens for testing purposes.
 
 ## Overview
 
@@ -51,5 +52,3 @@ Finally, storage providers can then settle deal payments to receive their fair s
 Putting it all together, we get the following:
 
 <img id="figure-overview" src="../../images/overview_flow.svg" alt="The described flow">
-
-

--- a/docs/src/architecture/pallets/storage-provider-extra.md
+++ b/docs/src/architecture/pallets/storage-provider-extra.md
@@ -47,13 +47,11 @@ Sealing a sector using Proof-of-Replication (PoRep) is a computation-intensive p
 - **Run a SNARK on the Proof**: Compress the proof using a Succinct Non-interactive Argument of Knowledge (SNARK).
 - **Submit the Compressed Proof:** Submit the result of the compression to the blockchain as certification of the storage commitment.
 
-
 ## Usage
 
 ### Modifying storage provider information
 
 The `Storage Provider Pallet` allows storage providers to modify their information such as changing the peer id, through `change_peer_id` and changing owners, through `change_owner_address`.
-
 
 ## Storage Provider Flow
 

--- a/docs/src/architecture/polka-storage-provider-server.md
+++ b/docs/src/architecture/polka-storage-provider-server.md
@@ -96,7 +96,7 @@ To achieve that, the pipeline is composed of 3 main stages.
 
 ### Add Piece
 
-The Add Piece stage gathers pieces into unsealed sectors, preparing them for the next steps.
+The Add Piece stage gathers pieces into unsealed sectors, preparing them for the next steps. The pipeline uses a configured fill threshold (default 95%) to determine when a sector is ready for sealing, or will seal after a configured delay even if not completely filled.
 
 While the system can theoretically support multiple sector sizes (2KiB, 8MiB, 512MiB and 1GiB), only the 1GiB sector size is considered safe for production use. Other sector sizes should be considered experimental and are not recommended for production deployments.
 

--- a/docs/src/architecture/polka-storage-provider-server.md
+++ b/docs/src/architecture/polka-storage-provider-server.md
@@ -96,7 +96,7 @@ To achieve that, the pipeline is composed of 3 main stages.
 
 ### Add Piece
 
-The Add Piece stage gathers pieces into unsealed sectors, preparing them for the next steps. The pipeline uses a configured fill threshold (default 95%) to determine when a sector is ready for sealing, or will seal after a configured delay even if not completely filled.
+The Add Piece stage gathers pieces into unsealed sectors, preparing them for the next steps. The pipeline uses a configured fill threshold (default 95%) to determine when a sector is ready for sealing, or will seal after a configured delay even if not completely filled. The time-based sealing is necessary to ensure data availability even during periods of low network activity, preventing pieces from remaining in an unsealed state indefinitely while waiting for the sector to reach optimal capacity.
 
 While the system can theoretically support multiple sector sizes (2KiB, 8MiB, 512MiB and 1GiB), only the 1GiB sector size is considered safe for production use. Other sector sizes should be considered experimental and are not recommended for production deployments.
 

--- a/docs/src/architecture/polka-storage-provider-server.md
+++ b/docs/src/architecture/polka-storage-provider-server.md
@@ -96,7 +96,7 @@ To achieve that, the pipeline is composed of 3 main stages.
 
 ### Add Piece
 
-The Add Piece stage gathers pieces into unsealed sectors, preparing them for the next steps. The pipeline uses a configured fill threshold (default 95%) to determine when a sector is ready for sealing, or will seal after a configured delay even if not completely filled. The time-based sealing is necessary to ensure data availability even during periods of low network activity, preventing pieces from remaining in an unsealed state indefinitely while waiting for the sector to reach optimal capacity.
+The Add Piece stage gathers pieces into unsealed sectors, preparing them for the next steps. The pipeline uses a configured fill threshold (default 95%) to determine when a sector is ready for sealing, or will seal after a configured delay even if not completely filled. The time-based sealing is important because once a storage deal is published, the storage provider has made a formal commitment to store that data. If the storage provider fails to complete the sealing process and prove storage after this commitment, they risk being slashed (penalized).
 
 While the system can theoretically support multiple sector sizes (2KiB, 8MiB, 512MiB and 1GiB), only the 1GiB sector size is considered safe for production use. Other sector sizes should be considered experimental and are not recommended for production deployments.
 

--- a/docs/src/getting-started/building/index.md
+++ b/docs/src/getting-started/building/index.md
@@ -7,20 +7,19 @@ Quick reminder that Windows is not part of the supported operating systems.
 As such, the following guides <b>have not been tested</b> on Windows.
 </div>
 
-
 We'll be building 5 artifacts:
 
-* `polka-storage-node` — the Polka Storage Polkadot parachain node.
-* `polka-storage-provider-server` — the Polka Storage Storage Provider,
+- `polka-storage-node` — the Polka Storage Polkadot parachain node.
+- `polka-storage-provider-server` — the Polka Storage Storage Provider,
   responsible for accepting deals, storing files and executing storage proofs.
-* `polka-storage-provider-client` — the Polka Storage Storage Provider client,
+- `polka-storage-provider-client` — the Polka Storage Storage Provider client,
   this CLI tool has several utilities to interact with the Storage Provider server,
   such as proposing and publishing deals, as well as some wallet utilities and proof demos.
-* `mater-cli` — the Mater CLI enables you to convert files into CARv2 archives,
+- `mater-cli` — the Mater CLI enables you to convert files into CARv2 archives,
   an essential part of preparing files for submission to the network.
-* `storagext-cli` — the Storagext CLI is a lower-level tool to manually run the Polka Storage extrinsics.
+- `storagext-cli` — the Storagext CLI is a lower-level tool to manually run the Polka Storage extrinsics.
 
 To build these artifacts, we provide two main methods:
 
-* [Building from source](./source.md)
-* [Building with Docker](./docker.md)
+- [Building from source](./source.md)
+- [Building with Docker](./docker.md)

--- a/docs/src/getting-started/building/source.md
+++ b/docs/src/getting-started/building/source.md
@@ -3,11 +3,11 @@
 This guide will outline how to setup your environment to build the Polka Storage parachain,
 we cover how to build the binaries directly on your system or using [Nix](https://nixos.org/download/) to ease the process.
 
-* [Get the code](#get-the-code)
-* [System dependencies](#system-dependencies)
-* [Using Nix](#using-nix)
-  * [Pre-requisites](#pre-requisites)
-* [Building](#building)
+- [Get the code](#get-the-code)
+- [System dependencies](#system-dependencies)
+- [Using Nix](#using-nix)
+  - [Pre-requisites](#pre-requisites)
+- [Building](#building)
 
 ## Get the code
 
@@ -22,9 +22,9 @@ cd polka-storage
 
 To build the binaries directly on your system you will need the following tools:
 
-* Rust 1.81.0 — you can install it using [`rustup`](https://rustup.rs/) and its [guide](https://rust-lang.github.io/rustup/installation/other.html) for help.
-* Other dependencies — keep reading, we'll get to it after the end of this list!
-* `just` (optional) — (after installing Rust) you can use `cargo install just` or check the [official list of packages](https://just.systems/man/en/packages.html).
+- Rust 1.81.0 — you can install it using [`rustup`](https://rustup.rs/) and its [guide](https://rust-lang.github.io/rustup/installation/other.html) for help.
+- Other dependencies — keep reading, we'll get to it after the end of this list!
+- `just` (optional) — (after installing Rust) you can use `cargo install just` or check the [official list of packages](https://just.systems/man/en/packages.html).
 
 The dependencies mentioned are for Linux distros using the `apt` family of package managers.
 Different systems may use different package managers, as such, they may require you to find the equivalent package.
@@ -40,7 +40,7 @@ $ sudo apt install -y libhwloc-dev \
     clang \
     build-essential \
     git \
-    libssl-dev \ 
+    libssl-dev \
     curl
 ```
 
@@ -56,15 +56,15 @@ Details can be found <a href="https://docs.nvidia.com/cuda/wsl-user-guide/index.
 </div>
 
 Requirements:
-* GCC 13
-* NVIDIA GPU
-* [Cuda drivers & toolkit (nvcc)](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#overview)
 
+- GCC 13
+- NVIDIA GPU
+- [Cuda drivers & toolkit (nvcc)](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#overview)
 
 <div class="warning">
 
 Not all of the binaries can be built from the polka-storage repository!
-We depend on the <a href="https://github.com/paritytech/zombienet/releases/tag/v1.3.116">zombienet</a> and <a href="https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2409-2">polkadot, polkadot-prepare-worker, polkadot-execute-worker</a> binaries which need to be downloaded regardless (if not using <a href="#using-nix">Nix</a>).
+We depend on the <a href="https://github.com/paritytech/zombienet/releases/tag/v1.3.116">zombienet</a> and <a href="https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2412">polkadot, polkadot-prepare-worker, polkadot-execute-worker</a> binaries which need to be downloaded regardless (if not using <a href="#using-nix">Nix</a>).
 
 </div>
 
@@ -122,7 +122,6 @@ cargo build --release -p polka-storage-provider-server --no-default-features --f
 cargo build --release -p polka-storage-provider-client --no-default-features --features cuda
 ```
 
-
 For more information on what each binary does, refer to [Building](./index.md).
 
 ### Just recipes
@@ -151,10 +150,11 @@ $ target/release/<BINARY-NAME>
 ```
 
 Where `<BINARY-NAME>` is one of:
-* `polka-storage-node`
-* `polka-storage-provider-server`
-* `polka-storage-provider-client`
-* `mater-cli`
-* `storagext-cli`
+
+- `polka-storage-node`
+- `polka-storage-provider-server`
+- `polka-storage-provider-client`
+- `mater-cli`
+- `storagext-cli`
 
 > Additionally, you can move them to a folder under your `$PATH` and run them as you would with any other binary.

--- a/docs/src/getting-started/demo-file-store.md
+++ b/docs/src/getting-started/demo-file-store.md
@@ -5,8 +5,8 @@ Before reading this guide, please follow the <a href="./local-testnet.md">local 
 You should have a working testnet and a Storage Provider running!
 </div>
 
-
 ## Storage Client
+
 <img class="right" src="../images/polkadot.svg" alt="The Polkadot logo" style="height: 100px; padding: 4px 8px 4px;">
 
 Alice is a [Storage User](../glossary.md#storage-user) and wants to store an image of her lovely Polkadot logo [`polkadot.svg`](../images/polkadot.svg) in the Polka Storage [parachain](../glossary.md#parachain).
@@ -35,7 +35,6 @@ $ polka-storage-provider-client proofs commp polkadot.car
 Afterwards, it's time to propose a deal, currently — i.e. while the network isn't live —
 any deals will be accepted by Charlie (the Storage Provider).
 
-
 Alice fills out the deal form according to a JSON template (`polka-logo-deal.json`):
 
 ```json
@@ -53,19 +52,18 @@ Alice fills out the deal form according to a JSON template (`polka-logo-deal.jso
 }
 ```
 
-* `piece_cid` — is the `cid` field from the previous step, where she calculated the piece commitment. It uniquely identifies the piece.
-* `piece_size` — is the `size` field from the previous step, where she calculated the piece commitment. It is the size of the processed piece, not the original file!
-* `client` — is the client's (i.e. the reader's) public key, encoded in bs58 format.
+- `piece_cid` — is the `cid` field from the previous step, where she calculated the piece commitment. It uniquely identifies the piece.
+- `piece_size` — is the `size` field from the previous step, where she calculated the piece commitment. It is the size of the processed piece, not the original file!
+- `client` — is the client's (i.e. the reader's) public key, encoded in bs58 format.
   For more information on how to generate your own keypair, read the [Polka Storage Provider CLI/`client`/`wallet`](../storage-provider-cli/client/wallet.md).
-* `provider` — is the storage provider's public key, encoded in bs58 format.
+- `provider` — is the storage provider's public key, encoded in bs58 format.
   If you don't know your storage provider's public key, you can query it using `polka-storage-provider-client`'s `info` command.
-* `label` — is an arbitrary string to be associated with the deal.
-* `start_block` — is the deal's start block, it MUST be positive and lower than `end_block`.
-* `end_block` — is the deal's end block, it must be positive and larger than `start_block`.
-* `storage_price_per_block` — the storage price over the duration of a single block — e.g. if your deal is 20 blocks long, it will cost `20 * storage_price_per_block` in total.
-* `provider_collateral` — the price to pay *by the storage provider* if they fail to uphold the deal.
-* `state` — the deal state, only `Published` is accepted.
-
+- `label` — is an arbitrary string to be associated with the deal.
+- `start_block` — is the deal's start block, it MUST be positive and lower than `end_block`.
+- `end_block` — is the deal's end block, it must be positive and larger than `start_block`.
+- `storage_price_per_block` — the storage price over the duration of a single block — e.g. if your deal is 20 blocks long, it will cost `20 * storage_price_per_block` in total.
+- `provider_collateral` — the price to pay _by the storage provider_ if they fail to uphold the deal.
+- `state` — the deal state, only `Published` is accepted.
 
 <div class="warning">
 
@@ -137,7 +135,8 @@ $ polka-storage-provider-client sign-deal --sr25519-key "//Alice" @polka-logo-de
 }
 ```
 
-> Hint: you can write the following command to *just* get the file:
+> Hint: you can write the following command to _just_ get the file:
+>
 > ```
 > polka-storage-provider-client sign-deal --sr25519-key "//Alice" @polka-logo-deal.json > signed-logo-deal.json
 > ```
@@ -159,8 +158,8 @@ On Alice's side, that's it!
 
 ## Additional Notes
 
-* As other parts of this project, file retrieval is actively being worked on! 🚧
-* Files stored in storage providers are public, as such, we suggest you encrypt your files.
+- As other parts of this project, file retrieval is actively being worked on! 🚧
+- Files stored in storage providers are public, as such, we suggest you encrypt your files.
   While file encryption is a broad enough topic, if you not sure about which tools to use,
   we suggest you keep it simple by compressing your file in a format such as [7zip](https://www.7-zip.org/) and using its encryption features.
   If 7zip doesn't cut it, you may want to take a look into [age](https://github.com/FiloSottile/age) or [VeraCrypt](https://www.veracrypt.fr/code/VeraCrypt/).

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -20,5 +20,3 @@ Before proceeding with the setup, please ensure the host system meets the follow
 - [_Local Testnet - Polka Storage Parachain_](local-testnet/index.md) — Covers how to setup a local testnet for the Polka Storage parachain, using Zombienet.
 - [_Launching a Storage Provider_](storage-provider.md) - Covers how to setup a Storage Provider.
 - [_Storing a file_](demo-file-store.md) — Covers how to store a file by the Storage Client.
-
-

--- a/docs/src/getting-started/local-testnet/getting-funds.md
+++ b/docs/src/getting-started/local-testnet/getting-funds.md
@@ -10,6 +10,7 @@ Please make sure to follow the instructions on how to generate a new account if 
 You can read more about creating a Polkadot account using the extension in the following [link](https://support.polkadot.network/support/solutions/articles/65000098878-how-to-create-a-dot-account#How-to-create-an-account-with-the-Polkadot-extension)
 
 Or you can watch the following video:
+
 <iframe
     style="display:block; margin-left:auto; margin-right:auto"
     width="560"
@@ -47,11 +48,11 @@ Make sure to run the local testnet, you can find how to do so in the [local test
 > If you have changed the `ws_port` value in the zombienet configuration — `local-testnet.toml`,
 > this URL is different and you should change the port accordingly.
 
-Under the developer tab, navigate to *Sudo*.
+Under the developer tab, navigate to _Sudo_.
 
 ![sudo selection](../../images/transfer-funds/developer-sudo.png)
 
-Once you are in *Sudo* you should select `balances` from the submit dropdown.
+Once you are in _Sudo_ you should select `balances` from the submit dropdown.
 
 ![balance selection](../../images/transfer-funds/select-balance.png)
 

--- a/docs/src/getting-started/local-testnet/index.md
+++ b/docs/src/getting-started/local-testnet/index.md
@@ -265,6 +265,7 @@ This link will automatically connect to Charlie's node running on a local machin
 ## Checking the logs
 
 At the end of the `zombienet` output you should see a table like so:
+
 ```
 ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                                         Node Information                                                          │
@@ -288,6 +289,7 @@ We strongly recommend you check the logs for the collator (in this case Charlie)
 
 > If the **Log Cmd** is shortened with `...`, try to search for the folder using the zombienet namespace, available at the top of the table.
 > For example:
+>
 > ```bash
 > $ ls /tmp | grep zombie-bcb786e1748ff0a6becd28289e1f70b9
 > ```
@@ -306,20 +308,23 @@ $ grep "<LOG_LEVEL>.*runtime::<EXTRINSIC_PALLET>" charlie.log
 ```
 
 Where `LOG_LEVEL` is one of:
-* `DEBUG`
-* `INFO`
-* `WARN`
-* `ERROR`
+
+- `DEBUG`
+- `INFO`
+- `WARN`
+- `ERROR`
 
 And the extrinsic pallet, is one of:
-* `storage_provider`
-* `market`
-* `proofs`
+
+- `storage_provider`
+- `market`
+- `proofs`
 
 > **Tip:** if you are running into the `AllProposalsInvalid` error,
 > try searching for `insane deal` in the logs, you should find the cause faster!
 >
 > For example:
+>
 > ```bash
 > $ grep "insane deal" -B 1 charlie.log
 > 2024-11-14 13:24:24.019 ERROR tokio-runtime-worker runtime::market: [Parachain] deal duration too short: 100 < 288000

--- a/docs/src/getting-started/storage-provider.md
+++ b/docs/src/getting-started/storage-provider.md
@@ -11,6 +11,7 @@ In this guide, we'll cover how to get up and running with the Storage Provider.
 
 To allow the Storage Provider to generate [PoRep](https://docs.filecoin.io/basics/the-blockchain/proofs#proof-of-replication-porep)
 and [PoSt](https://docs.filecoin.io/basics/the-blockchain/proofs#proof-of-spacetime-post) proofs we first generate the PoRep parameters:
+
 ```bash
 $ polka-storage-provider-client proofs porep-params
 Generating params for 2KiB sectors... It can take a couple of minutes ⌛
@@ -19,7 +20,9 @@ Generated parameters:
 /home/user/polka-storage/2KiB.porep.vk
 /home/user/polka-storage/2KiB.porep.vk.scale
 ```
+
 Then, we generate the PoSt parameters:
+
 ```bash
 $ polka-storage-provider-client proofs post-params
 Generating PoSt params for 2KiB sectors... It can take a few secs ⌛
@@ -31,12 +34,12 @@ Generated parameters:
 
 As advertised, the commands have generated the following files:
 
-* `2KiB.porep.params` — The PoRep parameters
-* `2KiB.porep.vk` — The PoRep verifying key
-* `2KiB.porep.vk.scale` — The PoRep verifying key, encoded in SCALE format
-* `2KiB.post.params` — The PoSt parameters
-* `2KiB.post.vk` — The PoSt verifying key
-* `2KiB.post.vk.scale` — The PoSt verifying key, encoded in SCALE format
+- `2KiB.porep.params` — The PoRep parameters
+- `2KiB.porep.vk` — The PoRep verifying key
+- `2KiB.porep.vk.scale` — The PoRep verifying key, encoded in SCALE format
+- `2KiB.post.params` — The PoSt parameters
+- `2KiB.post.vk` — The PoSt verifying key
+- `2KiB.post.vk.scale` — The PoSt verifying key, encoded in SCALE format
 
 ## Registering the Storage Provider
 
@@ -53,9 +56,9 @@ storagext-cli --ed25519-key <KEY> storage-provider register "<peer_id>"
 storagext-cli --ecdsa-key <KEY> storage-provider register "<peer_id>"
 ```
 
-
 Where `<KEY>` has been replaced accordingly to its key type.
-`<peer_id>` can be anything as it is currently used as a placeholder. *For example:*
+`<peer_id>` can be anything as it is currently used as a placeholder. _For example:_
+
 ```
 storagext-cli --sr25519-key "//Charlie" storage-provider register "placeholder"
 ```
@@ -68,10 +71,12 @@ storagext-cli --sr25519-key "//Charlie" proofs set-porep-verifying-key @2KiB.por
 ```
 
 > Additionally, you will need to add some balance to your Polka Storage escrow account, like so:
+>
 > ```
 > $ storagext-cli --sr25519-key "//Charlie" market add-balance 12500000000
 > [0x809d…8f10] Balance Added: { account: 5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y, amount: 12500000000 }
 > ```
+>
 > You can use other balance values! There's a minimum though — `1_000_000_000` (without the `_`).
 
 And you're ready!
@@ -79,7 +84,7 @@ And you're ready!
 ## Launching the server 🚀
 
 Similarly to the previous steps, here too you'll need to run a command.
-The following is the *minimal* command:
+The following is the _minimal_ command:
 
 ```bash
 polka-storage-provider-server \
@@ -91,6 +96,7 @@ polka-storage-provider-server \
 ```
 
 Where `--X-key <KEY>` matches the key type you used to register yourself with the network, in the previous step. For example:
+
 ```bash
 polka-storage-provider-server \
   --seal-proof 2KiB \

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -33,6 +33,7 @@ Dedicated CLIs
   - [`polka-storage-provider-server`](./storage-provider-cli/server.md) to launch the Storage Provider server.
   - [`polka-storage-provider-client`](./storage-provider-cli/client/index.md) to manage the wallet, propose & publish deals and do proof demos.
 - [`mater-cli`](./mater-cli/index.md) to convert or extract CARv2 files.
+- [`polka-fetch`](./polka-fetch/index.md) to retrieve stored files from the network.
 - [`storagext-cli`](./storagext-cli/index.md) to interact **directly** with the parachain — watch out, this is a low-level tool!
 
 Pallets:
@@ -41,6 +42,7 @@ Pallets:
 - [Market](./architecture/pallets/market.md)
 - [Proofs](./architecture/pallets/proofs.md)
 - [Randomness](./architecture/pallets/randomness.md)
+- [Faucet](./architecture/pallets/faucet.md)
 
 <p>
     <img
@@ -48,7 +50,7 @@ Pallets:
         alt="Polka Storage Client Upload">
 </p>
 
-**During  [Phase 1](https://polkadot.polkassembly.io/referenda/494), we implemented the following:**
+**During [Phase 1](https://polkadot.polkassembly.io/referenda/494), we implemented the following:**
 
 - Keeping track of [Storage Providers](./glossary.md#storage-provider),
 - [Publishing](./architecture/pallets/market.md#publish_storage_deals) Market Deals on-chain,

--- a/docs/src/mater-cli/index.md
+++ b/docs/src/mater-cli/index.md
@@ -20,7 +20,7 @@ The convert command converts a file to CARv2 format.
 
 | Argument        | Description                                                                                                                          |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `<INPUT_PATH>`  | Path to input file                                                                                                                   |
+| `<INPUT_PATH>`  | Path to input file. Use `-` to read from stdin.                                                                                      |
 | `[OUTPUT_PATH]` | Optional path to output CARv2 file. If no output path is given it will store the `.car` file in the same location as the input file. |
 | `-q`/`--quiet`  | If enabled, only the resulting CID will be printed.                                                                                  |
 | `--overwrite`   | If enabled, the output will overwrite any existing files.                                                                            |
@@ -28,8 +28,8 @@ The convert command converts a file to CARv2 format.
 ### Example
 
 ```bash
-$ mater-cli convert random1024.piece
-Converted examples/random1024.piece and saved the CARv2 file at examples/random1024.car with a CID of bafkreidvyofebclo4kny43vpoe5kejg3mqtpq2eemaojzyvlwikwdvusxy
+$ mater-cli convert examples/test-data-big.txt
+Converted examples/test-data-big.txt and saved the CARv2 file at examples/random1024.car with a CID of bafkreidvyofebclo4kny43vpoe5kejg3mqtpq2eemaojzyvlwikwdvusxy
 ```
 
 You can verify the output file using [`go-car`](https://github.com/ipld/go-car):
@@ -61,8 +61,9 @@ Convert a CARv2 file to its original format.
 
 | Argument        | Description                                                                                                                    |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `<INPUT_PATH>`  | Path to CARv2 file                                                                                                             |
+| `<INPUT_PATH>`  | Path to CARv2 file. Use `-` to read from stdin.                                                                                |
 | `[OUTPUT_PATH]` | Optional path to output file. If no output path is given it will remove the extension and store the file in the same location. |
+| `--overwrite`   | If enabled, the output will overwrite any existing files.                                                                      |
 
 ### Example
 
@@ -79,6 +80,20 @@ $ car create --no-wrap -f examples/random1024.go.car examples/random1024.piece
 ```
 
 ```bash
-$ cargo run -r --bin mater-cli extract examples/random1024.go.car
+$ mater-cli extract examples/random1024.go.car
 Successfully converted CARv2 file examples/random1024.go.car and saved it to to examples/random1024.go
+```
+
+### Using stdin/stdout
+
+You can use the `mater-cli` with standard input and output streams:
+
+```bash
+# Convert a file and output to stdout
+$ cat ./examples/test-data-big.txt | mater-cli convert -
+Converted - and saved the CARv2 file at stdin.car with a CID of bafkreiechz74drg7tg5zswmxf4g2dnwhemlwdv7e3l5ypehdqdwaoyz3dy
+
+# Extract a CAR file from stdin
+$ cat stdin.car | mater-cli extract - output.txt
+Successfully converted CARv2 file - and saved it to to output.txt
 ```

--- a/docs/src/storage-provider-cli/client/index.md
+++ b/docs/src/storage-provider-cli/client/index.md
@@ -24,7 +24,7 @@ $ polka-storage-provider-client info --rpc-server-url "http://127.0.0.1:8000"
 
 ## `propose-deal`
 
-The `propose-deal` command sends an *unsigned* deal to the storage provider,
+The `propose-deal` command sends an _unsigned_ deal to the storage provider,
 if the storage provider accepts the deal, a CID will be returned,
 that CID can then be used to upload a file to the storage provider —
 for details on this process, refer to the [File Upload chapter](../../getting-started/demo-file-store.md).
@@ -53,7 +53,7 @@ bagaaieradsfmawozrmgjwxosarexpg7w7ytoe7xw2c63hv6svdc5hpucqo3a
 
 The `sign-deal` commands takes a deal like the one passed to [`propose-deal`](#propose-deal) and signs it using the passed key,
 the returned deal can then be used with [`publish-deal`](#publish-deal) to send a deal for publishing.
-*This command does not call out to the network.*
+_This command does not call out to the network._
 
 ```bash
 $ DEAL_TO_SIGN='{
@@ -113,6 +113,26 @@ $ SIGNED_DEAL='{
 }'
 $ polka-storage-provider-client publish-deal "$SIGNED_DEAL"
 0
+```
+
+## `retrieve-deal`
+
+The `retrieve-deal` command fetches the details of a specific deal from the storage provider by its ID.
+
+```bash
+$ polka-storage-provider-client retrieve-deal 0
+{
+  "piece_cid": "baga6ea4seaqj527iqfb2kqhy3tmpydzroiigyaie6g3txai2kc3ooyl7kgpeipi",
+  "piece_size": 2048,
+  "client": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  "provider": "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
+  "label": "",
+  "start_block": 200,
+  "end_block": 250,
+  "storage_price_per_block": 500,
+  "provider_collateral": 1250,
+  "state": "Published"
+}
 ```
 
 ## `generate-peer-id`

--- a/docs/src/storage-provider-cli/client/proofs.md
+++ b/docs/src/storage-provider-cli/client/proofs.md
@@ -91,11 +91,73 @@ polka-storage-provider-client proofs porep \
     <INPUT_FILE> <INPUT_FILE_PIECE_CID>
 ```
 
-For a detailed description of all parameters, run:
+<details>
+<summary>Click to view the command's arguments description</summary>
 
-```bash
-polka-storage-provider-client proofs porep --help
 ```
+DEMO COMMAND - Generates PoRep for a piece file.
+
+Takes a piece file (in a CARv2 archive, unpadded), puts it into a sector (temp file), seals and proves it.
+
+When you run the command for the first time on a clean `cache_directory` it will fail, because `rust-fil-proofs` tries to validate cache based on
+https://github.com/filecoin-project/rust-fil-proofs/blob/5a0523ae1ddb73b415ce2fa819367c7989aaf73f/storage-proofs-porep/parent_cache.json.
+
+When you run the command for the second time, the cache is recreated and there are no verification issues.
+
+Usage: polka-storage-provider-client proofs porep [OPTIONS] --proof-parameters-path <PROOF_PARAMETERS_PATH> --cache-directory <CACHE_DIRECTORY> --sector-id <SECTOR_ID> --seal-randomness-height <SEAL_RANDOMNESS_HEIGHT> --pre-commit-block-number <PRE_COMMIT_BLOCK_NUMBER> <INPUT_PATH> <COMMP>
+
+Arguments:
+  <INPUT_PATH>
+          Piece file, CARv2 archive created with `mater-cli convert`
+
+  <COMMP>
+          CommP of a file, calculated with `commp` command
+
+Options:
+      --sr25519-key <SR25519_KEY>
+          Sr25519 keypair, encoded as hex, BIP-39 or a dev phrase like `//Alice`.
+
+          See `sp_core::crypto::Pair::from_string_with_seed` for more information.
+
+      --ecdsa-key <ECDSA_KEY>
+          ECDSA keypair, encoded as hex, BIP-39 or a dev phrase like `//Alice`.
+
+          See `sp_core::crypto::Pair::from_string_with_seed` for more information.
+
+      --ed25519-key <ED25519_KEY>
+          Ed25519 keypair, encoded as hex, BIP-39 or a dev phrase like `//Alice`.
+
+          See `sp_core::crypto::Pair::from_string_with_seed` for more information.
+
+  -s, --seal-proof <SEAL_PROOF>
+          PoRep has multiple variants dependent on the sector size. Parameters are required for each sector size and its corresponding PoRep Params
+
+          [default: 2KiB]
+          [possible values: 2KiB, 8MiB, 512MiB, 1GiB]
+
+  -p, --proof-parameters-path <PROOF_PARAMETERS_PATH>
+          Path to where parameters to corresponding `seal_proof` are stored
+
+  -c, --cache-directory <CACHE_DIRECTORY>
+          Directory where sector data like PersistentAux and TemporaryAux are stored
+
+  -o, --output-path <OUTPUT_PATH>
+          Directory where the proof files and the sector will be put. Defaults to the current directory
+
+      --sector-id <SECTOR_ID>
+          Sector number
+
+      --seal-randomness-height <SEAL_RANDOMNESS_HEIGHT>
+          The height at which we draw the randomness for deriving a sealed cid
+
+      --pre-commit-block-number <PRE_COMMIT_BLOCK_NUMBER>
+          Precommit block number
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+</details>
 
 ### Example
 
@@ -153,11 +215,63 @@ polka-storage-provider-client proofs post \
   <COMM_R>
 ```
 
-For a detailed description of all parameters, run:
+<details>
+<summary>Click to view the command's arguments description</summary>
 
-```bash
-polka-storage-provider-client proofs post --help
 ```
+Creates a PoSt for a single sector
+
+Usage: polka-storage-provider-client proofs post [OPTIONS] --proof-parameters-path <PROOF_PARAMETERS_PATH> --cache-directory <CACHE_DIRECTORY> --sector-number <SECTOR_NUMBER> --challenge-block <CHALLENGE_BLOCK> <REPLICA_PATH> <COMM_R>
+
+Arguments:
+  <REPLICA_PATH>
+          Replica file generated with `porep` command e.g. `77.sector.sealed`
+
+  <COMM_R>
+          CID - CommR of a replica (output of `porep` command)
+
+Options:
+      --sr25519-key <SR25519_KEY>
+          Sr25519 keypair, encoded as hex, BIP-39 or a dev phrase like `//Alice`.
+
+          See `sp_core::crypto::Pair::from_string_with_seed` for more information.
+
+      --ecdsa-key <ECDSA_KEY>
+          ECDSA keypair, encoded as hex, BIP-39 or a dev phrase like `//Alice`.
+
+          See `sp_core::crypto::Pair::from_string_with_seed` for more information.
+
+      --ed25519-key <ED25519_KEY>
+          Ed25519 keypair, encoded as hex, BIP-39 or a dev phrase like `//Alice`.
+
+          See `sp_core::crypto::Pair::from_string_with_seed` for more information.
+
+      --post-type <POST_TYPE>
+          PoSt has multiple variants dependant on the sector size. Parameters are required for each sector size and its corresponding PoSt
+
+          [default: 2KiB]
+          [possible values: 2KiB, 8MiB, 512MiB, 1GiB]
+
+  -p, --proof-parameters-path <PROOF_PARAMETERS_PATH>
+          Path to where parameters to corresponding `post_type` are stored
+
+  -c, --cache-directory <CACHE_DIRECTORY>
+          Directory where cache data from `porep` for the `replica_path` sector command has been stored. It must be the same, or else it won't work
+
+  -o, --output-path <OUTPUT_PATH>
+          Directory where the PoSt proof will be stored. Defaults to the current directory
+
+      --sector-number <SECTOR_NUMBER>
+          Sector Number used in the PoRep command
+
+      --challenge-block <CHALLENGE_BLOCK>
+          Block Number at which the randomness should be fetched from. It comes from the [`pallet_storage_provider::DeadlineInfo::challenge`] field
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+</details>
 
 ### Example
 

--- a/docs/src/storage-provider-cli/client/proofs.md
+++ b/docs/src/storage-provider-cli/client/proofs.md
@@ -91,6 +91,12 @@ polka-storage-provider-client proofs porep \
     <INPUT_FILE> <INPUT_FILE_PIECE_CID>
 ```
 
+For a detailed description of all parameters, run:
+
+```bash
+polka-storage-provider-client proofs porep --help
+```
+
 ### Example
 
 ```bash
@@ -145,6 +151,12 @@ polka-storage-provider-client proofs post \
   --challenge-block <CHALLENGE_BLOCK> \
   <REPLICA_PATH> \
   <COMM_R>
+```
+
+For a detailed description of all parameters, run:
+
+```bash
+polka-storage-provider-client proofs post --help
 ```
 
 ### Example

--- a/docs/src/storage-provider-cli/client/proofs.md
+++ b/docs/src/storage-provider-cli/client/proofs.md
@@ -68,7 +68,7 @@ Generated parameters:
 Generates a 2KiB sector-size PoRep proof for an input file and its piece commitment.
 Creates the sector containing only 1 piece, [seals it](https://spec.filecoin.io/#section-algorithms.pos.porep) by creating a replica and then creates a proof for it.
 
-> This is a *demo command*, showcasing the ability to generate a PoRep
+> This is a _demo command_, showcasing the ability to generate a PoRep
 > given the proving parameters so it can later be used to verify proof on-chain.
 > It uses hardcoded values, which normally would be sourced from the chain i.e:
 >
@@ -81,8 +81,13 @@ Creates the sector containing only 1 piece, [seals it](https://spec.filecoin.io/
 ```bash
 polka-storage-provider-client proofs porep \
     --sr25519-key|--ecdsa-key|--ed25519-key <KEY> \
+    --seal-proof <SEAL_PROOF> \
     --cache-directory <CACHE_DIRECTORY> \
-    --proofs-parameters-path <PROVING_PARAMS_FILE> \
+    --proof-parameters-path <PROVING_PARAMS_FILE> \
+    --output-path <OUTPUT_PATH> \
+    --sector-id <SECTOR_ID> \
+    --seal-randomness-height <SEAL_RANDOMNESS_HEIGHT> \
+    --pre-commit-block-number <PRE_COMMIT_BLOCK_NUMBER> \
     <INPUT_FILE> <INPUT_FILE_PIECE_CID>
 ```
 
@@ -120,7 +125,7 @@ Wrote proof to [...]/polka-storage/77.sector.proof.porep.scale
 Generates a 2KiB sector-sized PoSt proof.
 To be able to create a PoSt proof, first you need to generate a PoRep proof and a replica via `porep` command.
 
-> This is a *demo command*, showcasing the ability to generate a PoSt,
+> This is a _demo command_, showcasing the ability to generate a PoSt,
 > given the proving parameters so it can later be used to verify proof on-chain.
 > It uses hardcoded values, which normally would be sourced from the chain i.e:
 >
@@ -130,11 +135,15 @@ To be able to create a PoSt proof, first you need to generate a PoRep proof and 
 > ```
 
 ```bash
-polka-storage-provider-client proofs post
+polka-storage-provider-client proofs post \
   --sr25519-key|--ecdsa-key|--ed25519-key <KEY> \
+  --post-type <POST_TYPE> \
   --proof-parameters-path <PROOF_PARAMETERS_PATH> \
   --cache-directory <CACHE_DIRECTORY> \
-  <REPLICA_PATH>
+  --output-path <OUTPUT_PATH> \
+  --sector-number <SECTOR_NUMBER> \
+  --challenge-block <CHALLENGE_BLOCK> \
+  <REPLICA_PATH> \
   <COMM_R>
 ```
 

--- a/docs/src/storage-provider-cli/server.md
+++ b/docs/src/storage-provider-cli/server.md
@@ -18,8 +18,8 @@ To generate the ed25519 keypair use the following command:
 openssl genpkey -algorithm ED25519 -out <PRIVATE_KEY_PATH> -outpubkey <PUBLIC_KEY_PATH>
 ```
 
-
 ## CLI Options
+
 <!-- Sadly, tables will not cut it here, since the text is just too big for the table. -->
 
 ### `--sr25519-key`
@@ -99,13 +99,17 @@ The path to the PoRep proving parameters. They are shared across all of the node
 
 The path to the PoSt proving parameters. They are shared across all of the nodes in the network, as the chain stores corresponding Verifying Key parameters.
 
-### `--node-type`
-
-The P2P node type that the server will be running. Can be either `bootstrap` or `registration` node.
-
 ### `--p2p-key`
 
 The ED25519 private key used by the P2P node.
+
+### `--p2p-tcp-listen-address`
+
+P2P TCP listen address. Defaults to `/ip4/127.0.0.1/tcp/8002`.
+
+### `--p2p-ws-listen-address`
+
+P2P websocket listen address. Defaults to `/ip4/127.0.0.1/tcp/8003/ws`.
 
 ### `--rendezvous-point-address`
 
@@ -115,39 +119,60 @@ Rendezvous point address that the registration node connects to or the bootstrap
 
 Peer ID of the rendezvous point that the registration node connects to. Only needed if running a registration P2P node.
 
-### `--registration-ttl`
+### `--parallel-prove-commits`
 
-The TTL of the p2p registration in seconds. After the node registration expires, the server automatically re-registers itself.
+The number of prove commits to run in parallel. Defaults to 2.
+
+### `--fill-threshold`
+
+Percentage above which a sector is considered "full". Defaults to 95%.
+
+### `--wait-deals-delay`
+
+Amount of time to wait before sealing an unfilled sector. Defaults to 6h.
+
+### `--pre-commit-submission-slack`
+
+Time before sector's earliest deal start. Defaults to 1h.
 
 ### `--config`
 
 Takes in a path to a configuration file, it supports both JSON and TOML (files _must_ have the right extension).
 The supported configuration parameters are:
 
-| Name                       | Default                        |
-| -------------------------- | ------------------------------ |
-| `upload-listen-address`    | `127.0.0.1:8000`               |
-| `rpc-listen-address`       | `127.0.0.1:8001`               |
-| `node-url`                 | `ws://127.0.0.1:42069`         |
-| `database-directory`       | `/tmp/<random>/deals_database` |
-| `storage-directory`        | `/tmp/<random>/deals_storage`  |
-| `seal-proof`               | `2KiB`                         |
-| `post-proof`               | `2KiB`                         |
-| `porep_parameters`         | NA                             |
-| `post_parameters`          | NA                             |
-| `node_type`                | `bootstrap`                    |
-| `p2p_key`                  | NA                             |
-| `rendezvous_point_address` | NA                             |
-| `rendezvous_point`         | `None`                         |
-| `registration_ttl`         | `24 hours`                     |
+| Name                          | Default                        |
+| ----------------------------- | ------------------------------ |
+| `upload-listen-address`       | `127.0.0.1:8001`               |
+| `rpc-listen-address`          | `127.0.0.1:8000`               |
+| `node-url`                    | `ws://127.0.0.1:42069`         |
+| `database-directory`          | `/tmp/<random>/deals_database` |
+| `storage-directory`           | `/tmp/<random>/deals_storage`  |
+| `seal-proof`                  | `2KiB`                         |
+| `post-proof`                  | `2KiB`                         |
+| `porep_parameters`            | NA                             |
+| `post_parameters`             | NA                             |
+| `p2p_key`                     | NA                             |
+| `p2p_tcp_listen_address`      | `/ip4/127.0.0.1/tcp/8002`      |
+| `p2p_ws_listen_address`       | `/ip4/127.0.0.1/tcp/8003/ws`   |
+| `rendezvous_point_address`    | NA                             |
+| `rendezvous_point`            | NA                             |
+| `parallel_prove_commits`      | `2`                            |
+| `fill_threshold`              | `95`                           |
+| `wait_deals_delay`            | `6h`                           |
+| `pre_commit_submission_slack` | `1h`                           |
 
 #### Bare bones configuration
 
 ```json
 {
-    "porep_parameters": "/home/storage_provider/porep.params",
-    "post_parameters": "/home/storage_provider/post.params",
-    "p2p_key": "/home/storage_provider/private_key.pem",
-    "rendezvous_point_address": "/ip4/127.0.0.1/tcp/62649",
+  "porep_parameters": "/home/storage_provider/porep.params",
+  "post_parameters": "/home/storage_provider/post.params",
+  "p2p_key": "/home/storage_provider/private_key.pem",
+  "rendezvous_point_address": "/ip4/127.0.0.1/tcp/62649",
+  "rendezvous_point": "12D3KooWS8yJQR7xtThQ4XE714GGXf9MfRZ1ukm3YDroitATbzL5",
+  "parallel_prove_commits": 2,
+  "fill_threshold": 95,
+  "wait_deals_delay": "6h",
+  "pre_commit_submission_slack": "1h"
 }
 ```

--- a/docs/src/storage-provider-cli/server.md
+++ b/docs/src/storage-provider-cli/server.md
@@ -172,7 +172,7 @@ The supported configuration parameters are:
   "rendezvous_point": "12D3KooWS8yJQR7xtThQ4XE714GGXf9MfRZ1ukm3YDroitATbzL5",
   "parallel_prove_commits": 2,
   "fill_threshold": 95,
-  "wait_deals_delay": "6h",
+  "wait_deals_delay": "1h",
   "pre_commit_submission_slack": "1h"
 }
 ```


### PR DESCRIPTION
### Description

The PR contains:
* Prettier is now a recommended extension by the project. It's used for markdown formatting. (I couldn't find any other good formatter for Markdown).
* Changes from `*` to `_` for italic text and using `-` for list items.
* Updated docs for cli tools

### Checklist

- [X] Make sure that you described what this change does.