### PR TITLE
fix: remove sc_cli from the SP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14108,7 +14108,6 @@ dependencies = [
  "primitives-p2p",
  "rand",
  "rocksdb",
- "sc-cli",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/storage-provider/server/Cargo.toml
+++ b/storage-provider/server/Cargo.toml
@@ -38,7 +38,6 @@ libp2p = { workspace = true, features = ["cbor", "dns", "identify", "macros", "n
 libp2p-length-prefix-codec = { workspace = true }
 rand = { workspace = true }
 rocksdb = { workspace = true }
-sc-cli = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sp-runtime = { workspace = true }

--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -168,9 +168,6 @@ pub enum ServerError {
     #[error("URL parse error: {0}")]
     ParseUrl(#[from] url::ParseError),
 
-    #[error(transparent)]
-    SubstrateCli(#[from] sc_cli::Error),
-
     #[error("Error occurred while working with a car file: {0}")]
     Mater(#[from] mater::Error),
 


### PR DESCRIPTION
As the title describes. This change alone removes something like 400 crates (I know it sounds insane but it is indeed something like this) from the dependency tree of the SP