### PR TITLE
fix: broken scripts

### DIFF
--- a/examples/deal_common.sh
+++ b/examples/deal_common.sh
@@ -2,8 +2,8 @@
 
 # Sets PIECE_CID and PIECE_SIZE based on the input file.
 function set_piece_vars {
-    INPUT_FILE=$1
-    INPUT_TMP_FILE=$2
+    local INPUT_FILE=$1
+    local INPUT_TMP_FILE=$2
 
     # Convert file to CARv2 format  
     echo "Converting ${INPUT_FILE} to CARv2 format..."
@@ -23,16 +23,16 @@ function set_latest_block {
 # Full publish deal flow.
 # INPUT_FILE should be set before calling.
 function publish_deal {
-    CLIENT=$1
-    PROVIDER=$2
-    PIECE_CID=$3
-    PIECE_SIZE=$4
-    START_BLOCK=$5
-    END_BLOCK=$6
-    CLIENT_ACCOUNT=$7
-    PROVIDER_ACCOUNT=$8
-    INPUT_FILE=$9
-    PORT="${10:-8001}"
+    local CLIENT=$1
+    local PROVIDER=$2
+    local PIECE_CID=$3
+    local PIECE_SIZE=$4
+    local START_BLOCK=$5
+    local END_BLOCK=$6
+    local CLIENT_ACCOUNT=$7
+    local PROVIDER_ACCOUNT=$8
+    local INPUT_FILE=$9
+    local PORT="${10:-8001}"
 
     URL="http://127.0.0.1:"$PORT""
 

--- a/examples/deal_functions.sh
+++ b/examples/deal_functions.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Sets PIECE_CID and PIECE_SIZE based on the input file.
+function set_piece_vars {
+    INPUT_FILE=$1
+    INPUT_TMP_FILE=$2
+
+    # Convert file to CARv2 format  
+    echo "Converting ${INPUT_FILE} to CARv2 format..."
+    target/release/mater-cli convert -q --overwrite "$INPUT_FILE" "$INPUT_TMP_FILE" > /dev/null 2>&1
+
+    echo "Calculating COMMP..."
+    COMMP="$(target/release/polka-storage-provider-client proofs commp ${INPUT_TMP_FILE})"
+    PIECE_CID=$(jq -r '.cid' <<< "$COMMP")
+    PIECE_SIZE=$(jq -r '.size' <<< "$COMMP")
+}
+
+# Sets latest finalized block from the chain
+function set_latest_block {
+    LATEST_BLOCK="$(./target/release/storagext-cli system get-height --wait-for-finalization | awk '{print $3}')"
+}
+
+# Full publish deal flow.
+# INPUT_FILE should be set before calling.
+function publish_deal {
+    CLIENT=$1
+    PROVIDER=$2
+    PIECE_CID=$3
+    PIECE_SIZE=$4
+    START_BLOCK=$5
+    END_BLOCK=$6
+    CLIENT_ACCOUNT=$7
+    PROVIDER_ACCOUNT=$8
+    INPUT_FILE=$9
+    PORT="${10:-8001}"
+
+    URL="http://127.0.0.1:"$PORT""
+
+    DEAL_JSON=$(
+        jq -n \
+    --arg piece_cid "$PIECE_CID" \
+    --argjson piece_size "$PIECE_SIZE" \
+    --argjson start_block "$START_BLOCK" \
+    --argjson end_block "$END_BLOCK" \
+    --arg client "$CLIENT_ACCOUNT" \
+    --arg provider "$PROVIDER_ACCOUNT" \
+    '{
+            "piece_cid": $piece_cid,
+            "piece_size": $piece_size,
+            "client": $client,
+            "provider": $provider,
+            "label": "",
+            "start_block": $start_block,
+            "end_block": $end_block,
+            "storage_price_per_block": 500,
+            "state": "Published"
+        }'
+    )
+
+    echo ""$CLIENT" is signing deal..."
+    SIGNED_DEAL_JSON="$(RUST_LOG=error target/release/polka-storage-provider-client sign-deal --sr25519-key "$CLIENT" "$DEAL_JSON")"
+
+    echo "Proposing deal between "$CLIENT_ACCOUNT" and "$PROVIDER_ACCOUNT"..."
+    DEAL_CID="$(curl -s -X POST -H "Content-Type: application/json" -d "$DEAL_JSON" "${URL}/api/v0/propose_deal" | jq -r)"
+
+    echo "Uploading deal with CID "$DEAL_CID" to storage provider..."
+    curl -s -X PUT -F "upload=@$INPUT_FILE" "${URL}/api/v0/upload/$DEAL_CID" > /dev/null 2>&1
+
+    echo "Publishing deal to ${PROVIDER}..."
+    curl -s -X POST -H "Content-Type: application/json" -d "$SIGNED_DEAL_JSON" "${URL}/api/v0/publish_deal" > /dev/null 2>&1
+}

--- a/examples/rpc_publish.sh
+++ b/examples/rpc_publish.sh
@@ -44,8 +44,8 @@ publish_deal \
     $PIECE_SIZE \
     $START_BLOCK \
     $END_BLOCK \
-    $(subkey inspect "${CLIENT}" | awk -F': +' '/SS58 Address/ {print $2}') \
-    $(subkey inspect "${PROVIDER}" | awk -F': +' '/SS58 Address/ {print $2}') \
+    $(subkey inspect "${CLIENT}" --output-type json | jq -r '.ss58Address') \
+    $(subkey inspect "${PROVIDER}" --output-type json | jq -r '.ss58Address') \
     "$INPUT_FILE"
 
 echo "Storage deal successfully published!"

--- a/examples/rpc_publish.sh
+++ b/examples/rpc_publish.sh
@@ -33,7 +33,7 @@ source "$(dirname "$0")/deal_common.sh"
 set_latest_block
 
 START_BLOCK=$((LATEST_BLOCK + 20))
-END_BLOCK=$((LATEST_BLOCK + 100))
+END_BLOCK=$((LATEST_BLOCK + 200))
 
 set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"
 

--- a/examples/rpc_publish.sh
+++ b/examples/rpc_publish.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 if [ "$#" -ne 1 ]; then
     echo "$0: input file required"
@@ -12,12 +11,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
 TMPDIR="${TMPDIR:-/tmp}"
-TMP_PATH="$TMPDIR/polka-storage"
+TMP_PATH="$TMPDIR/polka-storage-provider"
 
 mkdir -p "$TMP_PATH"
 
@@ -28,92 +27,25 @@ INPUT_FILE="$1"
 INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
 # CARv2 file location
 INPUT_TMP_FILE="$TMP_PATH/$INPUT_FILE_NAME.car"
-# Config file location
-CONFIG="$TMP_PATH/config.toml"
-# P2P Node variables
-P2P_PUBLIC_KEY="$TMP_PATH/public.pem"
-P2P_PRIVATE_KEY="$TMP_PATH/private.pem"
-P2P_BOOTSTRAP_PUBLIC_KEY="/tmp/zombienet/charlie-public.pem"
-P2P_ADDRESS="/ip4/127.0.0.1/tcp/62649"
-# Deal parameters JSON location
-DEAL_PARAMS="$TMP_PATH/deal_params.json"
 
-# Generate ED25519 private key
-openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY"
-# -outpubkey is only available in OpenSSL 3.4.0 onwards
-# https://github.com/openssl/openssl/commit/6c03fa21ed4bbc9fd6d3013fdf9f4646d231f831
-openssl pkey -in "$P2P_PRIVATE_KEY" -pubout -out "$P2P_PUBLIC_KEY"
+source "$(dirname "$0")/deal_functions.sh"
 
-# Generate Peer ID
-P2P_BOOTSTRAP_PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_BOOTSTRAP_PUBLIC_KEY")"
+set_latest_block
 
-# Convert file to CARv2 format
-target/release/mater-cli convert -q --overwrite "$INPUT_FILE" "$INPUT_TMP_FILE" &&
+START_BLOCK=$((LATEST_BLOCK + 20))
+END_BLOCK=$((LATEST_BLOCK + 100))
 
-# Calculate COMMP and set PIECE_CID and PIECE_SIZE
-INPUT_COMMP="$(target/release/polka-storage-provider-client proofs commp "$INPUT_TMP_FILE")"
-PIECE_CID="$(echo "$INPUT_COMMP" | jq -r ".cid")"
-PIECE_SIZE="$(echo "$INPUT_COMMP" | jq ".size")"
+set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"
 
-# Generate Peer ID from public key
-PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_PUBLIC_KEY")"
+publish_deal \
+    "$CLIENT" \
+    "$PROVIDER" \
+    "$PIECE_CID" \
+    $PIECE_SIZE \
+    $START_BLOCK \
+    $END_BLOCK \
+    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" \
+    "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y" \
+    "$INPUT_FILE"
 
-# echo config file in the file in the /tmp folder
-echo "seal_proof = '8MiB'
-post_proof = '8MiB'
-porep_parameters = 'target/params/8MiB.porep.params'
-post_parameters = 'target/params/8MiB.post.params'
-rendezvous_point_address = '$P2P_ADDRESS'
-p2p_key = '@$P2P_PRIVATE_KEY'
-rendezvous_point = '$P2P_BOOTSTRAP_PEER_ID'" > "$CONFIG"
-
-# echo deal parameters in the file in the /tmp folder
-echo '{ "minimum_price_per_block": 200, "deal_duration": { "lower": 50, "upper": 1800 }}' > "$DEAL_PARAMS"
-
-
-# It's a test setup based on the local verifying keys, everyone can run those extrinsics currently.
-# Each of the keys is different, because the processes are running in parallel.
-# If they were running in parallel on the same account, they'd conflict with each other on the transaction nonce.
-target/release/storagext-cli --sr25519-key "//Charlie" storage-provider register "$PEER_ID"
-
-wait
-
-# Setup deal parameters, has to go after registration.
-RUST_LOG=debug target/release/storagext-cli --sr25519-key "$PROVIDER" market publish-deal-parameters \
-    --deal-parameters @"$DEAL_PARAMS" &
-wait
-
-DEAL_JSON=$(
-    jq -n \
-   --arg piece_cid "$PIECE_CID" \
-   --argjson piece_size "$PIECE_SIZE" \
-   '{
-        "piece_cid": $piece_cid,
-        "piece_size": $piece_size,
-        "client": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        "provider": "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-        "label": "",
-        "start_block": 200,
-        "end_block": 250,
-        "storage_price_per_block": 500,
-        "state": "Published"
-    }'
-)
-SIGNED_DEAL_JSON="$(RUST_LOG=error target/release/polka-storage-provider-client sign-deal --sr25519-key "$CLIENT" "$DEAL_JSON")"
-
-(RUST_LOG=debug target/release/polka-storage-provider-server --sr25519-key "$PROVIDER" --config "$CONFIG") &
-sleep 5 # gives time for the server to start
-
-DEAL_CID="$(curl -X POST -H "Content-Type: application/json" -d "$DEAL_JSON" 'http://127.0.0.1:8001/api/v0/propose_deal' | jq -r)"
-echo "$DEAL_CID"
-
-# Regular upload
-# curl --upload-file "$INPUT_FILE" "http://localhost:8001/upload/$DEAL_CID"
-
-# Multipart upload
-curl -X PUT -F "upload=@$INPUT_FILE" "http://localhost:8001/upload/$DEAL_CID"
-
-curl -X POST -H "Content-Type: application/json" -d "$SIGNED_DEAL_JSON" 'http://127.0.0.1:8001/api/v0/publish_deal'
-
-# wait until user Ctrl+Cs so that the commitment can actually be calculated
-wait
+echo "Storage deal successfully published!"

--- a/examples/rpc_publish.sh
+++ b/examples/rpc_publish.sh
@@ -28,7 +28,7 @@ INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
 # CARv2 file location
 INPUT_TMP_FILE="$TMP_PATH/$INPUT_FILE_NAME.car"
 
-source "$(dirname "$0")/deal_functions.sh"
+source "$(dirname "$0")/deal_common.sh"
 
 set_latest_block
 
@@ -44,8 +44,8 @@ publish_deal \
     $PIECE_SIZE \
     $START_BLOCK \
     $END_BLOCK \
-    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" \
-    "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y" \
+    $(subkey inspect "${CLIENT}" | awk -F': +' '/SS58 Address/ {print $2}') \
+    $(subkey inspect "${PROVIDER}" | awk -F': +' '/SS58 Address/ {print $2}') \
     "$INPUT_FILE"
 
 echo "Storage deal successfully published!"

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -15,7 +15,7 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
-source "$(dirname "$0")/deal_functions.sh"
+source "$(dirname "$0")/deal_common.sh"
 
 CLIENT="//Alice"
 PROVIDER="//Charlie"

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -38,8 +38,8 @@ do
         $PIECE_SIZE \
         $START_BLOCK \
         $END_BLOCK \
-        $(subkey inspect "${CLIENT}" | awk -F': +' '/SS58 Address/ {print $2}') \
-        $(subkey inspect "${PROVIDER}" | awk -F': +' '/SS58 Address/ {print $2}') \
+        $(subkey inspect "${CLIENT}" --output-type json | jq -r '.ss58Address') \
+        $(subkey inspect "${PROVIDER}" --output-type json | jq -r '.ss58Address') \
         "$INPUT_FILE"
     echo "Published deal between ${PROVIDER} and ${CLIENT}"
 done

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -30,7 +30,7 @@ do
     set_latest_block
 
     START_BLOCK=$((i + $LATEST_BLOCK))
-    END_BLOCK=$((i + $LATEST_BLOCK + 100))
+    END_BLOCK=$((i + $LATEST_BLOCK + 200))
     publish_deal \
         "$CLIENT" \
         "$PROVIDER" \
@@ -38,8 +38,8 @@ do
         $PIECE_SIZE \
         $START_BLOCK \
         $END_BLOCK \
-        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" \
-        "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y" \
+        $(subkey inspect "${CLIENT}" | awk -F': +' '/SS58 Address/ {print $2}') \
+        $(subkey inspect "${PROVIDER}" | awk -F': +' '/SS58 Address/ {print $2}') \
         "$INPUT_FILE"
     echo "Published deal between ${PROVIDER} and ${CLIENT}"
 done

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 if [ "$#" -ne 1 ]; then
     echo "$0: input file required"
@@ -12,10 +11,11 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
+source "$(dirname "$0")/deal_functions.sh"
 
 CLIENT="//Alice"
 PROVIDER="//Charlie"
@@ -24,42 +24,24 @@ INPUT_FILE="$1"
 INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
 INPUT_TMP_FILE="/tmp/$INPUT_FILE_NAME.car"
 
-target/release/mater-cli convert -q --overwrite "$INPUT_FILE" "$INPUT_TMP_FILE" &&
-INPUT_COMMP="$(target/release/polka-storage-provider-client proofs commp "$INPUT_TMP_FILE")"
-PIECE_CID="$(echo "$INPUT_COMMP" | jq -r ".cid")"
-PIECE_SIZE="$(echo "$INPUT_COMMP" | jq ".size")"
-
-
-for i in $(seq 100 100 | tac);
+for i in $(seq 50 60);
 do
-    DEAL_JSON=$(
-        jq -n \
-    --arg piece_cid "$PIECE_CID" \
-    --argjson start_block "$i" \
-    --argjson piece_size "$PIECE_SIZE" \
-    '{
-            "piece_cid": $piece_cid,
-            "piece_size": $piece_size,
-            "client": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            "provider": "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-            "label": "",
-            "start_block": $start_block,
-            "end_block": 250,
-            "storage_price_per_block": 500,
-            "state": "Published"
-        }'
-    )
-    SIGNED_DEAL_JSON="$(RUST_LOG=error target/release/polka-storage-provider-client sign-deal --sr25519-key "$CLIENT" "$DEAL_JSON")"
+    set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"
+    set_latest_block
 
