### PR TITLE
fix(sp): remove cli args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14026,7 +14026,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "cid 0.11.1",
- "clap",
  "filecoin-hashers",
  "filecoin-proofs",
  "fr32",

--- a/storage-provider/common/Cargo.toml
+++ b/storage-provider/common/Cargo.toml
@@ -18,7 +18,6 @@ codec = { workspace = true }
 filecoin-hashers.workspace = true
 filecoin-proofs.workspace = true
 
-clap = { workspace = true, features = ["derive"], optional = true }
 fr32.workspace = true
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -89,7 +89,6 @@ where
 
 /// Configuration for the sealing process.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-// #[cfg_attr(feature = "clap", derive(::clap::Args))]
 pub struct SealingConfiguration {
     /// The percentage above which a sector is considered "full", defaults to 95% of the registered
     /// sector size.

--- a/storage-provider/common/src/config/sealing.rs
+++ b/storage-provider/common/src/config/sealing.rs
@@ -89,7 +89,7 @@ where
 
 /// Configuration for the sealing process.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "clap", derive(::clap::Args))]
+// #[cfg_attr(feature = "clap", derive(::clap::Args))]
 pub struct SealingConfiguration {
     /// The percentage above which a sector is considered "full", defaults to 95% of the registered
     /// sector size.
@@ -102,11 +102,6 @@ pub struct SealingConfiguration {
         // The custom serializer enables custom validations
         deserialize_with = "fill_threshold_deserializer"
     )]
-    #[cfg_attr(feature = "clap", arg(
-        long,
-        default_value_t = default_fill_threshold(),
-        value_parser = fill_threshold_parser
-    ))]
     pub fill_threshold: u8,
 
     /// The amount of time to wait before sealing an unfilled sector, defaults to 6 hours.
@@ -114,7 +109,6 @@ pub struct SealingConfiguration {
         default = "default_wait_deals_delay",
         deserialize_with = "duration_deserializer"
     )]
-    #[cfg_attr(feature = "clap", arg(long, default_value = "6h", value_parser = duration_value_parser))]
     pub wait_deals_delay: Duration,
 
     /// The amount of time before a sector's earliest deal start; once hit, the sector is sealed &
@@ -123,7 +117,6 @@ pub struct SealingConfiguration {
         default = "default_pre_commit_submission_slack",
         deserialize_with = "duration_deserializer"
     )]
-    #[cfg_attr(feature = "clap", arg(long, default_value = "1h", value_parser = duration_value_parser))]
     pub pre_commit_submission_slack: Duration,
 }
 
@@ -139,14 +132,4 @@ impl Default for SealingConfiguration {
             pre_commit_submission_slack: default_pre_commit_submission_slack(),
         }
     }
-}
-
-/// Parses an integer between 0 and 100, values outside the range are considered invalid
-/// and return an error.
-#[cfg(feature = "clap")]
-fn fill_threshold_parser(src: &str) -> Result<u8, String> {
-    src.trim()
-        .parse::<u8>()
-        .map_err(|err| err.to_string())
-        .and_then(validate_percentage)
 }

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -16,7 +16,7 @@ opencl = ["polka-storage-proofs/opencl", "polka-storage-proofs/std", "polka-stor
 # "Homegrown" crates
 mater = { workspace = true }
 polka-storage-proofs = { workspace = true, default-features = false }
-polka-storage-provider-common = { workspace = true, features = ["clap"] }
+polka-storage-provider-common = { workspace = true }
 primitives = { workspace = true, features = ["clap", "serde", "std"] }
 primitives-p2p = { workspace = true, features = ["serde"] }
 storagext = { workspace = true, features = ["clap"] }

--- a/storage-provider/server/src/config.rs
+++ b/storage-provider/server/src/config.rs
@@ -5,7 +5,6 @@ use std::{
     str::FromStr,
 };
 
-use clap::Args;
 use libp2p::{identity::Keypair, Multiaddr, PeerId};
 use polka_storage_provider_common::config::sealing::SealingConfiguration;
 use primitives::proofs::{RegisteredPoStProof, RegisteredSealProof};
@@ -42,33 +41,27 @@ fn default_p2p_multiaddrs() -> Vec<Multiaddr> {
     ]
 }
 
-#[derive(Debug, Clone, Deserialize, Args)]
-#[group(multiple = true, conflicts_with = "config")]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationArgs {
     /// The server's listen address.
     #[serde(default = "default_upload_listen_address")]
-    #[arg(long, default_value_t = default_upload_listen_address())]
     pub(crate) upload_listen_address: SocketAddr,
 
     /// The server's listen address.
     #[serde(default = "default_rpc_listen_address")]
-    #[arg(long, default_value_t = default_rpc_listen_address())]
     pub(crate) rpc_listen_address: SocketAddr,
 
     /// The target parachain node's address.
     #[serde(default = "default_node_address")]
-    #[arg(long, default_value_t = default_node_address())]
     pub(crate) node_url: Url,
 
     /// RocksDB storage directory.
     /// Defaults to a temporary random directory, like `/tmp/<random>/deals_database`.
-    #[arg(long)]
     pub(crate) database_directory: Option<PathBuf>,
 
     /// Piece storage directory.
     /// Defaults to a temporary random directory, like `/tmp/<random>/...`.
-    #[arg(long)]
     pub(crate) storage_directory: Option<PathBuf>,
 
     /// The number of prove commits to be run in parallel.
