### PR TITLE
fix(storagext): replace u64 with BlockNumber

### DIFF
--- a/storagext/cli/src/cmd/system.rs
+++ b/storagext/cli/src/cmd/system.rs
@@ -18,7 +18,7 @@ pub(crate) enum SystemCommand {
     /// Wait for a specific block height
     WaitForHeight {
         /// Block heights to wait for
-        height: u64,
+        height: storagext::BlockNumber,
 
         /// Wait for finalized blocks only
         #[arg(long, default_value_t = false)]

--- a/storagext/lib/src/clients/system.rs
+++ b/storagext/lib/src/clients/system.rs
@@ -1,17 +1,19 @@
 use std::future::Future;
 
+use crate::BlockNumber;
+
 pub trait SystemClientExt {
     /// Get the current height of the chain.
     /// It returns latest non-finalized block.
     fn height(
         &self,
         wait_for_finalization: bool,
-    ) -> impl Future<Output = Result<u64, subxt::Error>>;
+    ) -> impl Future<Output = Result<BlockNumber, subxt::Error>>;
 
     /// Wait for the chain to reach a specific height.
     fn wait_for_height(
         &self,
-        height: u64,
+        height: BlockNumber,
         wait_for_finalization: bool,
     ) -> impl Future<Output = Result<(), subxt::Error>>;
 }
@@ -19,7 +21,7 @@ pub trait SystemClientExt {
 impl SystemClientExt for crate::runtime::client::Client {
     /// Get the current height of the chain.
     /// It returns latest non-finalized block.
-    async fn height(&self, wait_for_finalization: bool) -> Result<u64, subxt::Error> {
+    async fn height(&self, wait_for_finalization: bool) -> Result<BlockNumber, subxt::Error> {
         let mut block_stream = if wait_for_finalization {
             // NOTE: This is not the best way to implement this
             // see the source for .at_latest() for a possibly better version
@@ -39,7 +41,7 @@ impl SystemClientExt for crate::runtime::client::Client {
     /// Wait for the chain to reach a specific height.
     async fn wait_for_height(
         &self,
-        height: u64,
+        height: BlockNumber,
         wait_for_finalization: bool,
     ) -> Result<(), subxt::Error> {
         let mut block_stream = if wait_for_finalization {


### PR DESCRIPTION
### Description

First of a bunch of small PRs that replace the "static" type u64 with the BlockNumber alias, for both consistency and to lower the amount of changes in the chain migration *back* to u32