-    DEAL_CID="$(curl -X POST -H "Content-Type: application/json" -d "$DEAL_JSON" 'http://127.0.0.1:8001/api/v0/propose_deal' | jq -r)"
-    echo "-------------------------- Uploading deal $i..."
-    echo
-    curl -X PUT -F "upload=@$INPUT_FILE" "http://localhost:8001/upload/$DEAL_CID"
-
-    echo
-    echo "-------------------------- Publishing deal $i..."
-    curl -X POST -H "Content-Type: application/json" -d "$SIGNED_DEAL_JSON" 'http://127.0.0.1:8001/api/v0/publish_deal' &
+    START_BLOCK=$((i + $LATEST_BLOCK))
+    END_BLOCK=$((i + $LATEST_BLOCK + 100))
+    publish_deal \
+        "$CLIENT" \
+        "$PROVIDER" \
+        "$PIECE_CID" \
+        $PIECE_SIZE \
+        $START_BLOCK \
+        $END_BLOCK \
+        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" \
+        "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y" \
+        "$INPUT_FILE"
+    echo "Published deal between ${PROVIDER} and ${CLIENT}"
 done
 
-# wait until user Ctrl+Cs so that the commitment can actually be calculated
-wait
+echo 'Done publishing deals'

--- a/examples/rpc_replicated_file.sh
+++ b/examples/rpc_replicated_file.sh
@@ -38,7 +38,7 @@ for i in "${!ACCOUNTS[@]}"; do
     # Populate LATEST_BLOCK with the latest finalized block
     set_latest_block
     START_BLOCK=$((LATEST_BLOCK + 20))
