### PR TITLE
test(sp): Generate PoSt benchmark data

### DIFF
--- a/primitives/src/test_data/benchmark_data.rs
+++ b/primitives/src/test_data/benchmark_data.rs
@@ -30,6 +30,7 @@ where
 {
     pub storage_provider_name: &'static str,
     pub porep_verifying_key: &'static [u8],
+    pub post_verifying_key: &'static [u8],
     pub seal_proof: RegisteredSealProof,
     pub post_type: RegisteredPoStProof,
     pub comm_p: Commitment<CommP>,
@@ -150,6 +151,7 @@ where
         BenchmarkData {
             storage_provider_name: "//StorageProvider",
             porep_verifying_key: include_bytes!("../../../test-fixtures/keys/8MiB.porep.vk.scale"),
+            post_verifying_key: include_bytes!("../../../test-fixtures/keys/8MiB.post.vk.scale"),
             seal_proof: RegisteredSealProof::StackedDRG8MiBV1,
             post_type: RegisteredPoStProof::StackedDRGWindow8MiBV1,
             comm_p: Commitment::<CommP>::from_cid(
@@ -177,6 +179,9 @@ where
                 .expect("valid commitment"),
                 porep_proof: include_bytes!(
                     "../../../test-fixtures/proofs/8MiB/0.sector.proof.porep.scale"
+                ),
+                post_proof: include_bytes!(
+                    "../../../test-fixtures/proofs/8MiB/0.sector.proof.post.scale"
                 ),
             }],
             timeline: {

--- a/primitives/src/test_data/sector_data.rs
+++ b/primitives/src/test_data/sector_data.rs
@@ -11,4 +11,5 @@ pub struct SectorData {
     pub comm_r: Commitment<CommR>,
     pub comm_d: Commitment<CommD>,
     pub porep_proof: &'static [u8],
+    pub post_proof: &'static [u8],
 }

--- a/storage-provider/client/src/commands/mod.rs
+++ b/storage-provider/client/src/commands/mod.rs
@@ -12,6 +12,7 @@ use primitives::{proofs::RegisteredSealProof, DealId};
 use storagext::{
     deser::DeserializablePath,
     multipair::{MultiPairArgs, MultiPairSigner},
+    runtime::storage_provider::calls::types::register_storage_provider::WindowPostProofType,
     types::market::{ClientDealProposal as SxtClientDealProposal, DealProposal as SxtDealProposal},
 };
 use url::Url;
@@ -61,6 +62,11 @@ pub enum CliError {
 
     #[error("PoRep params for seal proof {seal_proof:?} not found, please download or generate them first")]
     MissingPoRepParams { seal_proof: RegisteredSealProof },
+
+    #[error(
+        "PoSt params for PoSt type {post_type:?} not found, please download or generate them first"
+    )]
+    MissingPoStParams { post_type: WindowPostProofType },
 }
 
 /// A CLI application that facilitates management operations over a running full

--- a/storage-provider/client/src/commands/proofs.rs
+++ b/storage-provider/client/src/commands/proofs.rs
@@ -550,7 +550,7 @@ fn post(
     sector_number: u32,
     comm_r: String,
     replica_path: PathBuf,
-    cache_directory: impl AsRef<Path>,
+    cache_directory: PathBuf,
     proof_parameters_path: PathBuf,
     post_type: RegisteredPoStProof,
 ) -> Result<(), CliError> {
@@ -581,7 +581,7 @@ fn post(
             .try_into()
             .map_err(|_| UtilsCommandError::CommRError)?,
         replica_path,
-        cache_path: cache_directory.as_ref().to_path_buf(),
+        cache_path: cache_directory,
     }];
     println!("Loading parameters...");
     let proof_parameters = post::load_groth16_parameters(proof_parameters_path)
@@ -790,7 +790,7 @@ async fn benchmark_data(input_path: PathBuf, sector_size: SectorSizeArg) -> Resu
             sector_number,
             comm_r.to_string(),
             sealed_sector_path,
-            &cache_directory,
+            cache_directory.path().to_path_buf(),
             post_params_path.clone(),
             post_type,
         )?;

