### PR TITLE
fix: change polkastore address and change keys

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -204,8 +204,8 @@ generate-proof-params sector-size:
 
 # sector-size = 8MiB, 1GiB available on the blob store
 download-params sector-size:
-    wget -O target/porep_params_{{sector-size}} https://polkastorage.blob.core.windows.net/proofs/{{sector-size}}.porep.params
-    wget -O target/post_params_{{sector-size}} https://polkastorage.blob.core.windows.net/proofs/{{sector-size}}.post.params
+    wget -O target/porep_params_{{sector-size}} https://polkastore.blob.core.windows.net/params/{{sector-size}}.porep.params
+    wget -O target/post_params_{{sector-size}} https://polkastore.blob.core.windows.net/params/{{sector-size}}.post.params
 
 # Run the benchmark tests
 bench-test pallet:


### PR DESCRIPTION
### Description

I needed to regen params and store them in the different blob store (because the old one was deleted).
Updated proofs and tests will be done by @Jinxit in #818.