-    END_BLOCK=$((LATEST_BLOCK + 100))
+    END_BLOCK=$((LATEST_BLOCK + 200))
 
     # Populate PIECE_CID and PIECE_SIZE
     set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"

--- a/examples/rpc_replicated_file.sh
+++ b/examples/rpc_replicated_file.sh
@@ -26,14 +26,14 @@ INPUT_FILE="$1"
 INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
 INPUT_TMP_FILE="/tmp/$INPUT_FILE_NAME.car"
 CLIENT="//Eve"
-CLIENT_ACCOUNT=$(subkey inspect "${CLIENT}" | awk -F': +' '/SS58 Address/ {print $2}')
+CLIENT_ACCOUNT=$(subkey inspect "${CLIENT}" --output-type json | jq -r '.ss58Address')
 declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
 declare -a PORTS=("8001" "8002" "8003")
 
 for i in "${!ACCOUNTS[@]}"; do
     PROVIDER="${ACCOUNTS[$i]}"
     PORT="${PORTS[$i]}"
-    PROVIDER_ACCOUNT=$(subkey inspect "${PROVIDER}" | awk -F': +' '/SS58 Address/ {print $2}')
+    PROVIDER_ACCOUNT=$(subkey inspect "${PROVIDER}" --output-type json | jq -r '.ss58Address')
 
     # Populate LATEST_BLOCK with the latest finalized block
     set_latest_block

