### PR TITLE
fix(sp/mater): streamed extraction on download

### DIFF
--- a/mater/cli/src/extract.rs
+++ b/mater/cli/src/extract.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, pin::pin};
 
+use futures::StreamExt;
 use mater::{Error, FileReader};
 use tokio::{
     fs::File,
-    io::{AsyncReadExt, BufReader},
+    io::{AsyncReadExt, AsyncWriteExt, BufReader},
 };
 
 /// Arbitrary value, it's just so the buffer doesn't constantly resize while loading the first bytes
@@ -15,7 +16,7 @@ pub(crate) async fn extract_file_from_car(
     output_path: &PathBuf,
     overwrite: bool,
 ) -> Result<(), Error> {
-    let output_file = if overwrite {
+    let mut output_file = if overwrite {
         File::create(&output_path).await?
     } else {
         File::create_new(&output_path).await?
@@ -27,21 +28,32 @@ pub(crate) async fn extract_file_from_car(
         // a possible alternative could be implementing a Reader that takes an AsyncRead
         // and makes it AsyncSeek by keeping read contents in memory and forward seeks (where
         // forward means that said part of the stream hasn't been loaded into memory yet) start
-        // loading file as needed before returning the new position
+        // loading file as needed before returning the new position.
 
         let mut buffer = Vec::with_capacity(STDIN_BUFFER_START_CAPACITY);
         let mut buffered_stdin = BufReader::new(tokio::io::stdin());
         buffered_stdin.read_to_end(&mut buffer).await?;
-        FileReader::from_vec(buffer)
-            .await?
-            .copy_to_writer(output_file)
-            .await
+
+        let mut reader = FileReader::from_vec(buffer).await?;
+        let root = *reader.roots().await?.get(0).ok_or(Error::EmptyRootsError)?;
+
+        let mut chunks = pin!(reader.chunk_stream(root));
+        while let Some(chunk) = chunks.next().await {
+            let chunk = chunk?;
+            output_file.write_all(&chunk).await?;
+        }
     } else {
-        FileReader::from_path(input_path)
-            .await?
-            .copy_to_writer(output_file)
-            .await
+        let mut reader = FileReader::from_path(input_path).await?;
+        let root = *reader.roots().await?.get(0).ok_or(Error::EmptyRootsError)?;
+
+        let mut chunks = pin!(reader.chunk_stream(root));
+        while let Some(chunk) = chunks.next().await {
+            let chunk = chunk?;
+            output_file.write_all(&chunk).await?;
+        }
     }
+
+    Ok(())
 }
 
 /// Tests for file extraction.

--- a/mater/lib/src/convert/reader.rs
+++ b/mater/lib/src/convert/reader.rs
@@ -5,12 +5,12 @@ use std::{
 };
 
 use async_stream::try_stream;
-use futures::{Stream, TryStreamExt};
+use futures::{future, Stream, TryStreamExt};
 use ipld_core::{cid::Cid, codec::Codec};
 use ipld_dagpb::{DagPbCodec, PbNode};
 use tokio::{
     fs::File,
-    io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWriteExt},
+    io::{AsyncRead, AsyncSeek, AsyncSeekExt},
 };
 
 use crate::{
@@ -22,9 +22,6 @@ use crate::{
 
 /// Extracts the raw data from a CARv2 file.
 /// It expects the CAR file to have only 1 root.
-///
-/// Disambiguation: this writer is not a [`File`](tokio::fs::File) writer,
-/// but rather a file writer in the CAR file format sense.
 pub struct FileReader<R> {
     reader: R,
     index: HashMap<Cid, BlockMetadata>,
@@ -113,12 +110,9 @@ where
     }
 
     /// Traverse the tree under the given [`Cid`], yielding the data in the leaves.
-    fn tree_stream<'a>(
-        &'a mut self,
-        cid: &'a Cid,
-    ) -> impl Stream<Item = Result<(Cid, Vec<u8>), Error>> + 'a {
+    fn tree_stream(mut self, cid: Cid) -> impl Stream<Item = Result<(Cid, Vec<u8>), Error>> {
         try_stream! {
-            let block_metadata = self.index.get(&cid).ok_or_else(|| Error::MissingCid(*cid))?;
+            let block_metadata = self.index.get(&cid).ok_or_else(|| Error::MissingCid(cid))?;
             let mut queue = VecDeque::new();
             queue.push_back(block_metadata);
 
@@ -152,35 +146,21 @@ where
         }
     }
 
-    /// Writes the content tree for the given [`Cid`] into `w`.
-    pub async fn copy_tree<W>(&mut self, cid: &Cid, mut w: W) -> Result<(), Error>
-    where
-        W: AsyncWriteExt + Unpin,
-    {
-        let loader = self.tree_stream(cid);
-        tokio::pin!(loader);
-        while let Some((_, block)) = loader.try_next().await? {
-            w.write_all(block.as_slice()).await?;
-        }
-        w.flush().await?;
-        Ok(())
-    }
-
-    /// Writes the content tree from the root into `w`.
+    /// Returns a stream of the chunks of the tree under the provided [`Cid`].
     ///
-    /// Assumes the file at least one root and will copy the file under the first root.
-    pub async fn copy_to_writer<W>(&mut self, mut writer: W) -> Result<(), Error>
-    where
-        W: AsyncWriteExt + Unpin,
-    {
-        let root = self.roots().await?[0];
-        self.copy_tree(&root, &mut writer).await
+    /// To retrieve a full file, use [`FileReader::roots`] to retrieve the root
+    /// before using [`chunk_stream`].
+    pub fn chunk_stream(self, cid: Cid) -> impl Stream<Item = Result<Vec<u8>, Error>> {
+        self.tree_stream(cid)
+            .and_then(|(_, chunk)| future::ok(chunk))
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::{io::Cursor, path::Path};
+    use std::path::Path;
+
+    use futures::StreamExt;
 
     use crate::{test_utils::assert_buffer_eq, FileReader};
 
@@ -190,14 +170,19 @@ mod test {
             .await
             .unwrap();
         let root = loader.roots().await.unwrap()[0];
-        let mut out_check = Cursor::new(vec![1u8; 4096]);
-        loader.copy_tree(&root, &mut out_check).await.unwrap();
+
+        let mut buffer = vec![];
+        loader
+            .chunk_stream(root)
+            .for_each(|res| {
+                let chunk = res.unwrap();
+                buffer.extend(chunk);
+                futures::future::ready(())
+            })
+            .await;
 
         let expected = [0u8; 524288].as_slice();
-        let inner = out_check.into_inner();
-        let result = inner.as_slice();
-
-        assert_buffer_eq!(expected, result);
+        assert_buffer_eq!(expected, buffer.as_slice());
     }
 
     async fn load_and_compare<P1, P2>(original: P1, path: P2)
@@ -208,11 +193,18 @@ mod test {
         let original = tokio::fs::read(original).await.unwrap();
         let mut car = FileReader::from_path(path).await.unwrap();
 
-        let mut out_buffer: Vec<u8> = vec![];
         let root = car.roots().await.unwrap()[0];
-        car.copy_tree(&root, &mut out_buffer).await.unwrap();
 
-        crate::test_utils::assert_buffer_eq!(original, &out_buffer);
+        let mut out_buffer = vec![];
+        car.chunk_stream(root)
+            .for_each(|res| {
+                let chunk = res.unwrap();
+                out_buffer.extend(chunk);
+                futures::future::ready(())
+            })
+            .await;
+
+        assert_buffer_eq!(original, &out_buffer);
     }
 
     #[tokio::test]
@@ -220,9 +212,17 @@ mod test {
         let mut car = FileReader::from_path("tests/fixtures/car_v2/empty.car")
             .await
             .unwrap();
-        let mut out_buffer: Vec<u8> = vec![];
         let root = car.roots().await.unwrap()[0];
-        car.copy_tree(&root, &mut out_buffer).await.unwrap();
+
+        let mut out_buffer: Vec<u8> = vec![];
+        car.chunk_stream(root)
+            .for_each(|res| {
+                let chunk = res.unwrap();
+                out_buffer.extend(chunk);
+                futures::future::ready(())
+            })
+            .await;
+
         assert!(out_buffer.is_empty());
     }
 

--- a/storage-provider/server/src/storage.rs
+++ b/storage-provider/server/src/storage.rs
@@ -37,10 +37,7 @@ use tokio::{
     io::{AsyncRead, BufWriter},
     sync::mpsc::UnboundedSender,
 };
-use tokio_util::{
-    io::{ReaderStream, StreamReader},
-    sync::CancellationToken,
-};
+use tokio_util::{io::StreamReader, sync::CancellationToken};
 use tower_http::{
     cors::{Any, CorsLayer},
     trace::TraceLayer,

--- a/storage-provider/server/src/storage.rs
+++ b/storage-provider/server/src/storage.rs
@@ -1,4 +1,10 @@
-use std::{io, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    io::{self, ErrorKind},
+    net::SocketAddr,
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+};
 
 use axum::{
     body::Body,
@@ -314,25 +320,34 @@ async fn download(
     let (file_name, path) = content_path(&state.car_piece_storage_dir, cid);
     tracing::info!(?path, "file requested");
 
-    // Check if the file exists
-    if !path.exists() {
-        tracing::error!(?path, "file not found");
-        return Err((StatusCode::NOT_FOUND, "file not found".to_string()));
-    }
-
     // Open car file
     let file = File::open(&path).await.map_err(|e| {
-        tracing::error!(?e, ?path, "failed to open file");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to open file".to_string(),
-        )
+        if let ErrorKind::NotFound = e.kind() {
+            tracing::error!(?path, "file not found");
+            (StatusCode::NOT_FOUND, "file not found".to_string())
+        } else {
+            tracing::error!(?e, ?path, "failed to open file");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to open file".to_string(),
+            )
+        }
     })?;
 
-    // Convert the `AsyncRead` into a `Stream`
-    let stream = ReaderStream::new(file);
-    // Convert the `Stream` into the Body
-    let body = Body::from_stream(stream);
+    let mut reader = mater::FileReader::new(file)
+        .await
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+    let root = *reader
+        .roots()
+        .await
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?
+        .get(0)
+        .ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "malformed or corrupted file".to_string(),
+        ))?;
+    let body = Body::from_stream(reader.chunk_stream(root));
+
     // Response headers
     let headers = [
         (header::CONTENT_TYPE, "application/octet-stream"),


### PR DESCRIPTION
### Description

For some reason, the extraction endpoint was no longer sending extracted files.
Looking at the code, it makes perfect sense: the files weren't extracted (though at a certain point they were being sent extracted or at least extracted on the client)

Since clients don't really care for CAR files, and already build those behind the scenes, I made the endpoint extract the file on-demand.

I had to re-write some APIs since returning a stream from a `&mut self` isn't that cool when you need to send the stream through a `Body`