### PR TITLE
feat(mater): support UnixFS wrapping

### DIFF
--- a/mater/cli/src/convert.rs
+++ b/mater/cli/src/convert.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use mater::{Cid, Error, FileWriter};
+use mater::{Cid, Error, FileWriter, Wrapping};
 use tokio::fs::File;
 
 /// Converts a file at location `input_path` to a CARv2 file at `output_path`
@@ -8,6 +8,7 @@ pub(crate) async fn convert_file_to_car(
     input_path: &PathBuf,
     output_path: &PathBuf,
     overwrite: bool,
+    wrap: bool,
 ) -> Result<Cid, Error> {
     let output_file = if overwrite {
         File::create(output_path).await
@@ -16,10 +17,32 @@ pub(crate) async fn convert_file_to_car(
     }?;
 
     if input_path.as_os_str() == "-" {
-        FileWriter::import(tokio::io::stdin(), output_file).await
+        FileWriter::import(tokio::io::stdin(), output_file, Wrapping::NoWrap).await
     } else {
         let source_file = File::open(input_path).await?;
-        FileWriter::import(source_file, output_file).await
+        if wrap {
+            let filesize = source_file.metadata().await?.len();
+            let filename = input_path
+                .file_name()
+                .ok_or(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "filename was empty",
+                ))?
+                .to_str()
+                .ok_or(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "filename is not valid UTF-8",
+                ))?
+                .to_string();
+            FileWriter::import(
+                source_file,
+                output_file,
+                mater::Wrapping::Wrap { filename, filesize },
+            )
+            .await
+        } else {
+            FileWriter::import(source_file, output_file, mater::Wrapping::NoWrap).await
+        }
     }
 }
 