--- a/examples/rpc_replicated_file.sh
+++ b/examples/rpc_replicated_file.sh
@@ -1,23 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# This script will publish a file to Alice, Bob and Charlie
+# This script will publish a file to Alice, Bob and Charlie 
+# with Eve being the client.
 # it is supposed to be used in tandem with start_sps.sh
-#
-# It only publishes a single deal to each but changing is simple
-# simply change the `seq` call in the `upload_file` function
-#
-# To retrieve the file from the multiple providers at once you can run:
-#
-# RUST_LOG=debug cargo r -r -p polka-fetch -- \
-#   --provider /ip4/127.0.0.1/tcp/47002 \
-#   --provider /ip4/127.0.0.1/tcp/46002 \
-#   --provider /ip4/127.0.0.1/tcp/45002 \
-# --output /tmp/t \
-# --overwrite \
-# --payload-cid bafybeiefli7iugocosgirzpny4t6yxw5zehy6khtao3d252pbf352xzx5q
-#
-# The CID is for the spaceglenda.jpg file
 
 if [ "$#" -ne 1 ]; then
     echo "$0: input file required"
@@ -29,118 +15,48 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
+source "$(dirname "$0")/deal_functions.sh"
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
 
-CLIENT="//Eve"
-
 INPUT_FILE="$1"
 INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
 INPUT_TMP_FILE="/tmp/$INPUT_FILE_NAME.car"
-
-target/release/mater-cli convert -q --overwrite "$INPUT_FILE" "$INPUT_TMP_FILE" &&
-INPUT_COMMP="$(target/release/polka-storage-provider-client proofs commp "$INPUT_TMP_FILE")"
-PIECE_CID="$(echo "$INPUT_COMMP" | jq -r ".cid")"
-PIECE_SIZE="$(echo "$INPUT_COMMP" | jq ".size")"
-
-function base_port {
-    case $1 in
-        "//Alice")
-            echo 45000
-            ;;
-        "//Bob")
-            echo 46000
-            ;;
-        "//Charlie")
-            echo 47000
-            ;;
-        *)
-            echo "unknown account"
-            exit 1
-            ;;
-    esac
-}
-
-function public_key {
-    case $1 in
-        "//Alice")
-            echo 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-            ;;
-        "//Bob")
-            echo 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-            ;;
-        "//Charlie")
-            echo 5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
-            ;;
-        "//Dave")
-            echo 5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy
-            ;;
-        "//Eve")
-            echo 5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
-            ;;
-        "//Ferdie")
-            echo 5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL
-            ;;
-        *)
-            echo "unknown account"
-            exit 1
-            ;;
-    esac
-}
-
-function upload_file {
-    ACCOUNT=$1
-    STORAGE_URL=$2
-    RPC_URL=$3
-
-    for i in $(seq 60 60 | tac);
-    do
-        DEAL_JSON=$(
-            jq -n \
-        --arg piece_cid "$PIECE_CID" \
-        --argjson piece_size "$PIECE_SIZE" \
-        --arg client_addr "$(public_key "$CLIENT")" \
-        --arg provider_addr "$(public_key "$ACCOUNT")" \
-        --argjson start_block "$i" \
-        '{
-                "piece_cid": $piece_cid,
-                "piece_size": $piece_size,
-                "client": $client_addr,
-                "provider": $provider_addr,
-                "label": "",
-                "start_block": $start_block,
-                "end_block": 250,
-                "storage_price_per_block": 500,
-                "state": "Published"
-            }'
-        )
-        SIGNED_DEAL_JSON="$(RUST_LOG=error target/release/polka-storage-provider-client sign-deal --sr25519-key "$CLIENT" "$DEAL_JSON")"
-
-        DEAL_CID="$(curl -X POST -H "Content-Type: application/json" -d "$DEAL_JSON" "$RPC_URL/api/v0/propose_deal" | jq -r)"
-        echo "-------------------------- Uploading deal $i..."
-        echo
-        curl -X PUT -F "upload=@$INPUT_FILE" "$STORAGE_URL/upload/$DEAL_CID"
-
-        echo
-        echo "-------------------------- Publishing deal $i..."
-        curl -X POST -H "Content-Type: application/json" -d "$SIGNED_DEAL_JSON" "$RPC_URL/api/v0/publish_deal"
-    done
-}
-
+CLIENT="//Eve"
+CLIENT_ACCOUNT=$(subkey inspect "${CLIENT}" | awk -F': +' '/SS58 Address/ {print $2}')
 declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
-for ACCOUNT in "${ACCOUNTS[@]}"; do
-    STORAGE_URL="http://127.0.0.1:$(base_port "$ACCOUNT")"
-    RPC_URL="http://127.0.0.1:$(echo "$(base_port "$ACCOUNT") + 1" | bc)"
-    # RETRIEVAL_URL="/ip4/127.0.0.1/tcp/$(echo "$(base_port "$ACCOUNT") + 2" | bc)"
+declare -a PORTS=("8001" "8002" "8003")
 
