### PR TITLE
feat(sp/node): resolve PeerId -> Multiaddr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,12 +1461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2412#967989c5d94cb5d2060083ca7ddc5ac2cc2dd543"
@@ -6047,17 +6041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-ticker"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
-]
-
-[[package]]
 name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6413,12 +6396,6 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hex_fmt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -7935,7 +7912,7 @@ dependencies = [
  "libp2p-dns 0.40.1",
  "libp2p-identify 0.43.1",
  "libp2p-identity",
- "libp2p-kad",
+ "libp2p-kad 0.44.6",
  "libp2p-mdns 0.44.0",
  "libp2p-metrics 0.13.1",
  "libp2p-noise 0.43.2",
@@ -7969,14 +7946,13 @@ dependencies = [
  "libp2p-connection-limits 0.4.0",
  "libp2p-core 0.42.0",
  "libp2p-dns 0.42.0",
- "libp2p-gossipsub",
  "libp2p-identify 0.45.0",
  "libp2p-identity",
+ "libp2p-kad 0.46.2",
  "libp2p-mdns 0.46.0",
  "libp2p-metrics 0.15.0",
  "libp2p-noise 0.45.0",
  "libp2p-quic 0.11.1",
- "libp2p-rendezvous",
  "libp2p-request-response 0.27.0",
  "libp2p-swarm 0.45.1",
  "libp2p-tcp 0.42.0",
@@ -8126,37 +8102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-gossipsub"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-ticker",
- "getrandom",
- "hex_fmt",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "prometheus-client 0.22.3",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "rand",
- "regex",
- "sha2 0.10.8",
- "smallvec",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
 name = "libp2p-identify"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8252,6 +8197,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-kad"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
+dependencies = [
+ "arrayvec 0.7.6",
+ "asynchronous-codec 0.7.0",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-bounded 0.2.4",
+ "futures-timer",
+ "libp2p-core 0.42.0",
+ "libp2p-identity",
+ "libp2p-swarm 0.45.1",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.3.1",
+ "rand",
+ "sha2 0.10.8",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+ "uint 0.9.5",
+ "void",
+ "web-time",
+]
+
+[[package]]
 name = "libp2p-length-prefix-codec"
 version = "0.1.0"
 dependencies = [
@@ -8315,7 +8289,7 @@ dependencies = [
  "libp2p-core 0.40.1",
  "libp2p-identify 0.43.1",
  "libp2p-identity",
- "libp2p-kad",
+ "libp2p-kad 0.44.6",
  "libp2p-ping",
  "libp2p-swarm 0.43.7",
  "once_cell",
@@ -8330,9 +8304,9 @@ checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
 dependencies = [
  "futures",
  "libp2p-core 0.42.0",
- "libp2p-gossipsub",
  "libp2p-identify 0.45.0",
  "libp2p-identity",
+ "libp2p-kad 0.46.2",
  "libp2p-swarm 0.45.1",
  "pin-project",
  "prometheus-client 0.22.3",
@@ -8454,30 +8428,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "libp2p-rendezvous"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7e42a1a3315589649590228bbea53fa980e7e8e523dbe6edfbd9c1eb26de3e"
-dependencies = [
- "async-trait",
- "asynchronous-codec 0.7.0",
- "bimap",
- "futures",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-request-response 0.27.0",
- "libp2p-swarm 0.45.1",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "rand",
- "thiserror 1.0.69",
- "tracing",
- "void",
- "web-time",
 ]
 
 [[package]]

--- a/examples/start_sps.sh
+++ b/examples/start_sps.sh
@@ -17,24 +17,6 @@ mkdir -p /tmp/polka-storage-provider
 P2P_BOOTSTRAP_ADDRESS="/ip4/127.0.0.1/tcp/62649"
 P2P_BOOTSTRAP_PUBLIC_KEY="/tmp/zombienet/charlie-public.pem"
 
-# Adds funds to all test accounts
-function setup_balances {
-    declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie" "//Dave" "//Eve" "//Ferdie")
-    for ACCOUNT in "${ACCOUNTS[@]}"; do
-        RUST_LOG="storagext=debug,storagext-cli=debug" target/release/storagext-cli --sr25519-key "$ACCOUNT" market add-balance 250000000000 &
-    done
-    wait
-}
-
-function setup_network_keys {
-    # It's a test setup based on the local verifying keys, everyone can run those extrinsics currently.
-    # Each of the keys is different, because the processes are running in parallel.
-    # If they were running in parallel on the same account, they'd conflict with each other on the transaction nonce.
-    RUST_LOG="storagext=debug,storagext-cli=debug" target/release/storagext-cli --sr25519-key "//Alice" proofs set-porep-verifying-key --registered-proof 8MiB @examples/8MiB.porep.vk.scale &
-    RUST_LOG="storagext=debug,storagext-cli=debug" target/release/storagext-cli --sr25519-key "//Bob" proofs set-post-verifying-key --registered-proof 8MiB @examples/8MiB.post.vk.scale &
-    wait
-}
-
 function register_storage_provider {
     local SP_NAME="$1"
     local P2P_SP_KEY_DIR="/tmp/polka-storage-provider/$SP_NAME"
@@ -76,60 +58,62 @@ function ports {
     case $1 in
         "//Alice")
             local PORT=45000
-            echo "upload_listen_address = '127.0.0.1:$PORT'
-                  rpc_listen_address = '127.0.0.1:$(echo "$PORT + 1" | bc)'
-                  retrieval_listen_address = '/ip4/127.0.0.1/tcp/$(echo "$PORT + 2" | bc)'" |
+            echo "upload_listen_address = '0.0.0.0:$PORT'
+                  rpc_listen_address = '0.0.0.0:$(echo "$PORT + 1" | bc)'
+                  p2p_tcp_listen_address = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 2" | bc)'
+                  p2p_ws_listen_address = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 3" | bc)/ws'" |
             sed "s/\s\+//"
             ;;
         "//Bob")
             local PORT=46000
-            echo "upload_listen_address = '127.0.0.1:$PORT'
-                  rpc_listen_address = '127.0.0.1:$(echo "$PORT + 1" | bc)'
-                  retrieval_listen_address = '/ip4/127.0.0.1/tcp/$(echo "$PORT + 2" | bc)'" |
+            echo "upload_listen_address = '0.0.0.0:$PORT'
+                  rpc_listen_address = '0.0.0.0:$(echo "$PORT + 1" | bc)'
+                  p2p_tcp_listen_address = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 2" | bc)'
+                  p2p_ws_listen_address = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 3" | bc)/ws'" |
             sed "s/\s\+//"
             ;;
         "//Charlie")
             local PORT=47000
-            echo "upload_listen_address = '127.0.0.1:$PORT'
-                  rpc_listen_address = '127.0.0.1:$(echo "$PORT + 1" | bc)'
-                  retrieval_listen_address = '/ip4/127.0.0.1/tcp/$(echo "$PORT + 2" | bc)'" |
+            echo "upload_listen_address = '0.0.0.0:$PORT'
+                  rpc_listen_address = '0.0.0.0:$(echo "$PORT + 1" | bc)'
+                  p2p_tcp_listen_address = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 2" | bc)'
+                  p2p_ws_listen_address = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 3" | bc)/ws'" |
             sed "s/\s\+//"
             ;;
     esac
 }
 
-# Not necessary anymore, because Verifying Keys and balances are set in the genesis.
-# setup_balances
-# setup_network_keys
+function main {
+    declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
+    for ACCOUNT in "${ACCOUNTS[@]}"; do
+        register_storage_provider "$ACCOUNT"
+    done
+    wait
 
-declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
-for ACCOUNT in "${ACCOUNTS[@]}"; do
-    register_storage_provider "$ACCOUNT"
-done
-wait
+    # Get bootstrap P2P Peer ID. This works after running zombienet locally or in kubernetes
+    P2P_BOOTSTRAP_PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_BOOTSTRAP_PUBLIC_KEY")"
+    echo "Peer ID for bootstrap node: $P2P_BOOTSTRAP_PEER_ID"
 
-# Get bootstrap P2P Peer ID. This works after running zombienet locally or in kubernetes
-P2P_BOOTSTRAP_PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_BOOTSTRAP_PUBLIC_KEY")"
-echo "Peer ID for bootstrap node: $P2P_BOOTSTRAP_PEER_ID"
+    for ACCOUNT in "${ACCOUNTS[@]}"; do
+        echo "
+            $(ports "$ACCOUNT")
+            seal_proof = '8MiB'
+            post_proof = '8MiB'
+            porep_parameters = 'target/porep_params_8MiB'
+            post_parameters = 'target/porep_params_8MiB'
+            p2p_key = '@$(sp_private_key "$ACCOUNT")'
+            rendezvous_point_address = '$P2P_BOOTSTRAP_ADDRESS'
+            rendezvous_point = '$P2P_BOOTSTRAP_PEER_ID'
+            [sealing_configuration]
+            fill_threshold = 0
+            wait_deals_delay = '5m'
+            pre_commit_submission_slack = '1m'" | sed 's/\s\+//' > "$(sp_key_dir "$ACCOUNT")/config.toml"
 
-declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
-for ACCOUNT in "${ACCOUNTS[@]}"; do
-    echo "
-        $(ports "$ACCOUNT")
-        seal_proof = '8MiB'
-        post_proof = '8MiB'
-        porep_parameters = 'target/porep_params_8MiB'
-        post_parameters = 'target/porep_params_8MiB'
-        p2p_key = '@$(sp_private_key "$ACCOUNT")'
-        rendezvous_point_address = '$P2P_BOOTSTRAP_ADDRESS'
-        rendezvous_point = '$P2P_BOOTSTRAP_PEER_ID'
-        [sealing_configuration]
-        fill_threshold = 0
-        wait_deals_delay = '5m'
-        pre_commit_submission_slack = '1m'" | sed 's/\s\+//' > "$(sp_key_dir "$ACCOUNT")/config.toml"
+        RUST_LOG="tower_http=debug,polka_storage_provider_server=debug,polka_storage_provider_server::p2p=trace,yamux=off,multistream_select=off,polka_storage_provider_common=debug" target/release/polka-storage-provider-server \
+            --sr25519-key "$ACCOUNT" \
+            --config "$(sp_key_dir "$ACCOUNT")/config.toml" &
+    done
+    wait
+}
 
-    RUST_LOG="polka_storage_provider_server=debug" target/release/polka-storage-provider-server \
-        --sr25519-key "$ACCOUNT" \
-        --config "$(sp_key_dir "$ACCOUNT")/config.toml" &
-done
-wait
+main

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -42,11 +42,10 @@ jsonrpsee = { features = ["server"], workspace = true }
 libp2p = { workspace = true, features = [
   "cbor",
   "dns",
-  "gossipsub",
   "identify",
+  "kad",
   "macros",
   "noise",
-  "rendezvous",
   "request-response",
   "tcp",
   "tokio",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -230,8 +230,9 @@ fn testnet_genesis(
             // 1 == pallets/storage-provider/lib.rs:calculate_pre_commit_deposit
             // NOTE(@th7nder,11/03/2025): please be aware, that this amount needs to be endowed to Market Pallet as well!
             "balances": vec![
+                (get_account_id_from_seed::<sr25519::Public>("Alice"), 25_000_000_000 as Balance),
+                (get_account_id_from_seed::<sr25519::Public>("Bob"), 12_500_000_001 as Balance),
                 (get_account_id_from_seed::<sr25519::Public>("Charlie"), 12_500_000_001 as Balance),
-                (get_account_id_from_seed::<sr25519::Public>("Alice"), 25_000_000_000 as Balance)
             ],
         },
         "sudo": { "key": Some(root) }

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -171,7 +171,7 @@ fn on_request_response_event(
                 log::trace!("Received a request-response request ({request_id}): {request:?}");
                 let Some(kref) = swarm.behaviour_mut().kad.kbucket(request.0) else {
                     log::trace!("KBucket query returned None, we're the node containing the peer");
-                    let peer_id = swarm.local_peer_id().clone();
+                    let peer_id = *swarm.local_peer_id();
                     let multiaddrs = swarm.external_addresses().cloned().collect();
                     let peer_info = PeerInfoResponse::Found(PeerInfo {
                         peer_id,
@@ -210,7 +210,7 @@ fn on_request_response_event(
                     return;
                 };
 
-                let peer_id = entry.node.key.preimage().clone();
+                let peer_id = *entry.node.key.preimage();
                 let multiaddrs = entry.node.value.clone().into_vec();
                 let response = PeerInfoResponse::Found(PeerInfo {
                     peer_id,

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -193,10 +193,7 @@ fn on_request_response_event(
                 log::trace!("KBucket contains peer {}, searching for it", request.0);
                 let entry = kref
                     .iter()
-                    .filter(|entry| entry.node.key.preimage() == &request.0)
-                    .take(1)
-                    .collect::<Vec<_>>()
-                    .pop();
+                    .find(|entry| entry.node.key.preimage() == &request.0);
                 let Some(entry) = entry else {
                     log::trace!("Could not find peer {} in KBucket", request.0);
                     if swarm

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -1,35 +1,28 @@
-use std::{
-    collections::HashMap,
-    hash::{DefaultHasher, Hash, Hasher},
-    io::{Error, ErrorKind},
-    time::Duration,
-};
+use std::time::Duration;
 
 use libp2p::{
     futures::StreamExt,
-    gossipsub::{self, IdentTopic},
     identify,
     identity::Keypair,
-    noise, rendezvous,
+    kad, noise,
     request_response::{self, Message, ProtocolSupport},
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, PeerId, StreamProtocol, Swarm, SwarmBuilder,
+    tcp, yamux, Multiaddr, StreamProtocol, Swarm, SwarmBuilder,
 };
 use libp2p_length_prefix_codec::LpCbor;
 use log::{debug, error, info, warn};
 use primitives_p2p::{
     PeerIdRequest, PeerInfo, PeerInfoResponse, BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL,
-    DEFAULT_REGISTRATION_TTL, GOSSIP_TOPIC, IDENTIFY_PROTOCOL_VERSION,
+    IDENTIFY_PROTOCOL_VERSION,
 };
 
 use crate::service::p2p::P2PError;
 
 #[derive(NetworkBehaviour)]
 pub struct BootstrapBehaviour {
-    pub rendezvous: rendezvous::server::Behaviour,
     pub identify: identify::Behaviour,
-    pub gossipsub: gossipsub::Behaviour,
     pub request_response: request_response::Behaviour<LpCbor<PeerIdRequest, PeerInfoResponse>>,
+    pub kad: kad::Behaviour<kad::store::MemoryStore>,
 }
 
 pub struct BootstrapConfig {
@@ -77,38 +70,22 @@ impl BootstrapConfig {
             .await
             .map_err(|_| P2PError::InvalidWebsocketConfig)?
             .with_behaviour(|key| {
-                // To content-address message, we can take the hash of message and use it as an ID.
-                let message_id_fn = |message: &gossipsub::Message| {
-                    let mut s = DefaultHasher::new();
-                    message.data.hash(&mut s);
-                    gossipsub::MessageId::from(s.finish().to_string())
-                };
-                let gossipsub_config = gossipsub::ConfigBuilder::default()
-                    .message_id_fn(message_id_fn)
-                    .build()
-                    .map_err(|msg| Error::new(ErrorKind::Other, msg))?;
-
                 Ok(BootstrapBehaviour {
-                    // Rendezvous server behaviour for serving new peers to connecting nodes.
-                    rendezvous: rendezvous::server::Behaviour::new(
-                        rendezvous::server::Config::default()
-                            .with_max_ttl(DEFAULT_REGISTRATION_TTL), // Max TTL of 24 hours
-                    ),
                     // The identify behaviour is used to share the external address and the public key with connecting clients.
                     identify: identify::Behaviour::new(identify::Config::new(
                         IDENTIFY_PROTOCOL_VERSION.to_string(),
                         key.public(),
                     )),
-                    gossipsub: gossipsub::Behaviour::new(
-                        gossipsub::MessageAuthenticity::Signed(key.clone()),
-                        gossipsub_config,
-                    )?,
                     request_response: request_response::Behaviour::new(
                         [(
                             StreamProtocol::new(BOOTSTRAP_REQUEST_RESPONSE_PROTOCOL),
                             ProtocolSupport::Full,
                         )],
                         request_response::Config::default(),
+                    ),
+                    kad: kad::Behaviour::new(
+                        key.public().to_peer_id(),
+                        kad::store::MemoryStore::new(key.public().to_peer_id()),
                     ),
                 })
             })
@@ -145,11 +122,7 @@ pub(crate) async fn bootstrap(
             Err(err) => error!("Failed to dial peer at address {addr} with error: {err}"),
         }
     }
-    swarm
-        .behaviour_mut()
-        .gossipsub
-        .subscribe(&IdentTopic::new(GOSSIP_TOPIC))?;
-    let mut registrations = HashMap::new();
+
     loop {
         tokio::select! {
             event = swarm.select_next_some() => match event {
@@ -162,100 +135,22 @@ pub(crate) async fn bootstrap(
                 SwarmEvent::ConnectionClosed { peer_id, .. } => {
                     info!("Disconnected from {}", peer_id);
                 }
-                SwarmEvent::Behaviour(BootstrapBehaviourEvent::Rendezvous(event)) => on_rendezvous_event(&mut swarm, event, &mut registrations),
-                SwarmEvent::Behaviour(BootstrapBehaviourEvent::Gossipsub(event)) => on_gossipsub_event(event, *swarm.local_peer_id(), &mut registrations),
-                SwarmEvent::Behaviour(BootstrapBehaviourEvent::RequestResponse(event)) => on_request_response_event(&mut swarm, event, &registrations),
+                SwarmEvent::Behaviour(BootstrapBehaviourEvent::Identify(event)) => {
+                    match event {
+                        identify::Event::Received {  peer_id, info, .. } => {
+                            log::trace!("Received an identify received event");
+                            for addr in info.listen_addrs {
+                                log::debug!("Adding address to kademlia: peer_id={peer_id}, addr={addr:?}");
+                                swarm.behaviour_mut().kad.add_address(&peer_id, addr);
+                            }
+                        },
+                        _ => log::debug!("Unhandled Identify event: {event:?}"),
+                    };
+                }
+                SwarmEvent::Behaviour(BootstrapBehaviourEvent::RequestResponse(event)) => on_request_response_event(&mut swarm, event, ),
                 other => debug!("Encountered event: {other:?}"),
             }
         }
-    }
-}
-
-/// Handles events within the rendezvous protocol
-fn on_rendezvous_event(
-    swarm: &mut Swarm<BootstrapBehaviour>,
-    event: rendezvous::server::Event,
-    registrations: &mut HashMap<PeerId, PeerInfo>,
-) {
-    match event {
-        rendezvous::server::Event::RegistrationExpired(registration) => {
-            let id = registration.record.peer_id();
-            info!(
-                "Registration for peer {} expired in namespace {}",
-                id, registration.namespace
-            );
-            // Registration expired, remove entry from hashmap
-            if registrations.remove(&id).is_none() {
-                error!(
-                    "Could not remove registration for {:?} because it was not found",
-                    id
-                );
-            }
-        }
-        rendezvous::server::Event::PeerRegistered { peer, registration } => {
-            info!(
-                "Peer {} registered for namespace '{}' for {} seconds",
-                peer, registration.namespace, registration.ttl
-            );
-            let peer_info = PeerInfo {
-                peer_id: peer,
-                multiaddrs: registration.record.addresses().to_vec(),
-            };
-            // Serialize PeerInfo
-            let encoded_peer_info = match serde_json::to_vec(&peer_info) {
-                Ok(info) => info,
-                Err(..) => {
-                    error!(peer_info:?; "Failed to serialize peer_info");
-                    return;
-                }
-            };
-            insert_or_update_registrations(registrations, peer_info);
-            // Send registration information to other bootstrap nodes.
-            match swarm
-                .behaviour_mut()
-                .gossipsub
-                .publish(IdentTopic::new(GOSSIP_TOPIC), encoded_peer_info)
-            {
-                Ok(..) => info!("Successfully published new peer info for peer {peer}"),
-                Err(e) => error!(e:?; "Failed to publish new peer info for peer {peer}"),
-            }
-        }
-        other => debug!("Encountered other rendezvous event: {other:?}"),
-    }
-}
-
-/// Handles events within the gossipsub protocol
-fn on_gossipsub_event(
-    event: gossipsub::Event,
-    local_peer_id: PeerId,
-    registrations: &mut HashMap<PeerId, PeerInfo>,
-) {
-    match event {
-        // Received a message with peer information from another bootstrap node.
-        gossipsub::Event::Message {
-            propagation_source: peer_id,
-            message_id: id,
-            message,
-        } => {
-            // Got a message from ourselves, return early.
-            if peer_id == local_peer_id {
-                return;
-            }
-            // Deserialize peer info
-            let peer_info: PeerInfo = match serde_json::from_slice(&message.data) {
-                Ok(info) => info,
-                Err(..) => {
-                    error!(message:? = message.data; "Received invalid peer info from peer {peer_id:?}");
-                    return;
-                }
-            };
-            info!(
-                "Got registration: {:?} with id: {} from peer: {:?}",
-                peer_info, id, peer_id
-            );
-            insert_or_update_registrations(registrations, peer_info);
-        }
-        other => debug!("Encountered other gossipsub event: {other:?}"),
     }
 }
 
@@ -263,7 +158,6 @@ fn on_gossipsub_event(
 fn on_request_response_event(
     swarm: &mut Swarm<BootstrapBehaviour>,
     event: request_response::Event<PeerIdRequest, PeerInfoResponse>,
-    registrations: &HashMap<PeerId, PeerInfo>,
 ) {
     match event {
         // Message received, looking up the mapping
@@ -274,28 +168,53 @@ fn on_request_response_event(
                 request_id,
             } = message
             {
-                info!("Got request with id {request_id} from {peer}");
-                let id: PeerId = request.into();
-                let response = match registrations.get(&id) {
-                    Some(peer_info) => {
-                        info!("Peer {id:?} found in registrations");
-                        PeerInfoResponse::Found(peer_info.clone())
-                    }
-                    None => {
-                        info!("Peer {id:?} not found in registrations");
-                        PeerInfoResponse::NotFound(id.into())
-                    }
+                log::trace!("Received a request-response request ({request_id}): {request:?}");
+                // When we receive a message from
+                let Some(kref) = swarm.behaviour_mut().kad.kbucket(request.0) else {
+                    log::trace!("KBucket query returned None, we're the node containing the peer");
+                    let peer_id = swarm.local_peer_id().clone();
+                    let multiaddrs = swarm.external_addresses().cloned().collect();
+                    let peer_info = PeerInfoResponse::Found(PeerInfo {
+                        peer_id,
+                        multiaddrs,
+                    });
+                    log::trace!("Sending response to request ({request_id}): {peer_info:?}");
+                    swarm
+                        .behaviour_mut()
+                        .request_response
+                        .send_response(channel, peer_info)
+                        .unwrap(); // TODO: remove
+                    return;
                 };
-                // Sending the peer information back to the client who opened the channel.
-                // Could add retries here.
-                if swarm
+
+                log::trace!("KBucket contains peer {}, searching for it", request.0);
+                let entry = kref
+                    .iter()
+                    .filter(|entry| entry.node.key.preimage() == &request.0)
+                    .take(1)
+                    .collect::<Vec<_>>()
+                    .pop();
+                let Some(entry) = entry else {
+                    log::trace!("Could not find peer {} in KBucket", request.0);
+                    swarm
+                        .behaviour_mut()
+                        .request_response
+                        .send_response(channel, PeerInfoResponse::NotFound(request))
+                        .unwrap();
+                    return;
+                };
+                let peer_id = entry.node.key.preimage().clone();
+                let multiaddrs = entry.node.value.clone().into_vec();
+                let response = PeerInfoResponse::Found(PeerInfo {
+                    peer_id,
+                    multiaddrs,
+                });
+                log::trace!("Found entry in KBucket, sending response: {response:?}");
+                swarm
                     .behaviour_mut()
                     .request_response
                     .send_response(channel, response)
-                    .is_err()
-                {
-                    error!("Failed to send peer info to {peer:?}");
-                }
+                    .unwrap();
             }
         }
         request_response::Event::OutboundFailure {
@@ -312,22 +231,4 @@ fn on_request_response_event(
             debug!("Response with id {request_id} sent to {peer}")
         }
     }
-}
-
-/// Take the HashMap and update the entry based on peer_info.peer_id
-/// or insert a new entry.
-fn insert_or_update_registrations(
-    registrations: &mut HashMap<PeerId, PeerInfo>,
-    peer_info: PeerInfo,
-) {
-    registrations
-        .entry(peer_info.peer_id)
-        .and_modify(|info| {
-            for addr in peer_info.multiaddrs.iter() {
-                if !info.multiaddrs.contains(addr) {
-                    info.multiaddrs.push(addr.clone())
-                }
-            }
-        })
-        .or_insert(peer_info);
 }

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -161,7 +161,7 @@ fn on_request_response_event(
 ) {
     match event {
         // Message received, looking up the mapping
-        request_response::Event::Message { peer, message } => {
+        request_response::Event::Message { message, .. } => {
             if let Message::Request {
                 request,
                 channel,

--- a/node/src/service/p2p/bootstrap.rs
+++ b/node/src/service/p2p/bootstrap.rs
@@ -169,7 +169,6 @@ fn on_request_response_event(
             } = message
             {
                 log::trace!("Received a request-response request ({request_id}): {request:?}");
-                // When we receive a message from
                 let Some(kref) = swarm.behaviour_mut().kad.kbucket(request.0) else {
                     log::trace!("KBucket query returned None, we're the node containing the peer");
                     let peer_id = swarm.local_peer_id().clone();
@@ -179,11 +178,15 @@ fn on_request_response_event(
                         multiaddrs,
                     });
                     log::trace!("Sending response to request ({request_id}): {peer_info:?}");
-                    swarm
+
+                    if swarm
                         .behaviour_mut()
                         .request_response
                         .send_response(channel, peer_info)
-                        .unwrap(); // TODO: remove
+                        .is_err()
+                    {
+                        log::error!("Failed to send response to request {request_id}");
+                    }
                     return;
                 };
 
@@ -196,13 +199,17 @@ fn on_request_response_event(
                     .pop();
                 let Some(entry) = entry else {
                     log::trace!("Could not find peer {} in KBucket", request.0);
-                    swarm
+                    if swarm
                         .behaviour_mut()
                         .request_response
                         .send_response(channel, PeerInfoResponse::NotFound(request))
-                        .unwrap();
+                        .is_err()
+                    {
+                        log::error!("Failed to send response to request {request_id}")
+                    }
                     return;
                 };
+
                 let peer_id = entry.node.key.preimage().clone();
                 let multiaddrs = entry.node.value.clone().into_vec();
                 let response = PeerInfoResponse::Found(PeerInfo {
@@ -210,11 +217,14 @@ fn on_request_response_event(
                     multiaddrs,
                 });
                 log::trace!("Found entry in KBucket, sending response: {response:?}");
-                swarm
+                if swarm
                     .behaviour_mut()
                     .request_response
                     .send_response(channel, response)
-                    .unwrap();
+                    .is_err()
+                {
+                    log::error!("Failed to send response to request {request_id}");
+                }
             }
         }
         request_response::Event::OutboundFailure {

--- a/node/src/service/p2p/mod.rs
+++ b/node/src/service/p2p/mod.rs
@@ -19,8 +19,6 @@ pub enum P2PError {
     InvalidBehaviourConfig,
     #[error(transparent)]
     P2PTransport(#[from] libp2p::TransportError<std::io::Error>),
-    #[error(transparent)]
-    P2PSubscription(#[from] libp2p::gossipsub::SubscriptionError),
 }
 
 /// Runs a bootstrap node from the given config.

--- a/primitives-p2p/src/request_response/bootstrap.rs
+++ b/primitives-p2p/src/request_response/bootstrap.rs
@@ -43,7 +43,7 @@ pub struct PeerIdRequest(
             deserialize_with = "deserialize_peer_id"
         )
     )]
-    PeerId,
+    pub PeerId,
 );
 
 impl From<PeerId> for PeerIdRequest {

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -34,19 +34,7 @@ futures = { workspace = true }
 hyper = { workspace = true }
 integer-encoding = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "macros", "server", "ws-client"] }
-libp2p = { workspace = true, features = [
-  "cbor",
-  "dns",
-  "identify",
-  "macros",
-  "noise",
-  "rendezvous",
-  "request-response",
-  "tcp",
-  "tokio",
-  "websocket",
-  "yamux",
-] }
+libp2p = { workspace = true, features = ["cbor", "dns", "identify", "macros", "noise", "request-response", "tcp", "tokio", "websocket", "yamux"] }
 libp2p-length-prefix-codec = { workspace = true }
 rand = { workspace = true }
 rocksdb = { workspace = true }

--- a/storage-provider/server/src/p2p/mod.rs
+++ b/storage-provider/server/src/p2p/mod.rs
@@ -5,9 +5,11 @@ use futures::StreamExt;
 use libp2p::{
     identify::{self, Event as IdentifyEvent},
     identity::Keypair,
-    rendezvous::{self, client::Event as RendezvousEvent, Namespace},
     request_response::{self, Event as RequestResponseEvent, Message, ProtocolSupport},
-    swarm::{NetworkBehaviour, SwarmEvent},
+    swarm::{
+        dial_opts::{DialOpts, PeerCondition},
+        NetworkBehaviour, SwarmEvent,
+    },
     Multiaddr, PeerId, StreamProtocol, Swarm,
 };
 use libp2p_length_prefix_codec::LpCbor;
@@ -33,9 +35,6 @@ const REGISTRATION_TTL: Duration = Duration::from_secs(DEFAULT_REGISTRATION_TTL)
 
 /// Maximum length allowed for a multihash in bytes.
 const MAX_MULTIHASH_LENGTH: usize = 64;
-
-/// Unique namespace used for peer discovery and registration with rendezvous nodes.
-const P2P_NAMESPACE: &str = "polka-storage";
 
 /// Arguments used to configure the [`P2p`].
 pub struct P2pArgs<B, I>
@@ -64,7 +63,6 @@ where
     B: Blockstore + 'static,
 {
     identify: identify::Behaviour,
-    rendezvous: rendezvous::client::Behaviour,
     bitswap: beetswap::Behaviour<MAX_MULTIHASH_LENGTH, B>,
     request_response: request_response::Behaviour<LpCbor<PieceInfoRequest, PieceInfoResponse>>,
 }
@@ -98,8 +96,6 @@ where
             args.local_keypair.public(),
         ));
 
-        let rendezvous = rendezvous::client::Behaviour::new(args.local_keypair.clone());
-
         let bitswap = beetswap::Behaviour::new(args.blockstore);
 
         let request_response =
@@ -113,7 +109,6 @@ where
 
         let behaviour = Behaviour {
             identify,
-            rendezvous,
             bitswap,
             request_response,
         };
@@ -140,19 +135,10 @@ where
         loop {
             select! {
                 _ = register_interval.tick() => {
-                    // Check if there are any external addresses set, before we
-                    // actually try to register ourself with the rendezvous nodes
-                    if self.swarm.external_addresses().count() == 0 {
-                        debug!("External address not known. Skip registration.");
-                        register_interval.reset_after(Duration::from_secs(1));
-                        continue;
-                    }
-
                     // Dial rendezvous nodes again because the connection is not persisted
+                    // On dialing the identify protocol *should* be exchanged which will trigger
+                    // a "re-register" in the Kadmelia server, adding it to the server's kbucket
                     dial_rendezvous_nodes(&mut self.swarm, &self.rendezvous_nodes);
-
-                    // Register with the nodes
-                    request_registration(&mut self.swarm, &self.rendezvous_nodes);
                 }
                 event = self.swarm.select_next_some() => self.on_swarm_event(event),
                 _ = cancellation_token.cancelled() => {
@@ -166,54 +152,13 @@ where
     fn on_swarm_event(&mut self, event: SwarmEvent<BehaviourEvent<B>>) {
         match event {
             SwarmEvent::Behaviour(ev) => match ev {
-                BehaviourEvent::Identify(ev) => self.on_identify_event(ev),
-                BehaviourEvent::Rendezvous(ev) => self.on_rendezvous_event(ev),
                 BehaviourEvent::RequestResponse(ev) => self.on_request_response_event(ev),
-                _ => {}
+                _ => tracing::trace!("Unhandled behaviour event: {ev:?}"),
             },
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(%address, "Listening on");
             }
-            _ => {}
-        }
-    }
-
-    #[instrument(level = "trace", skip(self))]
-    fn on_identify_event(&mut self, event: IdentifyEvent) {
-        match event {
-            // once `/identify` did its job, we know the external address of the
-            // local node. The `observed_addr` is returned by the node with
-            // which we identified (and they identified with us). The
-            // `observed_addr` is an address that the other node observed when
-            // the local node connected.
-            IdentifyEvent::Received { info, .. } => {
-                self.swarm.add_external_address(info.observed_addr);
-            }
-            _ => {}
-        }
-    }
-
-    #[instrument(level = "trace", skip(self))]
-    fn on_rendezvous_event(&mut self, event: RendezvousEvent) {
-        match event {
-            RendezvousEvent::Registered {
-                rendezvous_node,
-                ttl,
-                ..
-            } => {
-                info!(%rendezvous_node, %ttl, "Successfully registered");
-            }
-            RendezvousEvent::RegisterFailed {
-                rendezvous_node,
-                error,
-                ..
-            } => {
-                warn!(%rendezvous_node, ?error, "Registration failed");
-            }
-            RendezvousEvent::Expired { peer } => {
-                debug!(%peer, "Registration expired");
-            }
-            _ => {}
+            _ => tracing::trace!("Unhandled swarm event: {event:?}"),
         }
     }
 
@@ -223,45 +168,48 @@ where
         event: RequestResponseEvent<PieceInfoRequest, PieceInfoResponse>,
     ) {
         match event {
-            RequestResponseEvent::Message { peer, message } => {
-                if let Message::Request {
-                    request,
-                    channel,
-                    request_id,
-                } = message
-                {
-                    debug!("Got request with id {request_id} from {peer}");
+            RequestResponseEvent::Message {
+                peer,
+                message:
+                    Message::Request {
+                        request,
+                        channel,
+                        request_id,
+                    },
+            } => {
+                debug!("Got request with id {request_id} from {peer}");
 
-                    let response = match self.index_db.get_piece_metadata(request.piece_cid) {
-                        Ok(info) => PieceInfoResponse::Found(PieceInfo { roots: info.roots }),
-                        Err(err) => {
-                            error!(?err, "error occurred while retrieving piece info");
-                            PieceInfoResponse::NotFound(request.piece_cid)
-                        }
-                    };
-
-                    let response_result = self
-                        .swarm
-                        .behaviour_mut()
-                        .request_response
-                        .send_response(channel, response);
-                    if let Err(err) = response_result {
-                        error!(%peer, ?err, "Failed to respond with piece info");
+                let response = match self.index_db.get_piece_metadata(request.piece_cid) {
+                    Ok(info) => PieceInfoResponse::Found(PieceInfo { roots: info.roots }),
+                    Err(err) => {
+                        error!(?err, "error occurred while retrieving piece info");
+                        PieceInfoResponse::NotFound(request.piece_cid)
                     }
+                };
+
+                let response_result = self
+                    .swarm
+                    .behaviour_mut()
+                    .request_response
+                    .send_response(channel, response);
+                if let Err(err) = response_result {
+                    error!(%peer, ?err, "Failed to respond with piece info");
                 }
             }
             RequestResponseEvent::OutboundFailure {
                 peer,
                 request_id,
                 error,
-            } => warn!("Failed to send response with id {request_id} to {peer}: {error}"),
+            } => tracing::error!("Failed to send response with id {request_id} to {peer}: {error}"),
             RequestResponseEvent::InboundFailure {
                 peer,
                 request_id,
                 error,
-            } => warn!("Failed to receive message with id {request_id} from {peer}: {error}"),
-            RequestResponseEvent::ResponseSent { peer, request_id } => {
-                debug!("Response with id {request_id} sent to {peer}")
+            } => tracing::error!(
+                "Failed to receive message with id {request_id} from {peer}: {error}"
+            ),
+            RequestResponseEvent::ResponseSent { .. } | RequestResponseEvent::Message { .. } => {
+                tracing::trace!("Unhandled request response event: {event:?}")
             }
         }
     }
@@ -276,32 +224,8 @@ where
         // Start dialing the node if needed
         if !swarm.is_connected(rendezvous_peer) {
             if let Err(err) = swarm.dial(rendezvous_addr.clone()) {
-                warn!(?err, %rendezvous_peer, %rendezvous_addr, "rendezvous node dialing error");
+                warn!(%rendezvous_peer, %rendezvous_addr, "Failed to dial rendezvous node with error: {err}");
                 continue;
-            }
-        }
-    }
-}
-
-/// Request registration with the rendezvous nodes.
-fn request_registration<B>(swarm: &mut Swarm<Behaviour<B>>, nodes: &[(PeerId, Multiaddr)])
-where
-    B: Blockstore,
-{
-    for (rendezvous_peer, rendezvous_addr) in nodes {
-        // Register with the node
-        let request_result = swarm.behaviour_mut().rendezvous.register(
-            Namespace::from_static(P2P_NAMESPACE),
-            *rendezvous_peer,
-            Some(REGISTRATION_TTL.as_secs()),
-        );
-
-        match request_result {
-            Ok(_) => {
-                info!(%rendezvous_peer, %rendezvous_addr, "Registration requested");
-            }
-            Err(err) => {
-                warn!(?err, %rendezvous_peer, %rendezvous_addr, "Registration request failed");
             }
         }
     }

--- a/storage-provider/server/src/p2p/mod.rs
+++ b/storage-provider/server/src/p2p/mod.rs
@@ -3,13 +3,10 @@ use std::{sync::Arc, time::Duration};
 use ::blockstore::Blockstore;
 use futures::StreamExt;
 use libp2p::{
-    identify::{self, Event as IdentifyEvent},
+    identify::{self},
     identity::Keypair,
     request_response::{self, Event as RequestResponseEvent, Message, ProtocolSupport},
-    swarm::{
-        dial_opts::{DialOpts, PeerCondition},
-        NetworkBehaviour, SwarmEvent,
-    },
+    swarm::{NetworkBehaviour, SwarmEvent},
     Multiaddr, PeerId, StreamProtocol, Swarm,
 };
 use libp2p_length_prefix_codec::LpCbor;

--- a/zombienet/local-testnet.toml
+++ b/zombienet/local-testnet.toml
@@ -31,7 +31,7 @@ args = [
   "--detailed-log-output",
   "--p2p-key=@/tmp/zombienet/charlie-private.pem",
   "--pool-type=fork-aware",
-  "-lparachain=debug,xcm=trace,runtime=trace,txpool=debug,basic-authorship=debug",
+  "-lparachain=debug,xcm=trace,runtime=trace,txpool=debug,basic-authorship=debug,polka_storage_node::service::p2p=trace",
 ]
 command = "target/release/polka-storage-node"
 name = "charlie"


### PR DESCRIPTION
### Description

TL;DR: removes Rendezvous+Gossipsub in favour of Kadmelia

The key motivation is that we get more control over the addresses being added, though it brings more advantages.

The main issue with gossip is that it is timing dependent as it merely serves as a way to disseminate information, not to store it. A solution is simply to constantly re-gossip all info but that doesn't scale. A DHT fills that purpose much better as the information is split among multiple nodes.

While implementing this multiple issues arose:
* Kad doesn't work on the JS side
* Request/Response stopped working when the swarm building process was rewritten
* WASM libp2p works on a demo but not in the real thing

And even now I can foresee more problems rising due to the fact that this PR abuses the Kbuckets to fetch the registered multiaddresses. Currently we don't go out into the network but we need to, because we can't rely on a single peer to know everyone. With the upcoming [libp2p peerstore](https://github.com/libp2p/rust-libp2p/blob/1206fef09885d024323479d0383c37c4fe281c7c/misc/peer-store/src/lib.rs#L5), maybe we can have a slightly more solid way of keeping track of peers but for *right now*, this works.

Another thing we might try in the future is to use litep2p as a slightly higher-level approach to libp2p.

Demo:

https://github.com/user-attachments/assets/67be9bb8-08ec-4d71-92b0-4f42e64fc7b4

The HTTP error happens because we still need to resolve the other protocol (HTTP/JSON-RPC) ports, for which we need another request response.
