### PR TITLE
refactor(sp): Move `assign_proving_period_offset` to primitives

### DIFF
--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -56,7 +56,9 @@ pub mod pallet {
             DeadlineInfo as ExternalDeadlineInfo, Market, ProofVerification,
             StorageProviderValidation,
         },
-        proofs::{derive_prover_id, PublicReplicaInfo, RegisteredPoStProof},
+        proofs::{
+            assign_proving_period_offset, derive_prover_id, PublicReplicaInfo, RegisteredPoStProof,
+        },
         randomness::{draw_randomness, AuthorVrfHistory, DomainSeparationTag},
         sector::{ProveCommitSector, SectorNumber, SectorPreCommitInfo},
         PartitionNumber, MAX_DEALS_PER_SECTOR, MAX_PARTITIONS_PER_DEADLINE,
@@ -71,7 +73,7 @@ pub mod pallet {
             DeclareFaultsParams, DeclareFaultsRecoveredParams, FaultDeclaration,
             RecoveryDeclaration,
         },
-        proofs::{assign_proving_period_offset, SubmitWindowedPoStParams},
+        proofs::SubmitWindowedPoStParams,
         sector::{
             ProveCommitResult, SectorOnChainInfo, SectorPreCommitOnChainInfo,
             TerminateSectorsParams, TerminationDeclaration,
@@ -397,8 +399,7 @@ pub mod pallet {
                 &owner,
                 current_block,
                 T::WPoStProvingPeriod::get(),
-            )
-            .map_err(|_| Error::<T>::ConversionError)?;
+            );
 
             let local_proving_start = calculate_first_proving_period_start::<BlockNumberFor<T>>(
                 current_block,

--- a/pallets/storage-provider/src/proofs.rs
+++ b/pallets/storage-provider/src/proofs.rs
@@ -8,7 +8,6 @@ use primitives::{
     MAX_POST_PROOFS_PER_BLOCK, MAX_POST_PROOF_BYTES,
 };
 use scale_info::TypeInfo;
-use sp_core::blake2_64;
 
 /// Proof of Spacetime data stored on chain.
 #[derive(RuntimeDebug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
@@ -31,41 +30,4 @@ pub struct SubmitWindowedPoStParams {
     pub partitions: BoundedVec<PartitionNumber, ConstU32<MAX_PARTITIONS_PER_DEADLINE>>,
     /// The proof submission.
     pub proofs: BoundedVec<PoStProof, ConstU32<MAX_POST_PROOFS_PER_BLOCK>>,
-}
-
-/// Error type for proof operations.
-#[derive(RuntimeDebug)]
-pub enum ProofError {
-    Conversion,
-}
-
-/// Assigns proving period offset randomly in the range [0, WPOST_PROVING_PERIOD)
-/// by hashing the address and current block number.
-///
-/// Reference:
-/// * <https://github.com/filecoin-project/builtin-actors/blob/17ede2b256bc819dc309edf38e031e246a516486/actors/miner/src/lib.rs#L4886>
-pub(crate) fn assign_proving_period_offset<AccountId, BlockNumber>(
-    addr: &AccountId,
-    current_block: BlockNumber,
-    wpost_proving_period: BlockNumber,
-) -> Result<BlockNumber, ProofError>
-where
-    AccountId: Encode,
-    BlockNumber: sp_runtime::traits::BlockNumber,
-{
-    // Encode address and current block number
-    let mut addr = addr.encode();
-    let mut block_num = current_block.encode();
-    // Concatenate the encoded block number to the encoded address.
-    addr.append(&mut block_num);
-    // Hash the address and current block number for a pseudo-random offset.
-    let digest = blake2_64(&addr);
-    // Create a pseudo-random offset from the bytes of the hash of the address and current block number.
-    let offset = u64::from_be_bytes(digest);
-    // Convert into block number
-    let mut offset =
-        TryInto::<BlockNumber>::try_into(offset).map_err(|_| ProofError::Conversion)?;
-    // Mod with the proving period so it is within the valid range of [0, WPOST_PROVING_PERIOD)
-    offset %= wpost_proving_period;
-    Ok(offset)
 }

--- a/primitives/src/proofs.rs
+++ b/primitives/src/proofs.rs
@@ -2,7 +2,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_decode::DecodeAsType;
 use scale_encode::EncodeAsType;
 use scale_info::TypeInfo;
-use sp_core::blake2_256;
+use sp_core::{blake2_256, blake2_64};
 
 use crate::{commitment::RawCommitment, sector::SectorSize};
 
@@ -239,6 +239,44 @@ impl RegisteredPoStProof {
     pub const fn _2KiB() -> Self {
         Self::StackedDRGWindow2KiBV1P1
     }
+}
+
+/// Assigns proving period offset randomly in the range [0, WPOST_PROVING_PERIOD)
+/// by hashing the address and current block number.
+///
+///
+/// # Panics
+/// Panics if `wpost_proving_period` is larger than `u32::MAX`.
+///
+/// Reference:
+/// * <https://github.com/filecoin-project/builtin-actors/blob/17ede2b256bc819dc309edf38e031e246a516486/actors/miner/src/lib.rs#L4886>
+pub fn assign_proving_period_offset<AccountId, BlockNumber>(
+    addr: &AccountId,
+    current_block: BlockNumber,
+    wpost_proving_period: BlockNumber,
+) -> BlockNumber
+where
+    AccountId: Encode,
+    BlockNumber: sp_runtime::traits::BlockNumber,
+{
+    // Encode address and current block number
+    let mut addr = addr.encode();
+    let mut block_num = current_block.encode();
+    // Concatenate the encoded block number to the encoded address.
+    addr.append(&mut block_num);
+    // Hash the address and current block number for a pseudo-random offset.
+    let digest = blake2_64(&addr);
+    // Create a pseudo-random offset from the bytes of the hash of the address and current block number.
+    let mut offset = u64::from_be_bytes(digest);
+    let wpost_proving_period: u32 = wpost_proving_period
+        .try_into()
+        .unwrap_or_else(|_| panic!("wpost_proving_period must fit in a u32"));
+    // Mod with the proving period so it is within the valid range of [0, WPOST_PROVING_PERIOD)
+    offset %= wpost_proving_period as u64;
+    // Offset will now fit in a u32.
+    let offset = offset as u32;
+    // Convert into block number
+    BlockNumber::from(offset)
 }
 
 // serde_json requires std, hence, to test the serialization, we need:


### PR DESCRIPTION
### Description

PR 1 of many to introduce benchmarking of the storage-provider pallet's `submit_windowed_post` extrinsic.

This PR makes `assign_proving_period_offset` more widely accessible by moving it to the primitives crate.

### Important points for reviewers

Before this, the function first tried to convert a pseudo-random u64 into a BlockNumber, and returned an Err if the BlockNumber type was too small, then finally computed the offset modulo the proving period. After this PR, the function first verifies that the proving period fits in a u32 (~800 years), performs the modulo operation in 64 bits, and downcasts to a u32. If the proving period is too long, it panics instead of returning an Err.

To me it felt more natural for this operation to not fail for any reasonable input, and so the user doesn't have to consider the Err case.

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] Function error behaviour changed slightly.
- [x] Make sure that you described what this change does.
- [x] If there are follow-ups, have you created issues for them?
  - [x] This and upcoming PRs are a part of #739.
- [ ] Have you tested this solution?
  - The function has as many tests as before, which is none. If you think it's important I can add some just to lock down the current behaviour. 
- [x] Were there any alternative implementations considered?
    - [x] Keeping the Result return, but it seemed more like a distraction than a usable error.
- ~~[ ] Did you document new (or modified) APIs?~~