-    for i in $(seq 60 60 | tac);
-    do
-        upload_file "$ACCOUNT" "$STORAGE_URL" "$RPC_URL" &
-    done
+for i in "${!ACCOUNTS[@]}"; do
+    PROVIDER="${ACCOUNTS[$i]}"
+    PORT="${PORTS[$i]}"
+    PROVIDER_ACCOUNT=$(subkey inspect "${PROVIDER}" | awk -F': +' '/SS58 Address/ {print $2}')
+
+    # Populate LATEST_BLOCK with the latest finalized block
+    set_latest_block
+    START_BLOCK=$((LATEST_BLOCK + 20))
+    END_BLOCK=$((LATEST_BLOCK + 100))
+
+    # Populate PIECE_CID and PIECE_SIZE
+    set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"
+
+    # Publish deal
+    publish_deal \
+        "$CLIENT" \
+        "$PROVIDER" \
+        "$PIECE_CID" \
+        $PIECE_SIZE \
+        $START_BLOCK \
+        $END_BLOCK \
+        "$CLIENT_ACCOUNT" \
+        "$PROVIDER_ACCOUNT" \
+        "$INPUT_FILE" \
+        "$PORT"
+
+    echo "Published deal between "$CLIENT" and "$PROVIDER""
 done
 
-# wait until user Ctrl+Cs so that the commitment can actually be calculated
-wait
+echo "All deals published successfully"

--- a/examples/rpc_replicated_file.sh
+++ b/examples/rpc_replicated_file.sh
@@ -17,7 +17,7 @@ fi
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
-source "$(dirname "$0")/deal_functions.sh"
+source "$(dirname "$0")/deal_common.sh"
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1

--- a/examples/sp_common.sh
+++ b/examples/sp_common.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -e
+
+write_deal_parameters() {
+    local DEAL_PARAMS_PATH="$1"
+    local MINIMUM_PRICE_PER_BLOCK="${2:-200}"
+    local LOWER_DEAL_DURATION="${3:-50}"
+    local UPPER_DEAL_DURATION="${4:-5256000}"
+
+    echo "{ \"minimum_price_per_block\": $MINIMUM_PRICE_PER_BLOCK, \"deal_duration\": { \"lower\": $LOWER_DEAL_DURATION, \"upper\": $UPPER_DEAL_DURATION } }" > "$DEAL_PARAMS_PATH"
+}
+
+register_storage_provider() {
+    local SP_NAME="$1"
+    local PORT="$2"
+    local DEAL_PARAMS_PATH="$3"
+    local COLLATOR_WS_ADDR="${4:-"ws://127.0.0.1:42069"}"
+
+    SP_MULTIADDR="/ip4/127.0.0.1/tcp/$PORT"
+
+    echo "Registering storage provider $SP_NAME..."
+    RUST_LOG='debug,jsonrpsee-client=off' target/release/storagext-cli \
+        --sr25519-key "$SP_NAME" \
+        --node-rpc "$COLLATOR_WS_ADDR" \
+        storage-provider register \
+        --post-proof "8MiB" \
+        --deal-parameters @"$DEAL_PARAMS_PATH" \
+        "$SP_MULTIADDR"
+}
+
+generate_config_file() {
+    local CONFIG_FILE_PATH="$1"
+    local PORT="$2"
+    local DB_DIR="$3"
+    local STORAGE_DIR="$4"
+    local WAIT_DEALS_DELAY="${5:-1h}"
+    local COLLATOR_WS_ADDR="${6:-"ws://127.0.0.1:42069"}"
+
+    {
+        echo "seal_proof = '8MiB'"
+        echo "post_proof = '8MiB'"
+        echo "porep_parameters = 'target/params/8MiB.porep.params'"
+        echo "post_parameters = 'target/params/8MiB.post.params'"
+        echo "node_url = '$COLLATOR_WS_ADDR'"
+        echo "upload_listen_address = '127.0.0.1:$PORT'"
+
+        if [ -n "$DB_DIR" ]; then
+            echo "database_directory = '$DB_DIR'"
+        fi
+
+        if [ -n "$STORAGE_DIR" ]; then
+            echo "storage_directory = '$STORAGE_DIR'"
+        fi
+
+        echo "[sealing_configuration]"
+        echo "fill_threshold = 0"
+        echo "wait_deals_delay = '$WAIT_DEALS_DELAY'"
+        echo "pre_commit_submission_slack = '1m'"
+    } > "$CONFIG_FILE_PATH"
+}
+
+start_storage_provider() {
+    local SP_NAME="$1"
+    local CONFIG_FILE="$2"
+
+    echo "Starting storage provider $SP_NAME with config $CONFIG_FILE..."
+    RUST_LOG="tower_http=debug,polka_storage_provider_server=debug,yamux=off,multistream_select=off,jsonrpsee-client=off,libp2p=debug,storage_proofs_porep=debug,polka_storage_provider_common=debug" \
+        target/release/polka-storage-provider-server \
+        --sr25519-key "$SP_NAME" \
+        --config "$CONFIG_FILE"
+}

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -1,46 +1,32 @@
 #!/usr/bin/env bash
 set -e
 
+# Starts a single Storage Provider Charlie
+
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
-# requires the testnet to be running!
+source "$(dirname "$0")/sp_common.sh"
+
 export DISABLE_XT_WAIT_WARNING=1
+
+# CONFIGURATION
 TMPDIR="${TMPDIR:-/tmp}"
 TMP_PATH="$TMPDIR/polka-storage-provider"
-
-mkdir -p "$TMP_PATH"
-
-COLLATOR_WS_ADDR="ws://127.0.0.1:42069"
-SP_MULTIADDR="/ip4/127.0.0.1/tcp/8001"
 PROVIDER="//Charlie"
-# Config file location
+PORT="8001"
 CONFIG="$TMP_PATH/config.toml"
-# Deal parameters JSON location
 DEAL_PARAMS="$TMP_PATH/deal_params.json"
 
-echo '{ "minimum_price_per_block": 200, "deal_duration": { "lower": 50, "upper": 5256000 }}' > "$DEAL_PARAMS"
+# Ensure top-level TMP path exists
+mkdir -p "$TMP_PATH"
 