--- a/storage-provider/client/src/commands/proofs.rs
+++ b/storage-provider/client/src/commands/proofs.rs
@@ -634,6 +634,7 @@ fn write_proof_file(
 pub struct BenchmarkData {
     pub storage_provider_name: String,
     pub porep_verifying_key_path: PathBuf,
+    pub post_verifying_key_path: PathBuf,
     pub seal_proof: RegisteredSealProof,
     pub post_type: RegisteredPoStProof,
     pub comm_p: Commitment<CommP>,
@@ -650,6 +651,7 @@ pub struct SectorData {
     pub comm_r: Commitment<CommR>,
     pub comm_d: Commitment<CommD>,
     pub porep_proof_path: PathBuf,
+    pub post_proof_path: PathBuf,
 }
 
 async fn benchmark_data(input_path: PathBuf, sector_size: SectorSizeArg) -> Result<(), CliError> {
@@ -730,9 +732,20 @@ async fn benchmark_data(input_path: PathBuf, sector_size: SectorSizeArg) -> Resu
     println!("--- Using pre-generated PoRep params for seal proof {seal_proof:?} ---");
     println!("{}", porep_params_path.display());
 
+    let post_params_path = params_root.join(format!("{sector_size}.{POST_PARAMS_EXT}"));
+    let post_params_vk_path = keys_root.join(format!("{sector_size}.{POST_VK_EXT_SCALE}"));
+    if !tokio::fs::try_exists(&post_params_path).await?
+        || !tokio::fs::try_exists(&post_params_vk_path).await?
+    {
+        return Err(CliError::MissingPoStParams { post_type });
+    }
+    println!("--- Using pre-generated PoSt params for seal proof {seal_proof:?} ---");
+    println!("{}", post_params_path.display());
+
     let mut benchmark_data = BenchmarkData {
         storage_provider_name: PROVIDER_NAME.to_owned(),
         porep_verifying_key_path: porep_params_vk_path,
+        post_verifying_key_path: post_params_vk_path,
         seal_proof,
         post_type,
         comm_p,
@@ -768,6 +781,24 @@ async fn benchmark_data(input_path: PathBuf, sector_size: SectorSizeArg) -> Resu
         let porep_proof_path = proofs_root.join(&porep_file_name);
         tokio::fs::copy(output_path.path().join(&porep_file_name), &porep_proof_path).await?;
 
+        println!("--- Creating PoSt proof for sector {sector_number} ---");
+        let sealed_sector_path = output_path.path().join(format!("{}.sector.sealed", sector_number));
+        post(
+            &signer_key,
+            timeline.deadline_challenge_block().0.into(),
+            Some(output_path.path().to_path_buf()),
+            sector_number,
+            comm_r.to_string(),
+            sealed_sector_path,
+            &cache_directory,
+            post_params_path.clone(),
+            post_type,
+        )?;
+
+        let post_file_name = format!("{sector_number}.{POST_PROOF_EXT}");
+        let post_proof_path = proofs_root.join(&post_file_name);
+        tokio::fs::copy(output_path.path().join(&post_file_name), &post_proof_path).await?;
+
         benchmark_data.sectors.push(SectorData {
             sector_number: SectorNumber::new(sector_number)
                 .expect("sector IDs <= MAX_SECTORS_PER_CALL are safe"),
@@ -775,6 +806,7 @@ async fn benchmark_data(input_path: PathBuf, sector_size: SectorSizeArg) -> Resu
             comm_r,
             comm_d,
             porep_proof_path,
+            post_proof_path,
         });
         drop(output_path);
         drop(cache_directory);
@@ -790,6 +822,7 @@ fn emit_benchmark_constructor(benchmark_data: &BenchmarkData) -> String {
     let BenchmarkData {
         storage_provider_name,
         porep_verifying_key_path,
+        post_verifying_key_path,
         seal_proof,
         post_type,
         comm_p,
@@ -806,6 +839,7 @@ fn emit_benchmark_constructor(benchmark_data: &BenchmarkData) -> String {
                 comm_r,
                 comm_d,
                 porep_proof_path,
+                post_proof_path,
             } = sector;
             let sector_number = u32::from(*sector_number);
             let padded_piece_size = padded_piece_size.deref();
@@ -813,6 +847,8 @@ fn emit_benchmark_constructor(benchmark_data: &BenchmarkData) -> String {
             let comm_d = emit_commitment(comm_d);
             let porep_proof_path_rel = PathBuf::from(BENCH_DATA_DIR_TO_ROOT).join(porep_proof_path);
             let porep_proof_path = porep_proof_path_rel.to_string_lossy();
+            let post_proof_path_rel = PathBuf::from(BENCH_DATA_DIR_TO_ROOT).join(post_proof_path);
+            let post_proof_path = post_proof_path_rel.to_string_lossy();
             quote::quote! {
                 SectorData {
                     sector_number: SectorNumber::new(#sector_number).expect("valid sector ID"),
@@ -820,6 +856,7 @@ fn emit_benchmark_constructor(benchmark_data: &BenchmarkData) -> String {
                     comm_r: #comm_r,
                     comm_d: #comm_d,
                     porep_proof: include_bytes!(#porep_proof_path),
+                    post_proof: include_bytes!(#post_proof_path),
                 }
             }
         })
@@ -828,6 +865,9 @@ fn emit_benchmark_constructor(benchmark_data: &BenchmarkData) -> String {
     let porep_verifying_key_path_rel =
         PathBuf::from(BENCH_DATA_DIR_TO_ROOT).join(porep_verifying_key_path);
     let porep_verifying_key_path = porep_verifying_key_path_rel.to_string_lossy();
+    let post_verifying_key_path_rel =
+        PathBuf::from(BENCH_DATA_DIR_TO_ROOT).join(post_verifying_key_path);
+    let post_verifying_key_path = post_verifying_key_path_rel.to_string_lossy();
     let seal_proof = format_ident!("{seal_proof:?}");
     let post_type = format_ident!("{post_type:?}");
     let comm_p = emit_commitment(comm_p);
@@ -836,6 +876,7 @@ fn emit_benchmark_constructor(benchmark_data: &BenchmarkData) -> String {
         BenchmarkData {
             storage_provider_name: #storage_provider_name,
             porep_verifying_key: include_bytes!(#porep_verifying_key_path),
+            post_verifying_key: include_bytes!(#post_verifying_key_path),
             seal_proof: RegisteredSealProof::#seal_proof,
             post_type: RegisteredPoStProof::#post_type,
             comm_p: #comm_p,

--- a/storage-provider/client/src/commands/proofs.rs
+++ b/storage-provider/client/src/commands/proofs.rs
@@ -287,8 +287,11 @@ impl ProofsCommand {
                 sector_number,
                 challenge_block,
             } => {
+                let Some(signer) = Option::<MultiPairSigner>::from(signer_key) else {
+                    return Err(UtilsCommandError::NoSigner)?;
+                };
                 post(
-                    signer_key,
+                    &signer,
                     challenge_block,
                     output_path,
                     sector_number,
@@ -541,19 +544,16 @@ fn generate_post_params(
 }
 
 fn post(
-    signer_key: MultiPairArgs,
+    signer: &MultiPairSigner,
     challenge_block: u64,
     output_path: Option<PathBuf>,
     sector_number: u32,
     comm_r: String,
     replica_path: PathBuf,
-    cache_directory: PathBuf,
+    cache_directory: impl AsRef<Path>,
     proof_parameters_path: PathBuf,
     post_type: RegisteredPoStProof,
 ) -> Result<(), CliError> {
-    let Some(signer) = Option::<MultiPairSigner>::from(signer_key) else {
-        return Err(UtilsCommandError::NoSigner)?;
-    };
     let entropy = signer.account_id().encode();
     let randomness = get_randomness(
         DomainSeparationTag::WindowedPoStChallengeSeed,
@@ -581,7 +581,7 @@ fn post(
             .try_into()
             .map_err(|_| UtilsCommandError::CommRError)?,
         replica_path,
-        cache_path: cache_directory,
+        cache_path: cache_directory.as_ref().to_path_buf(),
     }];
     println!("Loading parameters...");
     let proof_parameters = post::load_groth16_parameters(proof_parameters_path)

--- a/storage-provider/client/src/commands/proofs.rs
+++ b/storage-provider/client/src/commands/proofs.rs
@@ -782,7 +782,9 @@ async fn benchmark_data(input_path: PathBuf, sector_size: SectorSizeArg) -> Resu
         tokio::fs::copy(output_path.path().join(&porep_file_name), &porep_proof_path).await?;
 
         println!("--- Creating PoSt proof for sector {sector_number} ---");
-        let sealed_sector_path = output_path.path().join(format!("{}.sector.sealed", sector_number));
+        let sealed_sector_path = output_path
+            .path()
+            .join(format!("{}.sector.sealed", sector_number));
         post(
             &signer_key,
             timeline.deadline_challenge_block().0.into(),


### PR DESCRIPTION
### Description

PR 6 of many to introduce benchmarking of the storage-provider pallet's `submit_windowed_post` extrinsic.

This PR adds code for generating PoSt benchmark data and embeds it for 8MiB.

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] None.
- [x] Make sure that you described what this change does.
- [x] If there are follow-ups, have you created issues for them?
  - [x] This and upcoming PRs are a part of #739.
- [x] Have you tested this solution?
- ~~[ ] Were there any alternative implementations considered?~~
- ~~[ ] Did you document new (or modified) APIs?~~
