### PR TITLE
test(market): Use runtime benchmark testnet parameters in market test benchmarks

### DIFF
--- a/pallets/market/benchmarks/src/mock.rs
+++ b/pallets/market/benchmarks/src/mock.rs
@@ -83,8 +83,8 @@ parameter_types! {
 parameter_types! {
     // NOTE: Changed from Testnet's 0 to 10 to match the storage-provider client's `porep` command.
     pub const PreCommitChallengeDelay: BlockNumber = 10;
-    pub const MinDealDuration: u64 = 2 * MINUTES;
-    pub const MaxDealDuration: u64 = 30 * MINUTES;
+    pub const MinDealDuration: u64 = 5 * MINUTES;
+    pub const MaxDealDuration: u64 = 180 * MINUTES;
 }
 
 impl pallet_market::Config for Test {
@@ -115,18 +115,18 @@ impl CurrencyProvider for Test {
 // Sourced from the Testnet runtime defined in <runtime/src/configs/mod.rs>.
 parameter_types! {
     // Storage Provider Pallet
-    pub const WPoStPeriodDeadlines: u64 = 10;
-    pub const WPoStProvingPeriod: BlockNumber = 40 * MINUTES;
-    pub const WPoStChallengeWindow: BlockNumber = 4 * MINUTES;
+    pub const WPoStProvingPeriod: BlockNumber = 6 * MINUTES;
+    pub const WPoStPeriodDeadlines: u64 = 3;
+    pub const WPoStChallengeWindow: BlockNumber = 2 * MINUTES;
     pub const WPoStChallengeLookBack: BlockNumber = MINUTES;
     pub const MinSectorExpiration: BlockNumber = 5 * MINUTES;
-    pub const MaxSectorExpiration: BlockNumber = 360 * MINUTES;
+    pub const MaxSectorExpiration: BlockNumber = 60 * MINUTES;
     pub const SectorMaximumLifetime: BlockNumber = 120 * MINUTES;
-    // NOTE: Changed from Testnet's 5 to 15 since the pre-commit delay is 10 blocks.
-    pub const MaxProveCommitDuration: BlockNumber = 15 * MINUTES;
+    pub const MaxProveCommitDuration: BlockNumber = 5 * MINUTES;
     pub const MaxPartitionsPerDeadline: u64 = 3000;
     pub const FaultMaxAge: BlockNumber = (5 * MINUTES) * 42;
-    pub const FaultDeclarationCutoff: BlockNumber = 2 * MINUTES;
+    pub const FaultDeclarationCutoff: BlockNumber = 1 * MINUTES;
+
     // <https://github.com/filecoin-project/builtin-actors/blob/8d957d2901c0f2044417c268f0511324f591cb92/runtime/src/runtime/policy.rs#L299>
     pub const AddressedSectorsMax: u64 = 25_000;
 


### PR DESCRIPTION
### Description

PR 4 of many to introduce benchmarking of the storage-provider pallet's `submit_windowed_post` extrinsic.

This PR changes the runtime parameters for market benchmarks to match what's in the node runtime.

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] None.
- [x] Make sure that you described what this change does.
- [x] If there are follow-ups, have you created issues for them?
  - [x] This and upcoming PRs are a part of #739.
- [x] Have you tested this solution?
  - [x] Having different (potentially faster) values for test and runtime benchmarks just causes more issues than it solves.
- ~~[ ] Did you document new (or modified) APIs?~~