-echo "Registering storage provider "$PROVIDER"..."
-RUST_LOG='debug,jsonrpsee-client=off' target/release/storagext-cli \
-    --sr25519-key "$PROVIDER" \
-    --node-rpc "$COLLATOR_WS_ADDR" \
-    storage-provider register \
-    --post-proof "8MiB" \
-    --deal-parameters @"$DEAL_PARAMS" \
-    "$SP_MULTIADDR"
+# Write deal parameters
+write_deal_parameters "$DEAL_PARAMS"
+# Register Storage Provider
+register_storage_provider "$PROVIDER" "$PORT" "$DEAL_PARAMS"
 wait
 
-echo "seal_proof = '8MiB'
-post_proof = '8MiB'
-porep_parameters = 'target/params/8MiB.porep.params'
-post_parameters = 'target/params/8MiB.post.params'
-node_url = '$COLLATOR_WS_ADDR'
-[sealing_configuration]
-fill_threshold = 0
-wait_deals_delay = '1h'
-pre_commit_submission_slack = '1m'" > "$CONFIG"
-
-echo "Staring storage provider "$PROVIDER"..."
-RUST_LOG="polka_storage_provider_server=debug,tower_http=debug,yamux=off,multistream_select=off,jsonrpsee-client=off,libp2p=debug,storage_proofs_porep=debug,polka_storage_provider_common=debug" target/release/polka-storage-provider-server \
-    --sr25519-key "$PROVIDER" \
-    --config "$CONFIG"
+# Write config
+generate_config_file "$CONFIG" "$PORT"
+# Start Storage Provider
+start_storage_provider "$PROVIDER" "$CONFIG"

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
@@ -11,8 +10,8 @@ TMP_PATH="$TMPDIR/polka-storage-provider"
 
 mkdir -p "$TMP_PATH"
 
-COLLATOR_IP_ADDR="127.0.0.1"
-
+COLLATOR_WS_ADDR="ws://127.0.0.1:42069"
+SP_MULTIADDR="/ip4/127.0.0.1/tcp/8001"
 PROVIDER="//Charlie"
 # Config file location
 CONFIG="$TMP_PATH/config.toml"
@@ -21,25 +20,27 @@ DEAL_PARAMS="$TMP_PATH/deal_params.json"
 
 echo '{ "minimum_price_per_block": 200, "deal_duration": { "lower": 50, "upper": 5256000 }}' > "$DEAL_PARAMS"
 
+echo "Registering storage provider "$PROVIDER"..."
 RUST_LOG='debug,jsonrpsee-client=off' target/release/storagext-cli \
-    --sr25519-key "//Charlie" \
-    --node-rpc "ws://$COLLATOR_IP_ADDR:42069" \
+    --sr25519-key "$PROVIDER" \
+    --node-rpc "$COLLATOR_WS_ADDR" \
     storage-provider register \
     --post-proof "8MiB" \
     --deal-parameters @"$DEAL_PARAMS" \
-    "/ip4/127.0.0.1/tcp/8001"
+    "$SP_MULTIADDR"
 wait
 
 echo "seal_proof = '8MiB'
 post_proof = '8MiB'
 porep_parameters = 'target/params/8MiB.porep.params'
 post_parameters = 'target/params/8MiB.post.params'
-node_url = 'ws://$COLLATOR_IP_ADDR:42069'
+node_url = '$COLLATOR_WS_ADDR'
 [sealing_configuration]
 fill_threshold = 0
 wait_deals_delay = '1h'
 pre_commit_submission_slack = '1m'" > "$CONFIG"
 
+echo "Staring storage provider "$PROVIDER"..."
 RUST_LOG="polka_storage_provider_server=debug,tower_http=debug,yamux=off,multistream_select=off,jsonrpsee-client=off,libp2p=debug,storage_proofs_porep=debug,polka_storage_provider_common=debug" target/release/polka-storage-provider-server \
     --sr25519-key "$PROVIDER" \
     --config "$CONFIG"

--- a/examples/start_sps.sh
+++ b/examples/start_sps.sh
@@ -1,82 +1,57 @@
 #!/usr/bin/env bash
 set -e
 
-# Starts 3 storage providers — Alice, Bob & Charlie
-# You can check the configuration in their respective folders
+# Starts 3 Storage Providers — Alice, Bob & Charlie
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+source "$(dirname "$0")/sp_common.sh"
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
 
+# CONFIGURATION
 TMPDIR="${TMPDIR:-/tmp}"
 TMP_PATH="$TMPDIR/polka-storage-provider"
+DEAL_PARAMS="$TMP_PATH/deal_params.json"
+WAIT_DEALS_DELAY="5m"
 
+ACCOUNTS=("//Alice" "//Bob" "//Charlie")
+PORTS=("8001" "8002" "8003")
+
+# Ensure top-level TMP path exists
 mkdir -p "$TMP_PATH"
 
-COLLATOR_IP_ADDR="127.0.0.1"
-DEAL_PARAMS="$TMP_PATH/deal_params.json"
+# Write deal parameters
+write_deal_parameters "$DEAL_PARAMS"
 
-function register_storage_provider {
-    local SP_NAME="$1"
-    local SP_MULTIADDR_PORT="$2"
-    local SP_TMP_DIR="$TMP_PATH/${SP_NAME#//}"
+# Register each Storage Provider
+for i in "${!ACCOUNTS[@]}"; do
+    SP_NAME="${ACCOUNTS[$i]}"
+    SP_PORT="${PORTS[$i]}"
 
-    mkdir -p "$SP_TMP_DIR"
+    register_storage_provider "$SP_NAME" "$SP_PORT" "$DEAL_PARAMS"
+done
 
-    RUST_LOG="storagext=debug,storagext-cli=debug" target/release/storagext-cli \
-        --sr25519-key "$SP_NAME" \
-        --node-rpc "ws://$COLLATOR_IP_ADDR:42069" \
-        storage-provider register \
-        --post-proof "8MiB" \
-        --deal-parameters @"$DEAL_PARAMS" \
-        "/ip4/127.0.0.1/tcp/$SP_MULTIADDR_PORT"
-}
+wait
 
-function sp_tmp_dir {
-    echo "$TMP_PATH/$1"
-}
+for i in "${!ACCOUNTS[@]}"; do
+    SP_NAME="${ACCOUNTS[$i]}"
+    SP_PORT="${PORTS[$i]}"
+    SP_TMP_DIR="$TMP_PATH/${SP_NAME#//}"
 
