### PR TITLE
test(sp): Refactor benchmarks

### DIFF
--- a/pallets/storage-provider/benchmarks/src/benchmarking.rs
+++ b/pallets/storage-provider/benchmarks/src/benchmarking.rs
@@ -17,9 +17,9 @@ use pallet_proofs::Pallet as ProofsPallet;
 use pallet_storage_provider::{pallet::Call, Pallet as SpPallet};
 use primitives::{
     configs::BalanceOf,
-    proofs::RegisteredPoStProof,
-    sector::{ProveCommitSector, SectorNumber, SectorPreCommitInfo},
-    test_data::{generate_benchmark_account, BenchmarkData, StorageProviderData},
+    deals::ClientDealProposalOf,
+    sector::{ProveCommitSector, SectorPreCommitInfo},
+    test_data::{generate_benchmark_account, BenchmarkData},
     MAX_SECTORS_PER_CALL, PEER_ID_MAX_BYTES,
 };
 use sp_runtime::{AccountId32, MultiSignature, MultiSigner};
@@ -42,8 +42,6 @@ const EXISTENTIAL_DEPOSIT: u32 = 1_000_000_000;
     u64: TryFrom<BalanceOf<T>>,
 )]
 mod benchmarks {
-
-    use primitives::test_data::BenchmarkData;
 
     use super::*;
 
@@ -69,7 +67,7 @@ mod benchmarks {
 
     #[benchmark]
     fn pre_commit_sectors() {
-        let (sp_id, sectors) = prepare_pre_commit_sectors::<T>(1);
+        let (sp_id, _, sectors) = prepare_pre_commit_sectors::<T>(1);
 
         #[extrinsic_call]
         _(RawOrigin::Signed(sp_id.clone()), sectors);
@@ -84,7 +82,7 @@ mod benchmarks {
         #[extrinsic_call]
         _(RawOrigin::Signed(sp_id.clone()), prove_sectors.clone());
 
-        check_prove_commit_sectors::<T>(sp_id, prove_sectors, total_fee, 1);
+        check_prove_commit_sectors::<T>(sp_id, prove_sectors, total_fee);
     }
 
     impl_benchmark_test_suite!(Pallet, crate::test::new_test_ext(), crate::mock::Test);
@@ -94,6 +92,7 @@ fn prepare_pre_commit_sectors<T>(
     n: u32,
 ) -> (
     AccountId32,
+    BoundedVec<ClientDealProposalOf<T>, T::MaxDeals>,
     BoundedVec<SectorPreCommitInfo<BlockNumberFor<T>>, ConstU32<{ MAX_SECTORS_PER_CALL }>>,
 )
 where
@@ -108,11 +107,17 @@ where
     let data = BenchmarkData::<T>::load();
     let alice = create_account_with_balance::<T>(ALICE, EXISTENTIAL_DEPOSIT * 2);
     let sp = data.storage_provider();
-    create_and_register_storage_provider_with_balance::<T>(
-        &sp,
-        data.post_type,
-        EXISTENTIAL_DEPOSIT * 2,
+
+    pallet_balances::Pallet::<T>::make_free_balance_be(
+        &sp.account_id,
+        (EXISTENTIAL_DEPOSIT * 2).into(),
     );
+
+    assert_ok!(SpPallet::<T>::register_storage_provider(
+        RawOrigin::Signed(sp.account_id.clone()).into(),
+        sp.peer_id.clone(),
+        data.post_type,
+    ));
 
     assert_ok!(MarketPallet::<T>::add_balance(
         RawOrigin::Signed(sp.account_id.clone()).into(),
@@ -128,11 +133,14 @@ where
 
     assert_ok!(MarketPallet::<T>::publish_storage_deals(
         RawOrigin::Signed(sp.account_id.clone()).into(),
-        proposals,
+        proposals.clone(),
     ));
 
+    // Run to pre-commit period
+    run_to_block::<T>(data.pre_commit_block_number.into());
+
     let sectors = data.pre_commit_sectors(n);
-    (sp.account_id, sectors)
+    (sp.account_id, proposals, sectors)
 }
 
 fn check_pre_commit_sectors<T>(n: u32, sp_id: AccountId32)
@@ -162,26 +170,8 @@ where
     u64: TryFrom<BalanceOf<T>>,
 {
     let data = BenchmarkData::<T>::load();
-    let alice = create_account_with_balance::<T>(ALICE, EXISTENTIAL_DEPOSIT * 2);
-    let sp = data.storage_provider();
-    create_and_register_storage_provider_with_balance::<T>(
-        &sp,
-        data.post_type,
-        EXISTENTIAL_DEPOSIT * 2,
-    );
+    let (sp_id, proposals, sector_pre_commits) = prepare_pre_commit_sectors::<T>(n);
 
-    assert_ok!(MarketPallet::<T>::add_balance(
-        RawOrigin::Signed(sp.account_id.clone()).into(),
-        EXISTENTIAL_DEPOSIT.into()
-    ));
-
-    assert_ok!(MarketPallet::<T>::add_balance(
-        RawOrigin::Signed(alice.0.clone()).into(),
-        EXISTENTIAL_DEPOSIT.into()
-    ));
-
-    let proposals = data.deal_proposals(&alice, n);
-    let sectors_pre_commits = data.pre_commit_sectors(n);
     let prove_sectors = data.prove_commit_sectors(n);
     let total_collateral: u64 = proposals
         .iter()
@@ -191,21 +181,13 @@ where
         })
         .sum();
 
-    assert_ok!(MarketPallet::<T>::publish_storage_deals(
-        RawOrigin::Signed(sp.account_id.clone()).into(),
-        proposals,
-    ));
-
-    // Run to pre-commit period
-    run_to_block::<T>(data.pre_commit_block_number.into());
-
     assert_ok!(SpPallet::<T>::pre_commit_sectors(
-        RawOrigin::Signed(sp.account_id.clone()).into(),
-        sectors_pre_commits
+        RawOrigin::Signed(sp_id.clone()).into(),
+        sector_pre_commits
     ));
 
     assert_ok!(ProofsPallet::<T>::set_porep_verifying_key(
-        RawOrigin::Signed(sp.account_id.clone()).into(),
+        RawOrigin::Signed(sp_id.clone()).into(),
         data.seal_proof,
         data.verifying_key.to_vec(),
     ));
@@ -215,30 +197,34 @@ where
         BlockNumberFor::<T>::from(data.pre_commit_block_number) + T::PreCommitChallengeDelay::get(),
     );
 
-    (sp.account_id, prove_sectors, total_collateral as u32)
+    (sp_id, prove_sectors, total_collateral as u32)
 }
 
 fn check_prove_commit_sectors<T: crate::Config>(
     sp_id: T::AccountId,
     prove_sectors: BoundedVec<ProveCommitSector, ConstU32<MAX_SECTORS_PER_CALL>>,
     total_fee: u32,
-    n: u32,
 ) where
-    T: crate::Config,
+    T: crate::Config<
+            PeerId = BoundedPeerIdBytes,
+            AccountId = AccountId32,
+            OffchainSignature = MultiSignature,
+        > + primitives::configs::MarketProvider,
+    BlockNumberFor<T>: From<u64> + Into<u64> + Add,
+    u64: TryFrom<BalanceOf<T>>,
 {
     assert_eq!(
         MarketPallet::<T>::free(&sp_id),
         Some((EXISTENTIAL_DEPOSIT - total_fee).into()),
-        "n == {n}"
     );
 
     let state = SpPallet::<T>::storage_providers(sp_id).unwrap();
     let balance: BalanceOf<T> = 0_u32.into();
-    assert_eq!(state.pre_commit_deposits, balance, "n == {n}");
+    assert_eq!(state.pre_commit_deposits, balance);
 
     // check that the sector has been activated
     assert!(!state.sectors.is_empty());
-    for sector in prove_sectors {
+    for sector in &prove_sectors {
         assert!(state.sectors.contains_key(&sector.sector_number));
     }
     // always assigns first deadline and first partition, probably will fail when we change deadline
@@ -251,9 +237,9 @@ fn check_prove_commit_sectors<T: crate::Config>(
             }
         }
     }
-    assert_eq!(sectors.len(), n as usize, "n == {n}, state: {state:#?}");
-    assert!((0..n).all(|i| {
-        let sector_number = SectorNumber::new(i).unwrap();
+    assert_eq!(sectors.len(), prove_sectors.len(), "state: {state:#?}");
+    assert!(prove_sectors.iter().all(|sector| {
+        let sector_number = sector.sector_number;
         sectors.contains(&&sector_number)
     }));
 }
@@ -284,20 +270,4 @@ where
     let account = generate_benchmark_account::<T>(name);
     pallet_balances::Pallet::<T>::make_free_balance_be(&account.0, balance.into());
     account
-}
-
-fn create_and_register_storage_provider_with_balance<T>(
-    provider: &StorageProviderData,
-    post_proof: RegisteredPoStProof,
-    balance: u32,
-) where
-    T: crate::Config<AccountId = AccountId32, PeerId = BoundedPeerIdBytes>,
-{
-    pallet_balances::Pallet::<T>::make_free_balance_be(&provider.account_id, balance.into());
-
-    assert_ok!(SpPallet::<T>::register_storage_provider(
-        RawOrigin::Signed(provider.account_id.clone()).into(),
-        provider.peer_id.clone(),
-        post_proof,
-    ));
 }


### PR DESCRIPTION
### Description

The storage-provider benchmarks are essentially a sequence of operations where each benchmark wants to measure a different operation. Each operation's benchmark is split into a `prepare_` and `check_` function, originally to get rust-analyzer support, but with this refactor `prepare_prove_commit_sectors` calls `prepare_pre_commit_sectors` instead of duplicating the code.

I also inlined `create_and_register_storage_provider_with_balance` because after this refactor it was only used in one place.