### PR TITLE
ci: check for benchmark changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           files: |
             **/.github/workflows/*
             **/*.rs
-            **/Cargo.toml
+            **/Cargo.lock
             **/*.scale
       - name: Check if proper files changed
         id: check-files
@@ -135,13 +135,43 @@ jobs:
       - name: Check tests
         run: cargo clippy --profile ci --locked --no-deps
 
+  check-benchmarks:
+    runs-on: self-hosted
+    outputs:
+      skip: ${{ steps.check-benchmarks.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c #v44.5.7
+        id: changed-files
+        with:
+          files: |
+            **/pallets/**/*.rs
+            **/primitives/**/*.rs
+            **/runtime/**/*.rs
+            **/test-fixtures/**/*.rs
+            **/Cargo.lock
+            **/*.scale
+      - name: Check if proper files changed
+        id: check-benchmarks
+        run: |
+          if [[ "${{ steps.changed-files.outputs.any_changed }}" == "false" ]]; then
+            echo "No files changed. Skipping CI."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Some files changed. Running CI."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # This is easier to configure in the GitHub settings
   benchmarks:
     runs-on: self-hosted
     needs:
+      - check-benchmarks
       - format
     env:
       RUSTFLAGS: -D warnings
+
+    if: ${{ needs.check-benchmarks.outputs.skip == 'false' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ parachains-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = 
 
 [workspace.lints.rust]
 suspicious_double_ref_op = { level = "allow", priority = 2 }
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin)'] }
+unexpected_cfgs = { level = "allow" }
 
 [workspace.lints.clippy]
 all = { level = "allow", priority = 0 }

--- a/Justfile
+++ b/Justfile
@@ -176,24 +176,6 @@ kube-testnet:
     openssl pkey -in /tmp/zombienet/charlie-private.pem -pubout -out /tmp/zombienet/charlie-public.pem # Generate public key so script can get the Peer ID
     zombienet -p kubernetes spawn zombienet/local-kube-testnet.toml
 
-# The tarpaulin calls for test coverage have the following options:
-# --locked: To not update the Cargo.lock file.
-# --skip-clean: Prevents tarpaulin from running `cargo clean` to reduce runtime.
-# --fail-immediately: Makes tarpaulin stop when a test fails.
-# --out: Specifies the output type, html for humans, lcov for Coverage Gutters.
-# --output-dir: Specifies the output directory, these must be in sync with .vscode/settings.json and have extension Coverage Gutters to display it in VS Code.
-
-pallet-storage-provider-coverage:
-    mkdir -p coverage
-    cargo tarpaulin -p pallet-storage-provider --locked --skip-clean --fail-immediately --out html lcov --output-dir coverage/pallet-storage-provider
-
-market-coverage:
-    mkdir -p coverage
-    cargo tarpaulin -p pallet-market -p pallet-market-benchmarks --locked --skip-clean --fail-immediately --out html lcov --output-dir coverage/pallet-market
-
-mater-coverage:
-    mkdir -p coverage
-    cargo tarpaulin -p mater --locked --skip-clean --fail-immediately --out html lcov --output-dir coverage/mater
 
 full-coverage: pallet-storage-provider-coverage market-coverage mater-coverage
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
 
         buildInputs = with pkgs; [
           # Rust related deps
-          cargo-tarpaulin
           clang
           just
           mdbook

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -159,8 +159,6 @@ pub fn preset_names() -> Vec<PresetId> {
 
 #[cfg(test)]
 mod tests {
-    // NOTE(@Jinxit,02/06/2025): Excluded because it is too slow to run coverage for on CI.
-    #[cfg(not(tarpaulin))]
     #[test]
     fn check_presets() {
         let builder = sc_chain_spec::GenesisConfigBuilderRuntimeCaller::<()>::new(

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -159,6 +159,8 @@ pub fn preset_names() -> Vec<PresetId> {
 
 #[cfg(test)]
 mod tests {
+    // NOTE(@Jinxit,02/06/2025): Excluded because it is too slow to run coverage for on CI.
+    #[cfg(not(tarpaulin))]
     #[test]
     fn check_presets() {
         let builder = sc_chain_spec::GenesisConfigBuilderRuntimeCaller::<()>::new(


### PR DESCRIPTION
Check for changes to benchmark related files to skip over them and thus avoid ~5 extra minutes of build time