-function main {
-    echo '{ "minimum_price_per_block": 200, "deal_duration": { "lower": 50, "upper": 5256000 }}' > "$DEAL_PARAMS"
-    declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
-    declare -a PORTS=("8001" "8002" "8003")
-    for i in "${!ACCOUNTS[@]}"; do
-        ACCOUNT="${ACCOUNTS[$i]}"
-        PORT="${PORTS[$i]}"
-        register_storage_provider "$ACCOUNT" "$PORT"
-    done
-    wait
+    DB_DIR="$SP_TMP_DIR/db"
+    STORAGE_DIR="$SP_TMP_DIR/storage"
+    CONFIG_FILE="$SP_TMP_DIR/config.toml"
 
-    for i in "${!ACCOUNTS[@]}"; do
-        ACCOUNT="${ACCOUNTS[$i]}"
-        PORT="${PORTS[$i]}"
-        ACCOUNT_DIR="$(sp_tmp_dir "$ACCOUNT#//")"
-        DB_DIR="$(sp_tmp_dir "$ACCOUNT#//")/db"
-        STORAGE_DIR="$(sp_tmp_dir "$ACCOUNT#//")/storage"
+    # Ensure DB and Storage path exist
+    mkdir -p "$DB_DIR" "$STORAGE_DIR"
 
-        mkdir -p "$DB_DIR"
-        mkdir -p "$STORAGE_DIR"
-        echo "
-            seal_proof = '8MiB'
-            post_proof = '8MiB'
-            porep_parameters = 'target/params/8MiB.porep.params'
-            post_parameters = 'target/params/8MiB.post.params'
-            node_url = 'ws://$COLLATOR_IP_ADDR:42069'
-            upload_listen_address = '127.0.0.1:$PORT'
-            database_directory = '$DB_DIR'
-            storage_directory = '$STORAGE_DIR'
-            [sealing_configuration]
-            fill_threshold = 0
-            wait_deals_delay = '5m'
-            pre_commit_submission_slack = '1m'" | sed 's/\s\+//' > "$ACCOUNT_DIR/config.toml"
+    # Generate config file
+    generate_config_file "$CONFIG_FILE" "$SP_PORT" "$DB_DIR" "$STORAGE_DIR" "$WAIT_DEALS_DELAY"
 
-        echo "Starting storage provider "$PROVIDER" with upload address 127.0.0.1:"$PORT"..."
-        RUST_LOG="tower_http=debug,polka_storage_provider_server=debug,polka_storage_provider_server::p2p=trace,yamux=off,multistream_select=off,polka_storage_provider_common=debug" target/release/polka-storage-provider-server \
-            --sr25519-key "$ACCOUNT" \
-            --config "$ACCOUNT_DIR/config.toml" &
-    done
-    wait
-}
+    # Start Storage Provider
+    start_storage_provider "$SP_NAME" "$CONFIG_FILE" &
+done
 
-main
+wait

--- a/examples/start_sps.sh
+++ b/examples/start_sps.sh
@@ -2,113 +2,79 @@
 set -e
 
 # Starts 3 storage providers — Alice, Bob & Charlie
-# Ports start at 45000 and increment 1000 for each, so 45000, 46000 & 47000
 # You can check the configuration in their respective folders
-#
-# It also sets up balances for all accounts — Alice, Bob, Charlie, Dave, Eve & Ferdie
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 # requires the testnet to be running!
 export DISABLE_XT_WAIT_WARNING=1
 
-mkdir -p /tmp/polka-storage-provider
+TMPDIR="${TMPDIR:-/tmp}"
+TMP_PATH="$TMPDIR/polka-storage-provider"
 
-P2P_BOOTSTRAP_ADDRESS="/ip4/127.0.0.1/tcp/62649"
-P2P_BOOTSTRAP_PUBLIC_KEY="/tmp/zombienet/charlie-public.pem"
+mkdir -p "$TMP_PATH"
+
+COLLATOR_IP_ADDR="127.0.0.1"
+DEAL_PARAMS="$TMP_PATH/deal_params.json"
 
 function register_storage_provider {
     local SP_NAME="$1"
-    local P2P_SP_KEY_DIR="/tmp/polka-storage-provider/$SP_NAME"
-    local P2P_PUBLIC_KEY="$P2P_SP_KEY_DIR/public.pem"
-    local P2P_PRIVATE_KEY="$P2P_SP_KEY_DIR/private.pem"
+    local SP_MULTIADDR_PORT="$2"
+    local SP_TMP_DIR="$TMP_PATH/${SP_NAME#//}"
 
-    mkdir -p "$P2P_SP_KEY_DIR"
+    mkdir -p "$SP_TMP_DIR"
 
-    # Generate ED25519 private key
-    openssl genpkey -algorithm ED25519 -out "$P2P_PRIVATE_KEY"
-    # -outpubkey is only available in OpenSSL 3.4.0 onwards
-    # https://github.com/openssl/openssl/commit/6c03fa21ed4bbc9fd6d3013fdf9f4646d231f831
-    openssl pkey -in "$P2P_PRIVATE_KEY" -pubout -out "$P2P_PUBLIC_KEY"
-
-    # Generate Peer ID
-    P2P_SP_PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_PUBLIC_KEY")"
-    echo "Generated new peer ID for $PROVIDER: $P2P_SP_PEER_ID"
-
-    # Get bootstrap P2P Peer ID. This works after running zombienet locally or in kubernetes
-    P2P_BOOTSTRAP_PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_BOOTSTRAP_PUBLIC_KEY")"
-    echo "Peer ID for bootstrap node: $P2P_BOOTSTRAP_PEER_ID"
-
-    RUST_LOG="storagext=debug,storagext-cli=debug" target/release/storagext-cli --sr25519-key "$SP_NAME" storage-provider register --post-proof "8MiB" "$P2P_SP_PEER_ID"
+    RUST_LOG="storagext=debug,storagext-cli=debug" target/release/storagext-cli \
+        --sr25519-key "$SP_NAME" \
+        --node-rpc "ws://$COLLATOR_IP_ADDR:42069" \
+        storage-provider register \
+        --post-proof "8MiB" \
+        --deal-parameters @"$DEAL_PARAMS" \
+        "/ip4/127.0.0.1/tcp/$SP_MULTIADDR_PORT"
 }
 