@@ -51,7 +74,7 @@ mod tests {
         let output_path = temp_dir.path().join("test_output.car");
 
         // Call the function under test
-        let result = convert_file_to_car(&input_path, &output_path, false).await;
+        let result = convert_file_to_car(&input_path, &output_path, false, false).await;
 
         // Assert the result is Ok
         assert!(result.is_ok());
@@ -75,7 +98,7 @@ mod tests {
         let output_path = temp_dir.path().join("test_output.car");
 
         // Call the function under test
-        let result = convert_file_to_car(&input_path, &output_path, false).await;
+        let result = convert_file_to_car(&input_path, &output_path, false, false).await;
 
         // Assert the result is an error
         assert!(result.is_err());
@@ -100,7 +123,7 @@ mod tests {
         File::create_new(&output_path).await?;
 
         // Call the function under test
-        let result = convert_file_to_car(&input_path, &output_path, false).await;
+        let result = convert_file_to_car(&input_path, &output_path, false, false).await;
 
         // Assert the result is an error
         assert!(result.is_err());

--- a/mater/cli/src/main.rs
+++ b/mater/cli/src/main.rs
@@ -29,6 +29,10 @@ enum MaterCli {
         /// If enabled, the output will overwrite any existing files.
         #[arg(long, action)]
         overwrite: bool,
+
+        /// If enabled, the file will be wrapped with UnixFS information.
+        #[arg(long, action)]
+        wrap: bool,
     },
     /// Convert a CARv2 file to its original format
     Extract {
@@ -50,6 +54,7 @@ async fn main() -> Result<(), Error> {
             output_path,
             quiet,
             overwrite,
+            wrap,
         } => {
             let output_path = output_path.unwrap_or_else(|| {
                 // If we let the output become `-.car` it isn't only weird
@@ -65,7 +70,7 @@ async fn main() -> Result<(), Error> {
                     new_path
                 }
             });
-            let cid = convert_file_to_car(&input_path, &output_path, overwrite).await?;
+            let cid = convert_file_to_car(&input_path, &output_path, overwrite, wrap).await?;
 
             if quiet {
                 println!("{}", cid);

--- a/mater/lib/src/convert/mod.rs
+++ b/mater/lib/src/convert/mod.rs
@@ -2,7 +2,7 @@ mod reader;
 mod writer;
 
 pub use reader::FileReader;
-pub use writer::FileWriter;
+pub use writer::{FileWriter, Wrapping};
 
 /// The default block size, as defined in
 /// [boxo](https://github.com/ipfs/boxo/blob/f4fe8997dcbeb39b3a4842d8f08b34739bfd84a4/chunker/parse.go#L13).

--- a/mater/lib/src/convert/writer.rs
+++ b/mater/lib/src/convert/writer.rs
@@ -4,15 +4,32 @@ use std::{
 };
 
 use futures::stream::StreamExt;
-use ipld_core::cid::Cid;
+use ipld_core::{cid::Cid, codec::Codec};
+use ipld_dagpb::{DagPbCodec, PbLink, PbNode};
+use quick_protobuf::MessageWrite;
+use sha2::Sha256;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
-    unixfs::stream_balanced_tree,
+    multicodec::generate_multihash,
+    unixfs::{stream_balanced_tree, unixfs_pb},
     v1::{self, CarWriter},
     v2::{self, CarWriter as _},
-    BlockMetadata, Config, Error, Index, IndexEntry, IndexSorted, SingleWidthIndex,
+    BlockMetadata, Config, Error, Index, IndexEntry, IndexSorted, SingleWidthIndex, DAG_PB_CODE,
 };
+
+/// Wrapping configuration
+pub enum Wrapping {
+    /// Do not wrap the file with UnixFS information.
+    NoWrap,
+    /// Wrap the file with UnixFS information.
+    Wrap {
+        /// File name.
+        filename: String,
+        /// File size.
+        filesize: u64,
+    },
+}
 
 /// CAR file writer.
 ///
@@ -87,19 +104,19 @@ where
 {
     /// Convert `source` into a CAR file, writing it to `writer`.
     /// Returns the root [`Cid`].
-    pub async fn import<S>(source: S, writer: W) -> Result<Cid, Error>
+    pub async fn import<S>(source: S, writer: W, wrap: Wrapping) -> Result<Cid, Error>
     where
         S: AsyncRead + Unpin,
     {
         let mut writer = Self::new(writer).await?;
-        writer.write_from(source).await?;
+        writer.write_from(source, wrap).await?;
         let root = *writer.roots.first().ok_or(Error::EmptyRootsError)?;
         writer.finish().await?;
         Ok(root)
     }
 
     /// Writes the contents from `source`, adding a new root to [`FileWriter`].
-    pub async fn write_from<S>(&mut self, source: S) -> Result<(), Error>
+    pub async fn write_from<S>(&mut self, source: S, wrapping: Wrapping) -> Result<(), Error>
     where
         S: AsyncRead + Unpin,
     {
@@ -136,7 +153,49 @@ where
             }
 
             if nodes.as_mut().peek().await.is_none() {
-                root = Some(node_cid);
+                if let Wrapping::Wrap { filename, filesize } = &wrapping {
+                    let block_offset = current_position;
+
+                    let link = PbLink {
+                        cid: node_cid,
+                        name: Some(filename.to_string()),
+                        size: Some(*filesize),
+                    };
+
+                    let pb_node_data = unixfs_pb::Data {
+                        Type: unixfs_pb::mod_Data::DataType::Directory,
+                        filesize: None,
+                        blocksizes: vec![],
+                        ..Default::default()
+                    };
+                    let mut pb_node_data_bytes = vec![];
+                    let mut pb_node_data_writer =
+                        quick_protobuf::Writer::new(&mut pb_node_data_bytes);
+                    pb_node_data.write_message(&mut pb_node_data_writer)?;
+
+                    let pb_node = PbNode {
+                        links: vec![link],
+                        data: Some(pb_node_data_bytes.into()),
+                    };
+
+                    let outer = DagPbCodec::encode_to_vec(&pb_node)?;
+                    let cid = Cid::new_v1(DAG_PB_CODE, generate_multihash::<Sha256, _>(&outer));
+
+                    let written = self.writer.write_block(&cid, &outer).await? as u64;
+                    current_position += written;
+                    self.index.insert(
+                        cid,
+                        BlockMetadata {
+                            block_offset,
+                            cid,
+                            data_offset_source: block_offset + written,
+                            data_size: outer.len() as u64,
+                        },
+                    );
+                    root = Some(cid);
+                } else {
+                    root = Some(node_cid);
+                }
             }
         }
 
@@ -233,7 +292,10 @@ mod tests {
         let reference = tokio::fs::read(reference).await.unwrap();
 
         let mut store = FileWriter::in_memory().await.unwrap();
-        store.write_from(file).await.unwrap();
+        store
+            .write_from(file, crate::Wrapping::NoWrap)
+            .await
+            .unwrap();
         let output = store.finish().await.unwrap().into_inner();
         assert_buffer_eq!(&output, &reference);
     }
@@ -260,7 +322,10 @@ mod tests {
     async fn dedup() {
         let input = Cursor::new(vec![0u8; 524288]);
         let mut store = FileWriter::in_memory().await.unwrap();
-        store.write_from(input).await.unwrap();
+        store
+            .write_from(input, crate::Wrapping::NoWrap)
+            .await
+            .unwrap();
         let output = store.finish().await.unwrap().into_inner();
 
         let reference = tokio::fs::read("tests/fixtures/car_v2/zero.car")

--- a/mater/lib/src/lib.rs
+++ b/mater/lib/src/lib.rs
@@ -18,7 +18,7 @@ mod v1;
 mod v2;
 
 // We need to re-expose this because `read_block` returns `(Cid, Vec<u8>)`.
-pub use convert::{Config, FileReader, FileWriter};
+pub use convert::{Config, FileReader, FileWriter, Wrapping};
 pub use ipld::CidExt;
 pub use ipld_core::cid::Cid;
 pub use multicodec::{DAG_PB_CODE, IDENTITY_CODE, RAW_CODE};

--- a/mater/lib/src/unixfs/mod.rs
+++ b/mater/lib/src/unixfs/mod.rs
@@ -25,7 +25,7 @@ pub(crate) struct LinkInfo {
 }
 
 impl LinkInfo {
-    fn new(raw_data_length: u64, encoded_data_length: u64) -> Self {
+    pub fn new(raw_data_length: u64, encoded_data_length: u64) -> Self {
         Self {
             raw_data_length,
             encoded_data_length,

--- a/storage-provider/server/src/storage.rs
+++ b/storage-provider/server/src/storage.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use futures::{TryFutureExt, TryStreamExt};
 use hyper::{header::CONTENT_TYPE, Method};
-use mater::Cid;
+use mater::{Cid, Wrapping};
 use metrics_exporter_prometheus::PrometheusHandle;
 use polka_storage_provider_common::{
     commp::{commp, CommPError},
@@ -405,7 +405,7 @@ where
     // Stream the body from source to the temp file.
     let file = File::create(&temp_file_path).await?;
     let writer = BufWriter::new(file);
-    let cid = mater::FileWriter::import(source, writer).await?;
+    let cid = mater::FileWriter::import(source, writer, Wrapping::NoWrap).await?;
     tracing::trace!("finished writing the CAR archive");
 
     // If the file is successfully written, we can now move it to the final


### PR DESCRIPTION
### Description

Closes #678 

Wraps files in UnixFS information — when using (better) libraries, it allows the extractor to know the filename beforehand and write the file to the FS correctly.

I didn't add extraction support because it requires further re-architecture of the extraction work and maybe of the library API — in other words, I don't think it's worth the effort.