### PR TITLE
fix(runtime): Fix duplicate balances in genesis

### DIFF
--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -52,10 +52,7 @@ fn testnet_genesis(
             ..Default::default()
         },
         collator_selection: CollatorSelectionConfig {
-            invulnerables: invulnerables
-                .iter()
-                .map(|(acc, _)| acc.clone())
-                .collect::<Vec<_>>(),
+            invulnerables: invulnerables.keys().cloned().collect::<Vec<_>>(),
             candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
             ..Default::default()
         },

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -1,4 +1,4 @@
-use alloc::{vec, vec::Vec};
+use alloc::{collections::BTreeMap, vec, vec::Vec};
 
 use cumulus_primitives_core::ParaId;
 use parachains_common::AuraId;
@@ -25,8 +25,8 @@ pub fn template_session_keys(keys: AuraId) -> SessionKeys {
 }
 
 fn testnet_genesis(
-    invulnerables: Vec<(AccountId, AuraId)>,
-    endowed_accounts: Vec<(AccountId, Balance)>,
+    invulnerables: BTreeMap<AccountId, AuraId>,
+    endowed_accounts: BTreeMap<AccountId, Balance>,
     root: AccountId,
 ) -> Value {
     let post_1gib_vk = include_bytes!("../../test-fixtures/keys/1GiB.post.vk.scale");
@@ -43,7 +43,7 @@ fn testnet_genesis(
 
     let config = RuntimeGenesisConfig {
         balances: BalancesConfig {
-            balances: endowed_accounts,
+            balances: endowed_accounts.into_iter().collect(),
         },
         parachain_info: ParachainInfoConfig {
             // There is no reasonable default here - but at least 1000 is taken by AssetHub, so it should
@@ -54,8 +54,7 @@ fn testnet_genesis(
         collator_selection: CollatorSelectionConfig {
             invulnerables: invulnerables
                 .iter()
-                .cloned()
-                .map(|(acc, _)| acc)
+                .map(|(acc, _)| acc.clone())
                 .collect::<Vec<_>>(),
             candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
             ..Default::default()
@@ -100,7 +99,7 @@ fn testnet_genesis(
 fn local_testnet_genesis() -> Value {
     testnet_genesis(
         // initial collators.
-        vec![
+        [
             (
                 Sr25519Keyring::Alice.to_account_id(),
                 Sr25519Keyring::Alice.public().into(),
@@ -109,9 +108,10 @@ fn local_testnet_genesis() -> Value {
                 Sr25519Keyring::Bob.to_account_id(),
                 Sr25519Keyring::Bob.public().into(),
             ),
-        ],
+        ]
+        .into(),
         Sr25519Keyring::well_known()
-            .map(|k| (k.to_account_id(), 1u128 << 60))
+            .map(|k| (k.to_account_id(), (1u128 << 60) as Balance))
             .chain(
                 // This is a nice default for `maat/tests/real_world.rs`.
                 // Add balance to Charlie - Storage Provider.
@@ -142,7 +142,7 @@ fn local_testnet_genesis() -> Value {
 fn development_config_genesis() -> Value {
     testnet_genesis(
         // initial collators.
-        vec![
+        [
             (
                 Sr25519Keyring::Alice.to_account_id(),
                 Sr25519Keyring::Alice.public().into(),
@@ -151,9 +151,10 @@ fn development_config_genesis() -> Value {
                 Sr25519Keyring::Bob.to_account_id(),
                 Sr25519Keyring::Bob.public().into(),
             ),
-        ],
+        ]
+        .into(),
         Sr25519Keyring::well_known()
-            .map(|k| (k.to_account_id(), 1u128 << 60))
+            .map(|k| (k.to_account_id(), (1u128 << 60) as Balance))
             .collect(),
         Sr25519Keyring::Alice.to_account_id(),
     )


### PR DESCRIPTION
### Description

After merging the market balances with pallet_balances, there's some duplicate accounts in the genesis. With this change, the accounts are stored in a BTreeMap, meaning the later (more specific) values override the earlier.

### Checklist

- [x] Are there important points that reviewers should know?
  - [x] No
- [x] Make sure that you described what this change does.
- [x] If there are follow-ups, have you created issues for them?
  - [x] No
- [ ] Have you tested this solution?
  - Still running locally, but wanted to put up the PR in the meantime.
- [ ] Were there any alternative implementations considered?
- ~~[ ] Did you document new (or modified) APIs?~~
