### PR TITLE
fix(sp): replace Arc<PathBuf> with PathBuf

### DIFF
--- a/storage-provider/server/src/main.rs
+++ b/storage-provider/server/src/main.rs
@@ -15,8 +15,8 @@ mod pipeline;
 mod storage;
 
 use std::{
-    collections::HashMap, env::temp_dir, fmt::Debug, net::SocketAddr, ops::Deref, path::PathBuf,
-    sync::Arc, time::Duration,
+    collections::HashMap, env::temp_dir, fmt::Debug, net::SocketAddr, path::PathBuf, sync::Arc,
+    time::Duration,
 };
 
 use clap::Parser;
@@ -441,26 +441,24 @@ impl Server {
         let deal_database = Arc::new(DealDB::new(self.database_directory)?);
 
         // Car piece storage directory — i.e. the CAR archives from the input streams
-        let car_piece_storage_dir = Arc::new(self.storage_directory.join(CAR_PIECE_DIRECTORY_NAME));
-        let unsealed_sector_storage_dir =
-            Arc::new(self.storage_directory.join(UNSEALED_SECTOR_DIRECTORY_NAME));
-        let sealed_sector_storage_dir =
-            Arc::new(self.storage_directory.join(SEALED_SECTOR_DIRECTORY_NAME));
-        let sealing_cache_dir = Arc::new(self.storage_directory.join(SEALING_CACHE_DIRECTORY_NANE));
-        let index_dir = Arc::new(self.storage_directory.join(INDEXER_DIRECTORY_NAME));
+        let car_piece_storage_dir = self.storage_directory.join(CAR_PIECE_DIRECTORY_NAME);
+        let unsealed_sectors_dir = self.storage_directory.join(UNSEALED_SECTOR_DIRECTORY_NAME);
+        let sealed_sectors_dir = self.storage_directory.join(SEALED_SECTOR_DIRECTORY_NAME);
+        let sealing_cache_dir = self.storage_directory.join(SEALING_CACHE_DIRECTORY_NANE);
+        let index_dir = self.storage_directory.join(INDEXER_DIRECTORY_NAME);
 
         // Create the storage directories
-        tokio::fs::create_dir_all(car_piece_storage_dir.as_ref()).await?;
-        tokio::fs::create_dir_all(unsealed_sector_storage_dir.as_ref()).await?;
-        tokio::fs::create_dir_all(sealed_sector_storage_dir.as_ref()).await?;
-        tokio::fs::create_dir_all(sealing_cache_dir.as_ref()).await?;
-        tokio::fs::create_dir_all(index_dir.as_ref()).await?;
+        tokio::fs::create_dir_all(&car_piece_storage_dir).await?;
+        tokio::fs::create_dir_all(&unsealed_sectors_dir).await?;
+        tokio::fs::create_dir_all(&sealed_sectors_dir).await?;
+        tokio::fs::create_dir_all(&sealing_cache_dir).await?;
+        tokio::fs::create_dir_all(&index_dir).await?;
 
         // Channel used to action the indexer
         let (indexer_tx, indexer_rx) = tokio::sync::mpsc::unbounded_channel::<IndexerMessage>();
         // Indexer underlying database
         let lid = Arc::new(RocksDBLid::new(RocksDBStateStoreConfig {
-            path: index_dir.deref().clone(),
+            path: index_dir,
         })?);
 
         let (pipeline_tx, pipeline_rx) = tokio::sync::mpsc::unbounded_channel::<PipelineMessage>();
@@ -481,7 +479,7 @@ impl Server {
             server_info: server_info.clone(),
             xt_client: xt_client.clone(),
             xt_keypair: self.multi_pair_signer.clone(),
-            car_piece_storage_dir: car_piece_storage_dir.clone(),
+            car_piece_storage_dir,
             deal_db: deal_database.clone(),
             listen_address: self.upload_listen_address,
             post_proof: self.post_proof,
@@ -492,8 +490,8 @@ impl Server {
         let pipeline_state = PipelineState {
             db: deal_database.clone(),
             server_info: server_info.clone(),
-            unsealed_sectors_dir: unsealed_sector_storage_dir.clone(),
-            sealed_sectors_dir: sealed_sector_storage_dir,
+            unsealed_sectors_dir,
+            sealed_sectors_dir,
             sealing_cache_dir,
             porep_parameters: Arc::new(self.porep_parameters),
             post_parameters: Arc::new(self.post_parameters),

--- a/storage-provider/server/src/pipeline/mod.rs
+++ b/storage-provider/server/src/pipeline/mod.rs
@@ -59,9 +59,9 @@ pub enum PipelineError {
 pub struct PipelineState {
     pub server_info: ServerInfo,
     pub db: Arc<DealDB>,
-    pub unsealed_sectors_dir: Arc<PathBuf>,
-    pub sealed_sectors_dir: Arc<PathBuf>,
-    pub sealing_cache_dir: Arc<PathBuf>,
+    pub unsealed_sectors_dir: PathBuf,
+    pub sealed_sectors_dir: PathBuf,
+    pub sealing_cache_dir: PathBuf,
     pub porep_parameters: Arc<PoRepParameters>,
     pub post_parameters: Arc<PoStParameters>,
 

--- a/storage-provider/server/src/storage.rs
+++ b/storage-provider/server/src/storage.rs
@@ -53,7 +53,7 @@ use crate::{
 /// Shared state of the storage server.
 pub struct StorageServerState {
     pub server_info: ServerInfo,
-    pub car_piece_storage_dir: Arc<PathBuf>,
+    pub car_piece_storage_dir: PathBuf,
 
     pub deal_db: Arc<DealDB>,
 
@@ -79,7 +79,7 @@ pub async fn start_upload_server(
     // Create a storage folder if it doesn't exist.
     if !state.car_piece_storage_dir.exists() {
         tracing::info!(folder = ?state.car_piece_storage_dir, "creating storage folder");
-        fs::create_dir_all(state.car_piece_storage_dir.as_ref()).await?;
+        fs::create_dir_all(&state.car_piece_storage_dir).await?;
     }
 
     tracing::info!("Starting HTTP storage server at: {}", state.listen_address);
@@ -214,7 +214,7 @@ async fn upload(
         };
 
         let field_reader = StreamReader::new(field.map_err(std::io::Error::other));
-        stream_contents_to_car(state.car_piece_storage_dir.clone().as_ref(), field_reader)
+        stream_contents_to_car(&state.car_piece_storage_dir, field_reader)
             .await
             .map_err(|err| {
                 tracing::error!(%err, "failed to store file into CAR archive");
@@ -228,7 +228,7 @@ async fn upload(
                 .into_data_stream()
                 .map_err(|err| io::Error::new(io::ErrorKind::Other, err)),
         );
-        stream_contents_to_car(state.car_piece_storage_dir.clone().as_ref(), body_reader)
+        stream_contents_to_car(&state.car_piece_storage_dir, body_reader)
             .await
             .map_err(|err| {
                 tracing::error!(%err, "failed to store file into CAR archive");
@@ -377,24 +377,28 @@ async fn download(
 }
 
 /// Returns the tuple of file name and path for a specified Cid.
-fn content_path(folder: &std::path::Path, cid: Cid) -> (String, PathBuf) {
+fn content_path<P>(folder: P, cid: Cid) -> (String, PathBuf)
+where
+    P: AsRef<std::path::Path>,
+{
     let name = format!("{cid}.car");
-    let path = folder.join(&name);
+    let path = folder.as_ref().join(&name);
     (name, path)
 }
 
 /// Reads bytes from the source and writes them to a CAR file.
-async fn stream_contents_to_car<R>(
-    folder: &std::path::Path,
+async fn stream_contents_to_car<R, P>(
+    folder: P,
     source: R,
 ) -> Result<Cid, Box<dyn std::error::Error>>
 where
     R: AsyncRead + Unpin,
+    P: AsRef<std::path::Path>,
 {
     // Temp file which will be used to store the CAR file content. The temp
     // director has a randomized name and is created in the same folder as the
     // finalized uploads are stored.
-    let temp_dir = tempfile::tempdir_in(folder)?;
+    let temp_dir = tempfile::tempdir_in(folder.as_ref())?;
     let temp_file_path = temp_dir.path().join("temp.car");
     tracing::trace!("writing file to {}", temp_file_path.display());
 
@@ -406,7 +410,7 @@ where
 
     // If the file is successfully written, we can now move it to the final
     // location.
-    let (_, final_content_path) = content_path(folder, cid);
+    let (_, final_content_path) = content_path(folder.as_ref(), cid);
     fs::rename(temp_file_path, &final_content_path).await?;
     tracing::info!(?final_content_path, "CAR file created");
 


### PR DESCRIPTION
### Description

Definitely not one that @Jinxit will be a fan of but I spotted this while I was looking into adding SQLite

There's no point in adding the Arc indirection here since we're always allocating a new path with the `.join`