### PR TITLE
test(sp): Use runtime benchmark testnet parameters in SP test benchmarks

### DIFF
--- a/pallets/storage-provider/benchmarks/src/mock.rs
+++ b/pallets/storage-provider/benchmarks/src/mock.rs
@@ -14,7 +14,8 @@ use sp_runtime::{
 type Block = frame_system::mocking::MockBlock<Test>;
 type BlockNumber = u64;
 
-const MINUTES: BlockNumber = 1;
+const MILLISECS_PER_BLOCK: u64 = 6000;
+const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 
 #[frame_support::runtime]
 mod runtime {
@@ -99,27 +100,27 @@ impl pallet_proofs::Config for Test {
 // Sourced from the Testnet runtime defined in <runtime/src/configs/mod.rs>.
 parameter_types! {
     // Storage Provider Pallet
-    pub const WPoStPeriodDeadlines: u64 = 10;
-    pub const WPoStProvingPeriod: BlockNumber = 40 * MINUTES;
-    pub const WPoStChallengeWindow: BlockNumber = 4 * MINUTES;
+    pub const WPoStProvingPeriod: BlockNumber = 6 * MINUTES;
+    pub const WPoStPeriodDeadlines: u64 = 3;
+    pub const WPoStChallengeWindow: BlockNumber = 2 * MINUTES;
     pub const WPoStChallengeLookBack: BlockNumber = MINUTES;
     pub const MinSectorExpiration: BlockNumber = 5 * MINUTES;
-    pub const MaxSectorExpiration: BlockNumber = 360 * MINUTES;
+    pub const MaxSectorExpiration: BlockNumber = 60 * MINUTES;
     pub const SectorMaximumLifetime: BlockNumber = 120 * MINUTES;
-    // NOTE: Changed from Testnet's 5 to 15 since the pre-commit delay is 10 blocks.
-    pub const MaxProveCommitDuration: BlockNumber = 15 * MINUTES;
+    pub const MaxProveCommitDuration: BlockNumber = 5 * MINUTES;
     pub const MaxPartitionsPerDeadline: u64 = 3000;
     pub const FaultMaxAge: BlockNumber = (5 * MINUTES) * 42;
-    pub const FaultDeclarationCutoff: BlockNumber = 2 * MINUTES;
-    // NOTE: Changed from Testnet's 0 to 10 to match the storage-provider client's `porep` command.
-    pub const PreCommitChallengeDelay: BlockNumber = 10;
+    pub const FaultDeclarationCutoff: BlockNumber = 1 * MINUTES;
+
     // <https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/runtime/src/runtime/policy.rs#L299>
     pub const AddressedSectorsMax: u64 = 25_000;
 
     // Market Pallet
+    pub const MinDealDuration: u64 = 5 * MINUTES;
+    pub const MaxDealDuration: u64 = 180 * MINUTES;
+
+    pub const PreCommitChallengeDelay: BlockNumber = 10;
     pub const MarketPalletId: PalletId = PalletId(*b"spMarket");
-    pub const MinDealDuration: u64 = 2 * MINUTES;
-    pub const MaxDealDuration: u64 = 30 * MINUTES;
 }
 
 /// Randomness generator used by tests.

--- a/pallets/storage-provider/src/lib.rs
+++ b/pallets/storage-provider/src/lib.rs
@@ -1275,13 +1275,13 @@ pub mod pallet {
 
             // TODO(@th7nder,31/07/2024): this approach is suboptimal, as it's time complexity is O(StorageProviders * PreCommitedSectors).
             // We can reduce this by indexing pre-committed sectors by BlockNumber in which they're supposed to be activated in PreCommit and remove them in ProveCommit.
-            log::info!(target: LOG_TARGET, "checking pre_commited_sectors for block: {:?}", current_block);
+            log::debug!(target: LOG_TARGET, "checking pre_commited_sectors for block: {:?}", current_block);
 
             // We cannot modify storage map while inside `iter_keys()` as docs say it's undefined results.
             // And we can use `alloc::Vec`, because it's bounded by StorageProviders data structure anyways.
             let storage_providers: Vec<_> = StorageProviders::<T>::iter_keys().collect();
             for storage_provider in storage_providers {
-                log::info!(target: LOG_TARGET, "checking storage provider {:?}", storage_provider);
+                log::debug!(target: LOG_TARGET, "checking storage provider {:?}", storage_provider);
                 let Ok(mut state) = StorageProviders::<T>::try_get(storage_provider.clone()) else {
                     log::error!(target: LOG_TARGET, "catastrophe, couldn't find a storage provider based on key. it should have been there...");
                     continue;
@@ -1380,7 +1380,7 @@ pub mod pallet {
         /// * <https://github.com/filecoin-project/builtin-actors/blob/82d02e58f9ef456aeaf2a6c737562ac97b22b244/actors/miner/src/state.rs#L1192>
         fn check_deadlines(current_block: BlockNumberFor<T>) {
             const LOG_TARGET: &'static str = "runtime::storage_provider::check_deadlines";
-            log::info!(target: LOG_TARGET, "block: {:?}", current_block);
+            log::debug!(target: LOG_TARGET, "block: {:?}", current_block);
 
             // We cannot modify storage map while inside `iter_keys()` as docs say it's undefined results.
             // And we can use `alloc::Vec`, because it's bounded by StorageProviders data structure anyways.
@@ -1388,14 +1388,14 @@ pub mod pallet {
             // TODO(@th7nder,13/08/2024): this approach is suboptimal, as it's time complexity is O(StorageProviders * PreCommitedSectors).
             // We can reduce this by indexing pre-committed sectors by BlockNumber in which they're supposed to be activated in PreCommit and remove them in ProveCommit.
             for storage_provider in storage_providers {
-                log::info!(target: LOG_TARGET, "block: {:?}, checking storage provider {:?}", current_block, storage_provider);
+                log::debug!(target: LOG_TARGET, "block: {:?}, checking storage provider {:?}", current_block, storage_provider);
                 let Ok(mut state) = StorageProviders::<T>::try_get(storage_provider.clone()) else {
                     log::error!(target: LOG_TARGET, "missing storage provider {:?} (should have been added before)", storage_provider);
                     continue;
                 };
 
                 if current_block < state.proving_period_start {
-                    log::info!(target: LOG_TARGET, "skipping checking sp: {:?} on block: {:?} < proving_start {:?}, because it hasn't started yet.",
+                    log::debug!(target: LOG_TARGET, "skipping checking sp: {:?} on block: {:?} < proving_start {:?}, because it hasn't started yet.",
                     storage_provider, current_block, state.proving_period_start);
                     continue;
                 }
@@ -1413,12 +1413,12 @@ pub mod pallet {
                 };
 
                 if !current_deadline.period_started() {
-                    log::info!(target: LOG_TARGET, "block: {:?}, period for deadline {:?}, sp {:?} has not yet started...", current_block, current_deadline.idx, storage_provider);
+                    log::debug!(target: LOG_TARGET, "block: {:?}, period for deadline {:?}, sp {:?} has not yet started...", current_block, current_deadline.idx, storage_provider);
                     continue;
                 }
 
                 if !current_deadline.has_elapsed() {
-                    log::info!(target: LOG_TARGET,
+                    log::debug!(target: LOG_TARGET,
                     "block: {:?}, deadline {:?} for sp {:?} not yet elapsed. open_at: {:?} < current {:?} < close_at {:?}",
                     current_block,
                     current_deadline.idx, storage_provider, current_deadline.open_at, current_block, current_deadline.close_at
@@ -1426,7 +1426,7 @@ pub mod pallet {
                     continue;
                 }
 
-                log::info!(target: LOG_TARGET, "block: {:?}, checking storage provider {:?} deadline: {:?}",
+                log::debug!(target: LOG_TARGET, "block: {:?}, checking storage provider {:?} deadline: {:?}",
                     current_block,
                     storage_provider,
                     current_deadline.idx,
@@ -1496,7 +1496,7 @@ pub mod pallet {
                         owner: storage_provider.clone(),
                         faulty_partitions: faulty_partitions.try_into().expect("should be able to create a BTreeMap with a MAX_PARTITIONS_PER_DEADLINE bound after iterating over a map with the same bound"),
                     })
-                } else {
+                } else if !deadline.partitions.is_empty() {
                     log::info!(target: LOG_TARGET, "block: {:?}, sp: {:?}, deadline: {:?} - all proofs submitted on time.",
                         current_block,
                         storage_provider,


### PR DESCRIPTION
### Description

PR 2 of many to introduce benchmarking of the storage-provider pallet's `submit_windowed_post` extrinsic.

This PR changes the runtime parameters for the storage-provider benchmarks to match what's in the node runtime. I also changed some logs to be debug instead of info to reduce noise. It's not that noisy right now but it'll definitely help later.

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] None.
- [x] Make sure that you described what this change does.
- [x] If there are follow-ups, have you created issues for them?
  - [x] This and upcoming PRs are a part of #739.
- [x] Have you tested this solution?
- [x] Were there any alternative implementations considered?
  - [x] Having different (potentially faster) values for test and runtime benchmarks just causes more issues than it solves.
- ~~[ ] Did you document new (or modified) APIs?~~