-function sp_key_dir {
-    echo "/tmp/polka-storage-provider/$1"
-}
-
-function sp_public_key {
-    echo "$(sp_key_dir "$1")/public.pem"
-}
-
-function sp_private_key {
-    echo "$(sp_key_dir "$1")/private.pem"
-}
-
-function ports {
-    case $1 in
-        "//Alice")
-            local PORT=45000
-            echo "upload_listen_address = '0.0.0.0:$PORT'
-                  rpc_listen_address = '0.0.0.0:$(echo "$PORT + 1" | bc)'
-                  p2p_listen_addresses = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 2" | bc),/ip4/0.0.0.0/tcp/$(echo "$PORT + 3" | bc)/ws'" |
-            sed "s/\s\+//"
-            ;;
-        "//Bob")
-            local PORT=46000
-            echo "upload_listen_address = '0.0.0.0:$PORT'
-                  rpc_listen_address = '0.0.0.0:$(echo "$PORT + 1" | bc)'
-                  p2p_listen_addresses = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 2" | bc),/ip4/0.0.0.0/tcp/$(echo "$PORT + 3" | bc)/ws'" |
-            sed "s/\s\+//"
-            ;;
-        "//Charlie")
-            local PORT=47000
-            echo "upload_listen_address = '0.0.0.0:$PORT'
-                  rpc_listen_address = '0.0.0.0:$(echo "$PORT + 1" | bc)'
-                  p2p_listen_addresses = '/ip4/0.0.0.0/tcp/$(echo "$PORT + 2" | bc),/ip4/0.0.0.0/tcp/$(echo "$PORT + 3" | bc)/ws'" |
-            sed "s/\s\+//"
-            ;;
-    esac
+function sp_tmp_dir {
+    echo "$TMP_PATH/$1"
 }
 
 function main {
+    echo '{ "minimum_price_per_block": 200, "deal_duration": { "lower": 50, "upper": 5256000 }}' > "$DEAL_PARAMS"
     declare -a ACCOUNTS=("//Alice" "//Bob" "//Charlie")
-    for ACCOUNT in "${ACCOUNTS[@]}"; do
-        register_storage_provider "$ACCOUNT"
+    declare -a PORTS=("8001" "8002" "8003")
+    for i in "${!ACCOUNTS[@]}"; do
+        ACCOUNT="${ACCOUNTS[$i]}"
+        PORT="${PORTS[$i]}"
+        register_storage_provider "$ACCOUNT" "$PORT"
     done
     wait
 
-    # Get bootstrap P2P Peer ID. This works after running zombienet locally or in kubernetes
-    P2P_BOOTSTRAP_PEER_ID="$(target/release/polka-storage-provider-client generate-peer-id --pubkey "$P2P_BOOTSTRAP_PUBLIC_KEY")"
-    echo "Peer ID for bootstrap node: $P2P_BOOTSTRAP_PEER_ID"
+    for i in "${!ACCOUNTS[@]}"; do
+        ACCOUNT="${ACCOUNTS[$i]}"
+        PORT="${PORTS[$i]}"
+        ACCOUNT_DIR="$(sp_tmp_dir "$ACCOUNT#//")"
+        DB_DIR="$(sp_tmp_dir "$ACCOUNT#//")/db"
+        STORAGE_DIR="$(sp_tmp_dir "$ACCOUNT#//")/storage"
 
-    for ACCOUNT in "${ACCOUNTS[@]}"; do
+        mkdir -p "$DB_DIR"
+        mkdir -p "$STORAGE_DIR"
         echo "
-            $(ports "$ACCOUNT")
             seal_proof = '8MiB'
             post_proof = '8MiB'
-            porep_parameters = 'target/porep_params_8MiB'
-            post_parameters = 'target/porep_params_8MiB'
-            p2p_key = '@$(sp_private_key "$ACCOUNT")'
-            rendezvous_point_address = '$P2P_BOOTSTRAP_ADDRESS'
-            rendezvous_point = '$P2P_BOOTSTRAP_PEER_ID'
+            porep_parameters = 'target/params/8MiB.porep.params'
+            post_parameters = 'target/params/8MiB.post.params'
+            node_url = 'ws://$COLLATOR_IP_ADDR:42069'
+            upload_listen_address = '127.0.0.1:$PORT'
+            database_directory = '$DB_DIR'
+            storage_directory = '$STORAGE_DIR'
             [sealing_configuration]
             fill_threshold = 0
             wait_deals_delay = '5m'
-            pre_commit_submission_slack = '1m'" | sed 's/\s\+//' > "$(sp_key_dir "$ACCOUNT")/config.toml"
+            pre_commit_submission_slack = '1m'" | sed 's/\s\+//' > "$ACCOUNT_DIR/config.toml"
 
+        echo "Starting storage provider "$PROVIDER" with upload address 127.0.0.1:"$PORT"..."
         RUST_LOG="tower_http=debug,polka_storage_provider_server=debug,polka_storage_provider_server::p2p=trace,yamux=off,multistream_select=off,polka_storage_provider_common=debug" target/release/polka-storage-provider-server \
             --sr25519-key "$ACCOUNT" \
-            --config "$(sp_key_dir "$ACCOUNT")/config.toml" &
+            --config "$ACCOUNT_DIR/config.toml" &
     done
     wait
 }


### PR DESCRIPTION
This PR cleans up and modularizes the example bash scripts:

- Extracted shared logic (deal publishing, block fetching, piece CID/size calculation) into a new `deal_common.sh`.
- Extracted storage provider common logic into a new `sp_common.sh`.
- Removed redundant or hard-coded parameters.
- Scripts now fetch the latest finalized block height from the chain for start/end blocks.
- Made scripts quieter and easier to maintain.

Overall, this makes the RPC example flows cleaner, more maintainable, and easier to extend.