### PR TITLE
fix: update accounts and listen_address in scripts

### DIFF
--- a/examples/rpc_publish.sh
+++ b/examples/rpc_publish.sh
@@ -20,8 +20,8 @@ TMP_PATH="$TMPDIR/polka-storage-provider"
 
 mkdir -p "$TMP_PATH"
 
-CLIENT="//Alice"
-PROVIDER="//Charlie"
+CLIENT="//Eve"
+PROVIDER="//Alice"
 
 INPUT_FILE="$1"
 INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
@@ -33,7 +33,7 @@ source "$(dirname "$0")/deal_common.sh"
 set_latest_block
 
 START_BLOCK=$((LATEST_BLOCK + 20))
-END_BLOCK=$((LATEST_BLOCK + 200))
+END_BLOCK=$((START_BLOCK + 10000))
 
 set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"
 

--- a/examples/rpc_publish_multiple_clients.sh
+++ b/examples/rpc_publish_multiple_clients.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+
+# This script will publish a file from every client to every storage provider.
+# It is supposed to be used in tandem with start_sps.sh (which launches Alice, Bob, and Charlie)
+
+if [ "$#" -ne 1 ]; then
+    echo "$0: input file required"
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "$0: input file cannot be empty"
+    exit 1
+fi
+
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
+
+source "$(dirname "$0")/deal_common.sh"
+
+export DISABLE_XT_WAIT_WARNING=1
+
+INPUT_FILE="$1"
+INPUT_FILE_NAME="$(basename "$INPUT_FILE")"
+INPUT_TMP_FILE="/tmp/$INPUT_FILE_NAME.car"
+
+CLIENTS=("//David" "//Eve" "//Fred")
+PROVIDERS=("//Alice" "//Bob" "//Charlie")
+PORTS=("8001" "8002" "8003")
+
+# Convert file to CARv2 and calculate COMMP only once
+set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"
+
+for CLIENT in "${CLIENTS[@]}"; do
+    CLIENT_ACCOUNT=$(subkey inspect "${CLIENT}" --output-type json | jq -r '.ss58Address')
+
+    for i in "${!PROVIDERS[@]}"; do
+        PROVIDER="${PROVIDERS[$i]}"
+        PORT="${PORTS[$i]}"
+        PROVIDER_ACCOUNT=$(subkey inspect "${PROVIDER}" --output-type json | jq -r '.ss58Address')
+
+        # Get latest finalized block for each deal
+        set_latest_block
+        START_BLOCK=$((LATEST_BLOCK + 20))
+        END_BLOCK=$((START_BLOCK + 10000))
+
+        # Publish the deal
+        publish_deal \
+            "$CLIENT" \
+            "$PROVIDER" \
+            "$PIECE_CID" \
+            $PIECE_SIZE \
+            $START_BLOCK \
+            $END_BLOCK \
+            "$CLIENT_ACCOUNT" \
+            "$PROVIDER_ACCOUNT" \
+            "$INPUT_FILE" \
+            "$PORT"
+
+        echo "Published deal: ${CLIENT} -> ${PROVIDER}"
+    done
+done
+
+echo "All deals published successfully!"

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -18,7 +18,7 @@ export DISABLE_XT_WAIT_WARNING=1
 source "$(dirname "$0")/deal_common.sh"
 
 CLIENT="//Eve"
-PROVIDER="//Charlie"
+PROVIDER="//Alice"
 
 INPUT_FILE="$1"
 INPUT_FILE_NAME="$(basename "$INPUT_FILE")"

--- a/examples/rpc_publish_multiple_sectors.sh
+++ b/examples/rpc_publish_multiple_sectors.sh
@@ -17,7 +17,7 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM
 export DISABLE_XT_WAIT_WARNING=1
 source "$(dirname "$0")/deal_common.sh"
 
-CLIENT="//Alice"
+CLIENT="//Eve"
 PROVIDER="//Charlie"
 
 INPUT_FILE="$1"
@@ -30,7 +30,7 @@ do
     set_latest_block
 
     START_BLOCK=$((i + $LATEST_BLOCK))
-    END_BLOCK=$((i + $LATEST_BLOCK + 200))
+    END_BLOCK=$((10000 + $START_BLOCK))
     publish_deal \
         "$CLIENT" \
         "$PROVIDER" \

--- a/examples/rpc_replicated_file.sh
+++ b/examples/rpc_replicated_file.sh
@@ -38,7 +38,7 @@ for i in "${!ACCOUNTS[@]}"; do
     # Populate LATEST_BLOCK with the latest finalized block
     set_latest_block
     START_BLOCK=$((LATEST_BLOCK + 20))
-    END_BLOCK=$((LATEST_BLOCK + 200))
+    END_BLOCK=$((START_BLOCK + 10000))
 
     # Populate PIECE_CID and PIECE_SIZE
     set_piece_vars "$INPUT_FILE" "$INPUT_TMP_FILE"

--- a/examples/sp_common.sh
+++ b/examples/sp_common.sh
@@ -42,7 +42,7 @@ generate_config_file() {
         echo "porep_parameters = 'target/params/8MiB.porep.params'"
         echo "post_parameters = 'target/params/8MiB.post.params'"
         echo "node_url = '$COLLATOR_WS_ADDR'"
-        echo "upload_listen_address = '127.0.0.1:$PORT'"
+        echo "listen_address = '127.0.0.1:$PORT'"
 
         if [ -n "$DB_DIR" ]; then
             echo "database_directory = '$DB_DIR'"

--- a/examples/start_sp.sh
+++ b/examples/start_sp.sh
@@ -12,7 +12,7 @@ export DISABLE_XT_WAIT_WARNING=1
 # CONFIGURATION
 TMPDIR="${TMPDIR:-/tmp}"
 TMP_PATH="$TMPDIR/polka-storage-provider"
-PROVIDER="//Charlie"
+PROVIDER="//Alice"
 PORT="8001"
 CONFIG="$TMP_PATH/config.toml"
 DEAL_PARAMS="$TMP_PATH/deal_params.json"


### PR DESCRIPTION
This PR aligns account usage across example scripts and adds a new script for bulk deal publishing.

- Aligned `CLIENT` and `PROVIDER` values in publish/start scripts for consistency
- Increased `END_BLOCK` offset to ensure sufficient time for deal activation
- Fixed config key from `upload_listen_address` to `listen_address`
- Added a new script to publish a file from multiple clients to all storage providers