@@ -77,19 +70,16 @@ pub struct ConfigurationArgs {
     /// Creating a replica is memory-heavy process.
     /// E.g. With 2KiB sector sizes and 16GiB of RAM, it goes OOM at 4 parallel.
     #[serde(default = "default_parallel_prove_commits")]
-    #[arg(long, default_value_t = default_parallel_prove_commits())]
     pub(crate) parallel_prove_commits: NonZero<usize>,
 
     // NOTE: the following parameters are marked as "not required" so the CLI doesn't require them
     // when --config is used, otherwise, they're very much required
     /// Proof of Replication proof type.
     #[serde(default = "RegisteredSealProof::_2KiB")]
-    #[arg(long, required = false)]
     pub(crate) seal_proof: RegisteredSealProof,
 
     /// Proof of Spacetime proof type.
     #[serde(default = "RegisteredPoStProof::_2KiB")]
-    #[arg(long, required = false)]
     pub(crate) post_proof: RegisteredPoStProof,
 
     /// Proving Parameters for PoRep proof, corresponding to given `seal_proof` sector size.
@@ -98,7 +88,6 @@ pub struct ConfigurationArgs {
     /// Testing/temporary parameters can be generated via `polka-storage-provider-client proofs porep-params` command.
     /// Note that when you generate keys, for local testnet,
     /// **they need to be set** via an extrinsic pallet-proofs::set_porep_verifyingkey.
-    #[arg(long, required = false)]
     pub(crate) porep_parameters: PathBuf,
 
     /// Proving Parameters for PoSt proof, corresponding to given `post_proof` sector size.
@@ -107,35 +96,28 @@ pub struct ConfigurationArgs {
     /// Testing/temporary parameters can be generated via `polka-storage-provider-client proofs post-params` command.
     /// Note that when you generate keys, for local testnet,
     /// **they need to be set** via an extrinsic pallet-proofs::set_post_verifyingkey.
-    #[arg(long, required = false)]
     pub(crate) post_parameters: PathBuf,
 
     /// P2P ED25519 private key
     #[serde(deserialize_with = "deser_keypair")]
-    #[arg(long, value_parser = keypair_value_parser, required = false)]
     pub(crate) p2p_key: Keypair,
 
     /// P2P listen address.
     #[serde(default = "default_p2p_multiaddrs")]
-    #[arg(long, value_delimiter = ',', num_args = 1.., default_values_t = default_p2p_multiaddrs())]
     pub(crate) p2p_listen_addresses: Vec<Multiaddr>,
 
-    #[arg(long)]
     pub(crate) public_secure_upload_url: Option<String>,
 
-    #[arg(long)]
     pub(crate) public_secure_rpc_url: Option<String>,
 
     /// Rendezvous multiaddr that the node registers to.
-    #[arg(long, required = false)]
     pub(crate) rendezvous_point_address: Multiaddr,
 
     /// PeerID of the rendezvous node used.
     #[serde(deserialize_with = "deserialize_string_to_peer_id")]
-    #[arg(long, required = false)]
     pub(crate) rendezvous_point: PeerId,
 
-    #[clap(flatten)]
+    // #[clap(flatten)]
     #[serde(default)]
     pub(crate) sealing_configuration: SealingConfiguration,
 }

--- a/storage-provider/server/src/config.rs
+++ b/storage-provider/server/src/config.rs
@@ -117,7 +117,6 @@ pub struct ConfigurationArgs {
     #[serde(deserialize_with = "deserialize_string_to_peer_id")]
     pub(crate) rendezvous_point: PeerId,
 
-    // #[clap(flatten)]
     #[serde(default)]
     pub(crate) sealing_configuration: SealingConfiguration,
 }

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -210,12 +210,9 @@ pub struct ServerCli {
     #[command(flatten)]
     multipair: MultiPairArgs,
 
-    #[command(flatten)]
-    args: Option<ConfigurationArgs>,
-
     /// Path to the server configuration file.
     #[arg(long)]
-    config: Option<PathBuf>,
+    config: PathBuf,
 }
 
 /// A valid server configuration. To be created using [`ServerConfiguration::try_from`].
@@ -284,27 +281,19 @@ impl TryFrom<ServerCli> for Server {
     type Error = ServerError;
 
     fn try_from(value: ServerCli) -> Result<Self, Self::Error> {
-        let args: ConfigurationArgs = if let Some(config) = value.config {
-            let config = config.canonicalize()?;
-            match config.extension() {
-                Some(ext) if ext == "toml" => {
-                    let config = std::fs::read_to_string(config)?;
-                    // NOTE: without the type anotation a warning about 2024 edition is issued
-                    toml::from_str::<ConfigurationArgs>(&config)?
-                }
-                Some(ext) if ext == "json" => {
-                    serde_json::from_reader(std::fs::File::open(config)?)?
-                }
-                Some(ext) => {
-                    println!("{:?}", ext);
-                    return Err(ServerError::InvalidConfig("unsupported file format"));
-                }
-                None => return Err(ServerError::InvalidConfig("could not detect file format")),
+        let config = value.config.canonicalize()?;
+        let args = match config.extension() {
+            Some(ext) if ext == "toml" => {
+                let config = std::fs::read_to_string(config)?;
+                // NOTE: without the type anotation a warning about 2024 edition is issued
+                toml::from_str::<ConfigurationArgs>(&config)?
             }
-        } else {
-            value.args.expect(
-                "if `config == None` and `args_required_else_help = true`, then args must be Some",
-            )
+            Some(ext) if ext == "json" => serde_json::from_reader(std::fs::File::open(config)?)?,
+            Some(ext) => {
+                println!("{:?}", ext);
+                return Err(ServerError::InvalidConfig("unsupported file format"));
+            }
+            None => return Err(ServerError::InvalidConfig("could not detect file format")),
         };
 
         if args.post_proof.sector_size() != args.seal_proof.sector_size() {


### PR DESCRIPTION
### Description

Removes the CLI args, using only the config.

There's still a follow up coming to add a command to dump a default configuration.


### Checklist


- [x] Make sure that you described what this change does.
- [x] Have you tested this solution?